### PR TITLE
Add --render and --upload options to fit_model.py

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,7 @@
 # Copilot Instructions
 
+> **Keep in sync:** This file, `CLAUDE.md`, and `AGENTS.md` share the same content. When updating one, update all three.
+
 ## Project overview
 
 This project is an exploratory study of vocabulary development in children with Down syndrome that aims to characterise observed trajectories of word learning, spoken and gestured production, and relationships between words understood and produced. The primary goal of the study is to provide interpretable statistics that can accurately inform expectations, intervention and teaching practice. We evaluate and fit these models using Bayesian inference to estimate full probability distributions for parameters of interest, using an iterative workflow.
@@ -47,11 +49,13 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 ### Fit a model
 
 ```bash
-python scripts/fit_model.py <model_id> [--config <config>]
+python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 ```
 
 - `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
+- `--render`: render the Quarto model output after fitting.
+- `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `AZCOPY_BLOB_CONTAINER_URL` environment variable set to the target container URL.
 
 Output (traces, figures, summary tables) is written to `output/models/<model_name>/`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 - `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
-- `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `AZCOPY_BLOB_CONTAINER_URL` environment variable set to the target container URL.
+- `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
 
 Output (traces, figures, summary tables) is written to `output/models/<model_name>/`.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ Desktop.ini
 .env
 .env.*
 *.local
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Agent Instructions
 
+> **Keep in sync:** This file, `CLAUDE.md`, and `.github/copilot-instructions.md` share the same content. When updating one, update all three.
+
 ## Project overview
 
 This project is an exploratory study of vocabulary development in children with Down syndrome that aims to characterise observed trajectories of word learning, spoken and gestured production, and relationships between words understood and produced. The primary goal of the study is to provide interpretable statistics that can accurately inform expectations, intervention and teaching practice. We evaluate and fit these models using Bayesian inference to estimate full probability distributions for parameters of interest, using an iterative workflow.
@@ -47,11 +49,13 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 ### Fit a model
 
 ```bash
-python scripts/fit_model.py <model_id> [--config <config>]
+python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 ```
 
 - `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
+- `--render`: render the Quarto model output after fitting.
+- `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `AZCOPY_BLOB_CONTAINER_URL` environment variable set to the target container URL.
 
 Output (traces, figures, summary tables) is written to `output/models/<model_name>/`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 - `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
-- `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `AZCOPY_BLOB_CONTAINER_URL` environment variable set to the target container URL.
+- `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
 
 Output (traces, figures, summary tables) is written to `output/models/<model_name>/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+> **Keep in sync:** This file, `AGENTS.md`, and `.github/copilot-instructions.md` share the same content. When updating one, update all three.
+
 ## Project overview
 
 This project is an exploratory study of vocabulary development in children with Down syndrome that aims to characterise observed trajectories of word learning, spoken and gestured production, and relationships between words understood and produced. The primary goal of the study is to provide interpretable statistics that can accurately inform expectations, intervention and teaching practice. We evaluate and fit these models using Bayesian inference to estimate full probability distributions for parameters of interest, using an iterative workflow.
@@ -47,11 +49,13 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 ### Fit a model
 
 ```bash
-python scripts/fit_model.py <model_id> [--config <config>]
+python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 ```
 
 - `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
+- `--render`: render the Quarto model output after fitting.
+- `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `AZCOPY_BLOB_CONTAINER_URL` environment variable set to the target container URL.
 
 Output (traces, figures, summary tables) is written to `output/models/<model_name>/`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 - `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
-- `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `AZCOPY_BLOB_CONTAINER_URL` environment variable set to the target container URL.
+- `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
 
 Output (traces, figures, summary tables) is written to `output/models/<model_name>/`.
 

--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -5,17 +5,35 @@ Fits the specified model to the latest data. Saves plots and data, and report to
 """
 
 import argparse
+import os
+import subprocess
 from multiprocessing import freeze_support
 
 import dse_research_utils.environment.setup as setup
 from rich import print
 
 from vocab_growth.models import model_vg01, model_vg02, model_vg03, model_vg04
+from vocab_growth.storage import upload_to_blob_storage
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('model', type=str, default=None, help='Model id or all.')
-    parser.add_argument('--config', type=str, default='dev', help='Sampling configuration to use (e.g., dev[elopment], test, rep[orting])')
+    parser.add_argument("model", type=str, default=None, help="Model id or all.")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="dev",
+        help="Sampling configuration to use (e.g., dev[elopment], test, rep[orting])",
+    )
+    parser.add_argument(
+        "--render",
+        action="store_true",
+        help="Render the Quarto model output after fitting",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload model output to Azure Blob Storage using AzCopy",
+    )
 
     freeze_support()
 
@@ -23,14 +41,32 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.model == "vg01" or args.model == "all":
-        model_vg01.fit(args.config)
-    elif args.model == "vg02" or args.model == "all":
-        model_vg02.fit(args.config)
-    elif args.model == "vg03" or args.model == "all":
-        model_vg03.fit(args.config)
-    elif args.model == "vg04" or args.model == "all":
-        model_vg04.fit(args.config)
+    models = {
+        "vg01": model_vg01,
+        "vg02": model_vg02,
+        "vg03": model_vg03,
+        "vg04": model_vg04,
+    }
+
+    if args.model == "all":
+        to_fit = list(models.values())
+    elif args.model in models:
+        to_fit = [models[args.model]]
     else:
         print(f"Unknown model: {args.model}")
         exit(1)
+
+    contexts = [m.fit(args.config) for m in to_fit]
+
+    if args.render:
+        for context in contexts:
+            qmd_path = os.path.join(context.reporting.output_dir, "index.qmd")
+            print(f"\n[bold green]Rendering Quarto output: {qmd_path}[/bold green]")
+            subprocess.run(["quarto", "render", qmd_path], check=True)
+
+    if args.upload:
+        for context in contexts:
+            upload_to_blob_storage(
+                context.reporting.output_dir,
+                context.reporting.model_label,
+            )

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -29,14 +29,20 @@ def upload_to_blob_storage(output_dir: str, model_label: str) -> None:
     print(f"  Source: {source}")
     print(f"  Destination: {destination}")
 
-    result = subprocess.run(
-        ["azcopy", "copy", source, destination, "--recursive"],
-        check=False,
-    )
-
-    if result.returncode != 0:
-        print(
-            f"[bold red]Warning: AzCopy upload failed for {model_label} (exit code {result.returncode})[/bold red]"
+    try:
+        subprocess.run(
+            ["azcopy", "copy", source, destination, "--recursive"],
+            check=True,
         )
+    except FileNotFoundError:
+        print(
+            "[bold red]Error: `azcopy` was not found. Please install AzCopy and ensure it is available on PATH.[/bold red]"
+        )
+        raise
+    except subprocess.CalledProcessError as error:
+        print(
+            f"[bold red]Error: AzCopy upload failed for {model_label} (exit code {error.returncode}).[/bold red]"
+        )
+        raise
     else:
         print(f"[bold green]Upload complete: {model_label}[/bold green]")

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os
+import subprocess
+
+from rich import print
+
+
+def upload_to_blob_storage(output_dir: str, model_label: str) -> None:
+    """Upload model output directory to Azure Blob Storage using AzCopy."""
+    container_url = os.environ.get("DSERESEARCH_BLOB_CONTAINER_URL")
+    if not container_url:
+        print(
+            "[bold red]Error: DSERESEARCH_BLOB_CONTAINER_URL environment variable is not set.[/bold red]"
+        )
+        print("Set it to your Azure Blob container URL, e.g.:")
+        print(
+            "  export DSERESEARCH_BLOB_CONTAINER_URL='https://<account>.blob.core.windows.net/<container>'"
+        )
+        return
+
+    source = output_dir.replace("\\", "/").rstrip("/") + "/*"
+    destination = container_url.rstrip("/") + "/projects/vocabulary-growth/output/" + model_label + "/"
+
+    print(f"\n[bold green]Uploading to Azure Blob Storage: {model_label}[/bold green]")
+    print(f"  Source: {source}")
+    print(f"  Destination: {destination}")
+
+    result = subprocess.run(
+        ["azcopy", "copy", source, destination, "--recursive"],
+        check=False,
+    )
+
+    if result.returncode != 0:
+        print(
+            f"[bold red]Warning: AzCopy upload failed for {model_label} (exit code {result.returncode})[/bold red]"
+        )
+    else:
+        print(f"[bold green]Upload complete: {model_label}[/bold green]")

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -18,7 +18,9 @@ def upload_to_blob_storage(output_dir: str, model_label: str) -> None:
         print(
             "  export DSERESEARCH_BLOB_CONTAINER_URL='https://<account>.blob.core.windows.net/<container>'"
         )
-        return
+        raise RuntimeError(
+            "DSERESEARCH_BLOB_CONTAINER_URL environment variable is not set."
+        )
 
     source = output_dir.replace("\\", "/").rstrip("/") + "/*"
     destination = container_url.rstrip("/") + "/projects/vocabulary-growth/output/" + model_label + "/"

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -3,6 +3,7 @@
 
 import os
 import subprocess
+import uuid
 
 from rich import print
 
@@ -23,7 +24,8 @@ def upload_to_blob_storage(output_dir: str, model_label: str) -> None:
         )
 
     source = output_dir.replace("\\", "/").rstrip("/") + "/*"
-    destination = container_url.rstrip("/") + "/projects/vocabulary-growth/output/" + model_label + "/"
+    run_id = uuid.uuid7()
+    destination = container_url.rstrip("/") + "/projects/vocabulary-growth/output/" + str(run_id) + "/" + model_label + "/"
 
     print(f"\n[bold green]Uploading to Azure Blob Storage: {model_label}[/bold green]")
     print(f"  Source: {source}")


### PR DESCRIPTION
## Summary
- Add `--render` flag to invoke Quarto rendering after model fitting
- Add `--upload` flag to sync model output to Azure Blob Storage via AzCopy (reads container URL from `DSERESEARCH_BLOB_CONTAINER_URL` env var); each upload is placed under a unique UUIDv7 (timestamp-based) prefix before `model_label` in the destination path
- Refactor model dispatch in `fit_model.py` to correctly support `all` (previously only ran VG01 due to `elif` chain)
- Extract upload logic into `src/vocab_growth/storage.py` module
- Synchronise `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md` with updated command docs and add keep-in-sync notice

## Test plan
- [ ] Run `python scripts/fit_model.py vg01 --config dev` — verify basic fitting still works
- [ ] Run with `--render` — verify Quarto is invoked on output
- [ ] Run with `--upload` without `DSERESEARCH_BLOB_CONTAINER_URL` set — verify clear error message
- [ ] Run with `--upload` and env var set — verify AzCopy invocation with correct source/destination, including UUIDv7 prefix in destination path
- [ ] Run `ruff check scripts/fit_model.py src/vocab_growth/storage.py` — no lint errors

🤖 Generated with <a href="https://claude.ai/claude-code">Claude Code</a>