### PR TITLE
Add model VG05: joint understood-spoken model

### DIFF
--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -22,7 +22,7 @@ This model output is preliminary and likely to change as the model evolves and f
 If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
 :::
 
-This model jointly examines how age influences words understood and words spoken ($A \rightarrow U$, $A \rightarrow S$, $U \rightarrow S$), using a production-given-comprehension reparameterization that enforces $p_S \leq p_U$ by construction.
+This model jointly examines how age influences words understood and words spoken ($A \rightarrow U$, $A \rightarrow S$, $U \rightarrow S$), using a production-ratio reparameterization that enforces $p_S \leq p_U$ by construction.
 
 ```{python}
 import matplotlib.pyplot as plt
@@ -31,7 +31,7 @@ import pandas as pd
 
 ## Statistical model
 
-We jointly model words understood and words spoken as bounded count outcomes out of 800 possible words. The expected proportion of words understood, $p_U(a)$, is modelled as a smooth function of age using a linear trend plus a Gaussian process on the logit scale. The proportion of words spoken is derived as $p_S(a) = p_U(a) \cdot q(a)$, where $q(a) = \text{sigmoid}(h(a))$ is the production-given-comprehension rate -- the fraction of understood words that are spoken at age $a$. Since $q(a) \in (0, 1)$, this enforces $p_S \leq p_U$ by construction. Both $f_U(a)$ and $h(a)$ have their own linear trend and Gaussian process components, with HSGP approximations for scalability. Separate Beta-Binomial likelihoods with age-varying dispersion are used for each outcome. Observations where only one outcome is available are retained using separate observation indices.
+We jointly model words understood and words spoken as bounded count outcomes out of 800 possible words. The expected proportion of words understood, $p_U(a)$, is modelled as a smooth function of age using a linear trend plus a Gaussian process on the logit scale. The proportion of words spoken is derived as $p_S(a) = p_U(a) \cdot q(a)$, where $q(a) = \text{sigmoid}(h(a))$ is the production ratio -- the fraction of understood words that are spoken at age $a$. Since $q(a) \in (0, 1)$, this enforces $p_S \leq p_U$ by construction. Both $f_U(a)$ and $h(a)$ have their own linear trend and Gaussian process components, with HSGP approximations for scalability. Separate Beta-Binomial likelihoods with age-varying dispersion are used for each outcome. Observations where only one outcome is available are retained using separate observation indices.
 
 ::: {.callout-note}
 
@@ -53,7 +53,7 @@ For full details and discussion, please refer to the technical report.
 
 ![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.svg){#fig-slope-hi-u .lightbox fig-align="left"}
 
-### Production-given-comprehension rate
+### Production ratio
 
 ![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.svg){#fig-ell-q .lightbox fig-align="left"}
 
@@ -91,7 +91,7 @@ For full details and discussion, please refer to the technical report.
 
 ### Prior samples -- production rate q(a)
 
-![Prior sample trajectories for production-given-comprehension rate](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
+![Prior sample trajectories for production ratio q(a)](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
 
 ## Data
 
@@ -117,9 +117,9 @@ diagnostics
 
 ![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
 
-## Production-given-comprehension rate
+## Production ratio
 
-The production-given-comprehension rate $q(a) = P(\text{speaks} \mid \text{understands})$ represents the fraction of understood words that are spoken at each age.
+The production ratio $q(a) = p_S(a) / p_U(a)$ represents the fraction of understood words that are spoken at each age.
 
 ![Production rate q(a)](production_rate.svg){#fig-production-rate .lightbox fig-align="left"}
 

--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -1,0 +1,209 @@
+---
+title: "Model VG05: Joint model of words understood and spoken - children with Down syndrome"
+
+date: last-modified
+date-format: "YYYY-MM-DD HH:mm:ss Z"
+
+format:
+  html:
+    code-fold: true
+    theme: cosmo
+    number-sections: true
+    toc: true
+    toc-depth: 2
+    code-links:
+      - repo
+---
+
+::: {.callout-warning title="Warning: Preliminary model output"}
+
+This model output is preliminary and likely to change as the model evolves and further data are received.
+
+If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
+:::
+
+This model jointly examines how age influences words understood and words spoken ($A \rightarrow U$, $A \rightarrow S$, $U \rightarrow S$), using a production-given-comprehension reparameterization that enforces $p_S \leq p_U$ by construction.
+
+```{python}
+import matplotlib.pyplot as plt
+import pandas as pd
+```
+
+## Statistical model
+
+We jointly model words understood and words spoken as bounded count outcomes out of 800 possible words. The expected proportion of words understood, $p_U(a)$, is modelled as a smooth function of age using a linear trend plus a Gaussian process on the logit scale. The proportion of words spoken is derived as $p_S(a) = p_U(a) \cdot q(a)$, where $q(a) = \text{sigmoid}(h(a))$ is the production-given-comprehension rate -- the fraction of understood words that are spoken at age $a$. Since $q(a) \in (0, 1)$, this enforces $p_S \leq p_U$ by construction. Both $f_U(a)$ and $h(a)$ have their own linear trend and Gaussian process components, with HSGP approximations for scalability. Separate Beta-Binomial likelihoods with age-varying dispersion are used for each outcome. Observations where only one outcome is available are retained using separate observation indices.
+
+::: {.callout-note}
+
+For full details and discussion, please refer to the technical report.
+
+:::
+
+![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
+
+## Priors
+
+### Understood trajectory
+
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.svg){#fig-ell-u .lightbox fig-align="left"}
+
+![Amplitude prior `eta_u_dist`](eta_u_dist.svg){#fig-eta-u .lightbox fig-align="left"}
+
+![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.svg){#fig-slope-low-u .lightbox fig-align="left"}
+
+![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.svg){#fig-slope-hi-u .lightbox fig-align="left"}
+
+### Production-given-comprehension rate
+
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.svg){#fig-ell-q .lightbox fig-align="left"}
+
+![Amplitude prior `eta_q_dist`](eta_q_dist.svg){#fig-eta-q .lightbox fig-align="left"}
+
+![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.svg){#fig-slope-low-q .lightbox fig-align="left"}
+
+![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.svg){#fig-slope-hi-q .lightbox fig-align="left"}
+
+### Dispersion / overdispersion -- understood
+
+![`kappa_min_u_dist`](kappa_min_u_dist.svg){#fig-kappa-min-u .lightbox fig-align="left"}
+
+![`a_kappa_u_dist`](a_kappa_u_dist.svg){#fig-a-kappa-u .lightbox fig-align="left"}
+
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.svg){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+
+### Dispersion / overdispersion -- spoken
+
+![`kappa_min_s_dist`](kappa_min_s_dist.svg){#fig-kappa-min-s .lightbox fig-align="left"}
+
+![`a_kappa_s_dist`](a_kappa_s_dist.svg){#fig-a-kappa-s .lightbox fig-align="left"}
+
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.svg){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+
+## Prior predictive checks
+
+### Prior samples -- words understood
+
+![Prior sample trajectories (understood)](prior_samples_u.svg){#fig-prior-samples-u .lightbox fig-align="left"}
+
+### Prior samples -- words spoken
+
+![Prior sample trajectories (spoken)](prior_samples_s.svg){#fig-prior-samples-s .lightbox fig-align="left"}
+
+### Prior samples -- production rate q(a)
+
+![Prior sample trajectories for production-given-comprehension rate](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
+
+## Data
+
+```{python}
+descriptive_stats = pd.read_csv("descriptive_statistics.csv", index_col=0)
+descriptive_stats
+```
+
+## Diagnostics
+
+```{python}
+diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
+diagnostics
+```
+
+![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}
+
+![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
+
+![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+
+## Joint trajectory
+
+![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
+
+## Production-given-comprehension rate
+
+The production-given-comprehension rate $q(a) = P(\text{speaks} \mid \text{understands})$ represents the fraction of understood words that are spoken at each age.
+
+![Production rate q(a)](production_rate.svg){#fig-production-rate .lightbox fig-align="left"}
+
+```{python}
+summary_q = pd.read_csv("posterior_summary_q.csv")
+summary_q
+```
+
+## Comprehension-production gap
+
+The expected difference in word counts between understanding and production.
+
+![Comprehension-production gap](comprehension_production_gap.svg){#fig-gap .lightbox fig-align="left"}
+
+## Posterior predictions -- words understood
+
+### Posterior summary table
+
+```{python}
+posterior_summary_u = pd.read_csv("posterior_summary_u.csv")
+posterior_summary_u
+```
+
+### Posterior predictive PMF
+
+![posterior_predictive_pmf_u](posterior_predictive_pmf_u.svg){#fig-pmf-u .lightbox fig-align="left"}
+
+### Posterior predictive CDF
+
+![posterior_predictive_cdf_u](posterior_predictive_cdf_u.svg){#fig-cdf-u .lightbox fig-align="left"}
+
+### Count distributions by age
+
+![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.svg){#fig-count-dist-u .lightbox fig-align="left"}
+
+### Median trend
+
+![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.svg){#fig-trend-u .lightbox fig-align="left"}
+
+Smoothed:
+
+![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.svg){#fig-trend-u-smooth .lightbox fig-align="left"}
+
+### Learning rate
+
+![expected_learning_rate_u](expected_learning_rate_u.svg){#fig-rate-u .lightbox fig-align="left"}
+
+### Dispersion $\kappa$ -- understood
+
+![posterior_kappa_u](posterior_kappa_u.svg){#fig-kappa-u .lightbox fig-align="left"}
+
+## Posterior predictions -- words spoken
+
+### Posterior summary table
+
+```{python}
+posterior_summary_s = pd.read_csv("posterior_summary_s.csv")
+posterior_summary_s
+```
+
+### Posterior predictive PMF
+
+![posterior_predictive_pmf_s](posterior_predictive_pmf_s.svg){#fig-pmf-s .lightbox fig-align="left"}
+
+### Posterior predictive CDF
+
+![posterior_predictive_cdf_s](posterior_predictive_cdf_s.svg){#fig-cdf-s .lightbox fig-align="left"}
+
+### Count distributions by age
+
+![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.svg){#fig-count-dist-s .lightbox fig-align="left"}
+
+### Median trend
+
+![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.svg){#fig-trend-s .lightbox fig-align="left"}
+
+Smoothed:
+
+![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.svg){#fig-trend-s-smooth .lightbox fig-align="left"}
+
+### Learning rate
+
+![expected_learning_rate_s](expected_learning_rate_s.svg){#fig-rate-s .lightbox fig-align="left"}
+
+### Dispersion $\kappa$ -- spoken
+
+![posterior_kappa_s](posterior_kappa_s.svg){#fig-kappa-s .lightbox fig-align="left"}

--- a/docs/report/_quarto.yml
+++ b/docs/report/_quarto.yml
@@ -16,6 +16,8 @@ execute:
 date: now
 
 toc: true
+toc-depth: 2
+
 number-sections: true
 number-depth: 3
 

--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -12,7 +12,13 @@ from multiprocessing import freeze_support
 import dse_research_utils.environment.setup as setup
 from rich import print
 
-from vocab_growth.models import model_vg01, model_vg02, model_vg03, model_vg04
+from vocab_growth.models import (
+    model_vg01,
+    model_vg02,
+    model_vg03,
+    model_vg04,
+    model_vg05,
+)
 from vocab_growth.storage import upload_to_blob_storage
 
 if __name__ == "__main__":
@@ -46,6 +52,7 @@ if __name__ == "__main__":
         "vg02": model_vg02,
         "vg03": model_vg03,
         "vg04": model_vg04,
+        "vg05": model_vg05,
     }
 
     if args.model == "all":

--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -40,6 +40,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Upload model output to Azure Blob Storage",
     )
+    parser.add_argument(
+        "--include-traces",
+        action="store_true",
+        help="Include trace files (.nc) in the upload (excluded by default).",
+    )
 
     freeze_support()
 
@@ -76,4 +81,5 @@ if __name__ == "__main__":
             upload_to_blob_storage(
                 context.reporting.output_dir,
                 context.reporting.model_label,
+                include_traces=args.include_traces,
             )

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -17,6 +17,7 @@ MODEL_CONFIGS = {
     "vg02": ("VG02", "age-understood-ds"),
     "vg03": ("VG03", "age-spoken-td"),
     "vg04": ("VG04", "age-understood-td"),
+    "vg05": ("VG05", "age-understood-spoken-ds"),
 }
 
 if __name__ == "__main__":
@@ -26,7 +27,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "model",
         type=str,
-        help="Model id (vg01, vg02, vg03, vg04) or 'all'.",
+        help="Model id (vg01, vg02, vg03, vg04, vg05) or 'all'.",
     )
 
     args = parser.parse_args()

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -29,6 +29,11 @@ if __name__ == "__main__":
         type=str,
         help="Model id (vg01, vg02, vg03, vg04, vg05) or 'all'.",
     )
+    parser.add_argument(
+        "--include-traces",
+        action="store_true",
+        help="Include trace files (.nc) in the upload (excluded by default).",
+    )
 
     args = parser.parse_args()
 
@@ -51,4 +56,6 @@ if __name__ == "__main__":
             print("Run fit_model.py first to generate model output.")
             exit(1)
 
-        upload_to_blob_storage(output_dir, model_label)
+        upload_to_blob_storage(
+            output_dir, model_label, include_traces=args.include_traces
+        )

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -6,6 +6,7 @@ Shared dataclasses for the vocabulary growth model family.
 """
 
 from dataclasses import dataclass, field
+from typing import Generic, TypeVar
 
 import dse_research_utils.environment.info as env_info
 import dse_research_utils.statistics.models.data as model_data
@@ -20,51 +21,17 @@ from preliz.distributions.distributions import Continuous
 
 
 @dataclass
-class ModelConfiguration:
+class BaseModelConfiguration:
+    """Base configuration shared by all model variants."""
+
     slope_anchors: tuple[float, float]
-    """
-    Reference ages (months) for the slope parameterisation.
-    """
+    """Reference ages (months) for the slope parameterisation."""
     ell_months_range: tuple[int, int]
-    """
-    Range of length-scales in months for the HSGP prior.
-    """
-    p_slope_low_dist: Continuous
-    """
-    Prior distribution for the mean proportion of the outcome at the lower slope anchor.
-    """
-    p_slope_hi_dist: Continuous
-    """
-    Prior distribution for the mean proportion of the outcome at the upper slope anchor.
-    """
-    ell_unit_dist: Continuous
-    """
-    Prior distribution for the unit length-scale parameter (ell_unit).
-    """
-    eta_dist: Continuous
-    """
-    Prior distribution for the GP amplitude (eta).
-    """
-    kappa_min_dist: Continuous
-    """
-    Prior distribution for the minimum kappa value (kappa_min).
-    """
-    a_kappa_dist: Continuous
-    """
-    Prior distribution for the age slope of kappa (a_kappa).
-    """
-    b_kappa_mag_dist: Continuous
-    """
-    Prior distribution for the magnitude of the kappa parameter
-    """
+    """Range of length-scales in months for the HSGP prior."""
     n_plot: int
-    """
-    Number of points for plotting the developmental trajectory.
-    """
+    """Number of points for plotting the developmental trajectory."""
     ages_query: list[int]
-    """
-    Ages in months for querying the model.
-    """
+    """Ages in months for querying the model."""
 
     def __post_init__(self) -> None:
         if len(self.slope_anchors) != 2:
@@ -78,79 +45,69 @@ class ModelConfiguration:
 
 
 @dataclass
-class ModelSamples:
-    X_obs: np.ndarray
-    """
-    Observed ages in months, shape (n,).
-    """
-    X_plot: np.ndarray
-    """
-    Ages in months for the plot points, shape (n_plot,).
-    """
-    X_query: np.ndarray
-    """
-    Ages in months for the query points, shape (n_query,).
-    """
-    X_obs_z: np.ndarray
-    """
-    Standardized observed ages, shape (n, n_samples).
-    """
-    X_plot_z: np.ndarray
-    """
-    Standardized ages for the plot points, shape (n_plot, n_samples).
-    """
-    X_query_z: np.ndarray
-    """
-    Standardized ages for the query points, shape (n_query, n_samples).
-    """
-    f_obs: np.ndarray
-    """
-    Posterior samples of the latent linear predictor f for the observed points: (n, n_samples)
-    """
-    f_plot: np.ndarray
-    """
-    Posterior samples of the latent linear predictor f for the plot points: (n_plot, n_samples)
-    """
-    f_query: np.ndarray
-    """
-    Posterior samples of the latent linear predictor f for the query points: (n_query, n_samples)
-    """
-    p_obs: np.ndarray
-    """
-    Posterior samples of p(z) for the observed points: (n, n_samples)
-    """
-    p_plot: np.ndarray
-    """
-    Posterior samples of p(z) for the plot points: (n_plot, n_samples)
-    """
-    p_query: np.ndarray
-    """
-    Posterior samples of p(z) for the query points: (n_query, n_samples)
-    """
-    y_obs: np.ndarray
-    """
-    Observed vocabulary sizes, shape (n,).
-    """
-    y_plot: np.ndarray
-    """
-    Posterior predictive samples of y for the plot points: (n_plot, n_samples)
-    """
-    y_query: np.ndarray
-    """
-    Posterior predictive samples of y for the query points: (n_query, n_samples)
-    """
-    kappa_plot: np.ndarray
-    """
-    Posterior samples of κ for the plot points: (n_plot, n_samples)
-    """
-    kappa_query: np.ndarray
-    """
-    Posterior samples of κ for the query points: (n_query, n_samples)
-    """
+class ModelConfiguration(BaseModelConfiguration):
+    """Configuration for a single-outcome model (VG01-VG04)."""
+
+    p_slope_low_dist: Continuous
+    """Prior distribution for the mean proportion of the outcome at the lower slope anchor."""
+    p_slope_hi_dist: Continuous
+    """Prior distribution for the mean proportion of the outcome at the upper slope anchor."""
+    ell_unit_dist: Continuous
+    """Prior distribution for the unit length-scale parameter (ell_unit)."""
+    eta_dist: Continuous
+    """Prior distribution for the GP amplitude (eta)."""
+    kappa_min_dist: Continuous
+    """Prior distribution for the minimum kappa value (kappa_min)."""
+    a_kappa_dist: Continuous
+    """Prior distribution for the age slope of kappa (a_kappa)."""
+    b_kappa_mag_dist: Continuous
+    """Prior distribution for the magnitude of the kappa parameter."""
 
 
 @dataclass
-class ModelFitContext:
+class ModelSamples:
+    X_obs: np.ndarray
+    """Observed ages in months, shape (n,)."""
+    X_plot: np.ndarray
+    """Ages in months for the plot points, shape (n_plot,)."""
+    X_query: np.ndarray
+    """Ages in months for the query points, shape (n_query,)."""
+    X_obs_z: np.ndarray
+    """Standardized observed ages, shape (n, n_samples)."""
+    X_plot_z: np.ndarray
+    """Standardized ages for the plot points, shape (n_plot, n_samples)."""
+    X_query_z: np.ndarray
+    """Standardized ages for the query points, shape (n_query, n_samples)."""
+    f_obs: np.ndarray
+    """Posterior samples of the latent linear predictor f for the observed points: (n, n_samples)"""
+    f_plot: np.ndarray
+    """Posterior samples of the latent linear predictor f for the plot points: (n_plot, n_samples)"""
+    f_query: np.ndarray
+    """Posterior samples of the latent linear predictor f for the query points: (n_query, n_samples)"""
+    p_obs: np.ndarray
+    """Posterior samples of p(z) for the observed points: (n, n_samples)"""
+    p_plot: np.ndarray
+    """Posterior samples of p(z) for the plot points: (n_plot, n_samples)"""
+    p_query: np.ndarray
+    """Posterior samples of p(z) for the query points: (n_query, n_samples)"""
+    y_obs: np.ndarray
+    """Observed vocabulary sizes, shape (n,)."""
+    y_plot: np.ndarray
+    """Posterior predictive samples of y for the plot points: (n_plot, n_samples)"""
+    y_query: np.ndarray
+    """Posterior predictive samples of y for the query points: (n_query, n_samples)"""
+    kappa_plot: np.ndarray
+    """Posterior samples of kappa for the plot points: (n_plot, n_samples)"""
+    kappa_query: np.ndarray
+    """Posterior samples of kappa for the query points: (n_query, n_samples)"""
+
+
+C = TypeVar("C", bound=BaseModelConfiguration, default=ModelConfiguration)
+S = TypeVar("S", default=ModelSamples)
+
+
+@dataclass
+class ModelFitContext(Generic[C, S]):
     reporting: reporting.ReportingConfiguration
     sampling: sampling.SamplingConfiguration
     execution_context: str = field(default_factory=env_info.get_execution_context)
@@ -158,24 +115,20 @@ class ModelFitContext:
     dataframes: dict[str, pd.DataFrame] = field(default_factory=dict)
     _model_data: model_data.BinomialModelData | None = None
     _analysis_df: pd.DataFrame | None = None
-    _model_config: ModelConfiguration | None = None
+    _model_config: C | None = None
     _model: pm.Model | None = None
     _model_variables: dict | None = None
     _prior_samples: InferenceData | None = None
     _trace: InferenceData | None = None
-    _loocv: ELPDData | None = None
-    _model_samples: ModelSamples | None = None
+    _loocv: ELPDData | dict[str, ELPDData] | None = None
+    _model_samples: S | None = None
 
     def is_script(self) -> bool:
-        """
-        Check if the execution context is a script.
-        """
+        """Check if the execution context is a script."""
         return self.execution_context == "script"
 
     def is_interactive(self) -> bool:
-        """
-        Check if the execution context is interactive (e.g., Jupyter notebook).
-        """
+        """Check if the execution context is interactive (e.g., Jupyter notebook)."""
         return self.execution_context in ("jupyter", "ipython", "interactive-other")
 
     def set_model_data(
@@ -196,11 +149,11 @@ class ModelFitContext:
             raise ValueError("Analysis DataFrame has not been set in the context.")
         return self._analysis_df
 
-    def set_model_config(self, model_config: ModelConfiguration):
+    def set_model_config(self, model_config: C):
         self._model_config = model_config
 
     @property
-    def model_config(self) -> ModelConfiguration:
+    def model_config(self) -> C:
         if self._model_config is None:
             raise ValueError("Model configuration has not been set in the context.")
         return self._model_config
@@ -239,20 +192,20 @@ class ModelFitContext:
             raise ValueError("Trace has not been set in the context.")
         return self._trace
 
-    def set_loocv(self, loocv: ELPDData):
+    def set_loocv(self, loocv: ELPDData | dict[str, ELPDData]):
         self._loocv = loocv
 
     @property
-    def loocv(self) -> ELPDData:
+    def loocv(self) -> ELPDData | dict[str, ELPDData]:
         if self._loocv is None:
             raise ValueError("LOO-CV data has not been set in the context.")
         return self._loocv
 
-    def set_model_samples(self, model_samples: ModelSamples):
+    def set_model_samples(self, model_samples: S):
         self._model_samples = model_samples
 
     @property
-    def model_samples(self) -> ModelSamples:
+    def model_samples(self) -> S:
         if self._model_samples is None:
             raise ValueError("Model samples have not been set in the context.")
         return self._model_samples

--- a/src/vocab_growth/models/model_vg05.py
+++ b/src/vocab_growth/models/model_vg05.py
@@ -826,7 +826,7 @@ def configure_model(context: ModelFitContext):
     )
     print(f"[bold yellow]eta_q_dist:[/bold yellow] {eta_q_dist.summary(mass=context.reporting.hdi)}")
 
-    p_slope_low_q_dist = pz.Beta(alpha=1.0, beta=15)
+    p_slope_low_q_dist = pz.Beta(alpha=2, beta=5)
     context.plots["p_slope_low_q_dist"] = plot_dist.plot_distribution(
         p_slope_low_q_dist, context.reporting.output_dir, "p_slope_low_q_dist"
     )
@@ -1096,9 +1096,13 @@ def diagnostics(context: ModelFitContext):
 
     context.set_trace(trace)
 
-    loocv = az.loo(context.trace)
-    context.set_loocv(loocv)
-    print(loocv)
+    loocv_s = az.loo(context.trace, var_name="y_s_obs")
+    loocv_u = az.loo(context.trace, var_name="y_u_obs")
+    context._loocv = {"y_s_obs": loocv_s, "y_u_obs": loocv_u}
+    print("LOO-CV (words spoken):")
+    print(loocv_s)
+    print("\nLOO-CV (words understood):")
+    print(loocv_u)
 
 
 def sample_posterior_predictive(context: ModelFitContext):
@@ -1218,7 +1222,7 @@ def posterior_summary(context: ModelFitContext):
 
     # Production rate summary
     q_query_median = np.median(samples.q_query, axis=1)
-    q_query_hdi = az.hdi(samples.q_query, hdi_prob=hdi_prob)
+    q_query_hdi = az.hdi(samples.q_query.T, hdi_prob=hdi_prob)
 
     summary_q = pd.DataFrame(
         {
@@ -1305,9 +1309,9 @@ def plot_production_rate(
     q_plot = samples.q_plot
 
     q_median = np.median(q_plot, axis=1)
-    q_hdi = az.hdi(q_plot, hdi_prob=hdi_prob)
-    q_hdi_75 = az.hdi(q_plot, hdi_prob=0.75)
-    q_hdi_50 = az.hdi(q_plot, hdi_prob=0.50)
+    q_hdi = az.hdi(q_plot.T, hdi_prob=hdi_prob)
+    q_hdi_75 = az.hdi(q_plot.T, hdi_prob=0.75)
+    q_hdi_50 = az.hdi(q_plot.T, hdi_prob=0.50)
 
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
 
@@ -1350,8 +1354,8 @@ def plot_comprehension_production_gap(
     gap = (samples.p_u_plot - samples.p_s_plot) * n_trials  # in word count units
 
     gap_median = np.median(gap, axis=1)
-    gap_hdi = az.hdi(gap, hdi_prob=hdi_prob)
-    gap_hdi_50 = az.hdi(gap, hdi_prob=0.50)
+    gap_hdi = az.hdi(gap.T, hdi_prob=hdi_prob)
+    gap_hdi_50 = az.hdi(gap.T, hdi_prob=0.50)
 
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
 
@@ -1442,7 +1446,7 @@ def fit(config: str) -> ModelFitContext:
     )
     print(
         "[bold green]Fitting Model VG05: Joint model of words understood and spoken"
-        " (A → U, A → S, U → S)[/bold green]"
+        " (A -> U, A -> S, U -> S)[/bold green]"
     )
     print("[green]============================================================[/green]")
     print()

--- a/src/vocab_growth/models/model_vg05.py
+++ b/src/vocab_growth/models/model_vg05.py
@@ -5,7 +5,7 @@
 Model VG05: Joint model of words understood and spoken (A → U, A → S, U → S)
 - children with Down syndrome
 
-Uses a production-given-comprehension reparameterization:
+Uses a production-ratio reparameterization:
     p_U(a) = sigmoid(f_U(a))
     q(a)   = sigmoid(h(a))       # fraction of understood words spoken
     p_S(a) = p_U(a) * q(a)       # enforces p_S <= p_U by construction
@@ -41,7 +41,7 @@ import vocab_growth.data_utils as vocab_data_utils
 import vocab_growth.environment as local_env
 import vocab_growth.plotting as plotting
 import vocab_growth.posterior_analysis as posterior_analysis
-from vocab_growth.models.common import ModelFitContext
+from vocab_growth.models.common import BaseModelConfiguration, ModelFitContext
 
 EPSILON = math_constants.EPSILON
 
@@ -52,13 +52,8 @@ EPSILON = math_constants.EPSILON
 
 
 @dataclass
-class BivariateModelConfiguration:
+class BivariateModelConfiguration(BaseModelConfiguration):
     """Configuration for the bivariate (understood + spoken) model."""
-
-    slope_anchors: tuple[float, float]
-    """Reference ages (months) for the slope parameterisation."""
-    ell_months_range: tuple[int, int]
-    """Range of length-scales in months for the HSGP prior."""
 
     # Understood (U) trajectory priors
     p_slope_low_u_dist: Continuous
@@ -66,7 +61,7 @@ class BivariateModelConfiguration:
     ell_unit_u_dist: Continuous
     eta_u_dist: Continuous
 
-    # Production-given-comprehension rate (q) priors
+    # Production ratio (q) priors
     p_slope_low_q_dist: Continuous
     p_slope_hi_q_dist: Continuous
     ell_unit_q_dist: Continuous
@@ -81,21 +76,6 @@ class BivariateModelConfiguration:
     kappa_min_s_dist: Continuous
     a_kappa_s_dist: Continuous
     b_kappa_mag_s_dist: Continuous
-
-    n_plot: int
-    """Number of points for plotting the developmental trajectory."""
-    ages_query: list[int]
-    """Ages in months for querying the model."""
-
-    def __post_init__(self) -> None:
-        if len(self.slope_anchors) != 2:
-            raise ValueError("slope_anchors must be a tuple of two float values.")
-        if len(self.ell_months_range) != 2:
-            raise ValueError("ell_months_range must be a tuple of two int values.")
-        if self.n_plot <= 0:
-            raise ValueError("n_plot must be a positive integer.")
-        if not isinstance(self.ages_query, list) or len(self.ages_query) == 0:
-            raise ValueError("ages_query must be a non-empty list of integers.")
 
 
 @dataclass
@@ -158,6 +138,9 @@ class BivariateModelSamples:
     """Boolean array: True where spoken is observed, shape (n,)."""
 
 
+Vg05Context = ModelFitContext[BivariateModelConfiguration, BivariateModelSamples]
+
+
 # ============================================================
 # Data preparation
 # ============================================================
@@ -191,7 +174,9 @@ def prepare_model_data(
     n = len(analysis_df)
     n_u = int(analysis_df["understood"].notna().sum())
     n_s = int(analysis_df["spoken"].notna().sum())
-    n_both = int((analysis_df["understood"].notna() & analysis_df["spoken"].notna()).sum())
+    n_both = int(
+        (analysis_df["understood"].notna() & analysis_df["spoken"].notna()).sum()
+    )
 
     print(f"\n  Total observations:       {n}")
     print(f"  Understood observed:      {n_u}")
@@ -204,7 +189,9 @@ def prepare_model_data(
     X_obs = np.asarray(analysis_df["age"], dtype=float).reshape(-1, 1)
     y_u_valid = analysis_df.loc[analysis_df["understood"].notna(), "understood"]
     y_obs_placeholder = np.zeros(n, dtype=int)
-    y_obs_placeholder[analysis_df["understood"].notna().values] = y_u_valid.values.astype(int)
+    y_obs_placeholder[analysis_df["understood"].notna().values] = (
+        y_u_valid.values.astype(int)
+    )
 
     bmd = model_data.BinomialModelData(
         X_obs=X_obs, y_obs=y_obs_placeholder, n_trials=n_trials
@@ -218,7 +205,7 @@ def prepare_model_data(
 # ============================================================
 
 
-def build_model(context: ModelFitContext):
+def build_model(context: Vg05Context):
     """Build the bivariate PyMC model."""
     config = context.model_config
 
@@ -236,12 +223,8 @@ def build_model(context: ModelFitContext):
     has_s = analysis_df["spoken"].notna().values
 
     X_obs = np.asarray(analysis_df["age"], dtype=float).reshape(-1, 1)
-    y_u_observed = np.asarray(
-        analysis_df.loc[has_u, "understood"], dtype=int
-    )
-    y_s_observed = np.asarray(
-        analysis_df.loc[has_s, "spoken"], dtype=int
-    )
+    y_u_observed = np.asarray(analysis_df.loc[has_u, "understood"], dtype=int)
+    y_s_observed = np.asarray(analysis_df.loc[has_s, "spoken"], dtype=int)
 
     idx_u = np.where(has_u)[0]
     idx_s = np.where(has_s)[0]
@@ -377,12 +360,10 @@ def build_model(context: ModelFitContext):
         g_unit_u = hsgp_u.prior("g_unit_u", X=X_all_z_data, dims="all_id")
         g_u = pm.Deterministic("g_u", eta_u * g_unit_u, dims=("all_id",))
 
-        f_u_all = pm.Deterministic(
-            "f_u_all", mean_trend_u + g_u, dims=("all_id",)
-        )
+        f_u_all = pm.Deterministic("f_u_all", mean_trend_u + g_u, dims=("all_id",))
 
         # ============================================================
-        # Production-given-comprehension rate: h(a) -> q(a) = sigmoid(h(a))
+        # Production ratio: h(a) -> q(a) = sigmoid(h(a))
         # ============================================================
 
         p_slope_low_q = config.p_slope_low_q_dist.to_pymc("p_slope_low_q")
@@ -411,9 +392,7 @@ def build_model(context: ModelFitContext):
         g_unit_q = hsgp_q.prior("g_unit_q", X=X_all_z_data, dims="all_id")
         g_q = pm.Deterministic("g_q", eta_q * g_unit_q, dims=("all_id",))
 
-        h_all = pm.Deterministic(
-            "h_all", mean_trend_q + g_q, dims=("all_id",)
-        )
+        h_all = pm.Deterministic("h_all", mean_trend_q + g_q, dims=("all_id",))
 
         # ============================================================
         # Derived quantities: p_U, q, p_S
@@ -422,12 +401,8 @@ def build_model(context: ModelFitContext):
         p_u_all = pm.Deterministic(
             "p_u_all", pm.math.sigmoid(f_u_all), dims=("all_id",)
         )
-        q_all = pm.Deterministic(
-            "q_all", pm.math.sigmoid(h_all), dims=("all_id",)
-        )
-        p_s_all = pm.Deterministic(
-            "p_s_all", p_u_all * q_all, dims=("all_id",)
-        )
+        q_all = pm.Deterministic("q_all", pm.math.sigmoid(h_all), dims=("all_id",))
+        p_s_all = pm.Deterministic("p_s_all", p_u_all * q_all, dims=("all_id",))
 
         # f_S derived for diagnostics/plotting
         p_s_all_clip = pm.math.clip(p_s_all, EPSILON, 1 - EPSILON)
@@ -440,22 +415,14 @@ def build_model(context: ModelFitContext):
         # ---- Slice into obs/plot/query ----
 
         # Understood
-        _ = pm.Deterministic(
-            "f_u_obs", f_u_all[i_obs0:i_obs1], dims=("obs_id",)
-        )
-        _ = pm.Deterministic(
-            "f_u_plot", f_u_all[i_plot0:i_plot1], dims=("plot_id",)
-        )
+        _ = pm.Deterministic("f_u_obs", f_u_all[i_obs0:i_obs1], dims=("obs_id",))
+        _ = pm.Deterministic("f_u_plot", f_u_all[i_plot0:i_plot1], dims=("plot_id",))
         _ = pm.Deterministic(
             "f_u_query", f_u_all[i_query0:i_query1], dims=("query_id",)
         )
 
-        p_u_obs = pm.Deterministic(
-            "p_u_obs", p_u_all[i_obs0:i_obs1], dims=("obs_id",)
-        )
-        _ = pm.Deterministic(
-            "p_u_plot", p_u_all[i_plot0:i_plot1], dims=("plot_id",)
-        )
+        p_u_obs = pm.Deterministic("p_u_obs", p_u_all[i_obs0:i_obs1], dims=("obs_id",))
+        _ = pm.Deterministic("p_u_plot", p_u_all[i_plot0:i_plot1], dims=("plot_id",))
         _ = pm.Deterministic(
             "p_u_query", p_u_all[i_query0:i_query1], dims=("query_id",)
         )
@@ -463,33 +430,21 @@ def build_model(context: ModelFitContext):
         # Production rate
         _ = pm.Deterministic("h_obs", h_all[i_obs0:i_obs1], dims=("obs_id",))
         _ = pm.Deterministic("h_plot", h_all[i_plot0:i_plot1], dims=("plot_id",))
-        _ = pm.Deterministic(
-            "h_query", h_all[i_query0:i_query1], dims=("query_id",)
-        )
+        _ = pm.Deterministic("h_query", h_all[i_query0:i_query1], dims=("query_id",))
 
         _ = pm.Deterministic("q_obs", q_all[i_obs0:i_obs1], dims=("obs_id",))
         _ = pm.Deterministic("q_plot", q_all[i_plot0:i_plot1], dims=("plot_id",))
-        _ = pm.Deterministic(
-            "q_query", q_all[i_query0:i_query1], dims=("query_id",)
-        )
+        _ = pm.Deterministic("q_query", q_all[i_query0:i_query1], dims=("query_id",))
 
         # Spoken (derived)
-        p_s_obs = pm.Deterministic(
-            "p_s_obs", p_s_all[i_obs0:i_obs1], dims=("obs_id",)
-        )
-        _ = pm.Deterministic(
-            "p_s_plot", p_s_all[i_plot0:i_plot1], dims=("plot_id",)
-        )
+        p_s_obs = pm.Deterministic("p_s_obs", p_s_all[i_obs0:i_obs1], dims=("obs_id",))
+        _ = pm.Deterministic("p_s_plot", p_s_all[i_plot0:i_plot1], dims=("plot_id",))
         _ = pm.Deterministic(
             "p_s_query", p_s_all[i_query0:i_query1], dims=("query_id",)
         )
 
-        _ = pm.Deterministic(
-            "f_s_obs", f_s_all[i_obs0:i_obs1], dims=("obs_id",)
-        )
-        _ = pm.Deterministic(
-            "f_s_plot", f_s_all[i_plot0:i_plot1], dims=("plot_id",)
-        )
+        _ = pm.Deterministic("f_s_obs", f_s_all[i_obs0:i_obs1], dims=("obs_id",))
+        _ = pm.Deterministic("f_s_plot", f_s_all[i_plot0:i_plot1], dims=("plot_id",))
         _ = pm.Deterministic(
             "f_s_query", f_s_all[i_query0:i_query1], dims=("query_id",)
         )
@@ -521,12 +476,8 @@ def build_model(context: ModelFitContext):
         kappa_u_obs = pm.Deterministic(
             "kappa_u_obs", kappa_u_of_z(z_obs), dims="obs_id"
         )
-        _ = pm.Deterministic(
-            "kappa_u_plot", kappa_u_of_z(z_plot), dims="plot_id"
-        )
-        _ = pm.Deterministic(
-            "kappa_u_query", kappa_u_of_z(z_query), dims="query_id"
-        )
+        _ = pm.Deterministic("kappa_u_plot", kappa_u_of_z(z_plot), dims="plot_id")
+        _ = pm.Deterministic("kappa_u_query", kappa_u_of_z(z_query), dims="query_id")
 
         # ============================================================
         # Kappa — spoken
@@ -543,12 +494,8 @@ def build_model(context: ModelFitContext):
         kappa_s_obs = pm.Deterministic(
             "kappa_s_obs", kappa_s_of_z(z_obs), dims="obs_id"
         )
-        _ = pm.Deterministic(
-            "kappa_s_plot", kappa_s_of_z(z_plot), dims="plot_id"
-        )
-        _ = pm.Deterministic(
-            "kappa_s_query", kappa_s_of_z(z_query), dims="query_id"
-        )
+        _ = pm.Deterministic("kappa_s_plot", kappa_s_of_z(z_plot), dims="plot_id")
+        _ = pm.Deterministic("kappa_s_query", kappa_s_of_z(z_query), dims="query_id")
 
         # ============================================================
         # Likelihoods — separate observation indices
@@ -686,9 +633,18 @@ def extract_model_samples(trace: InferenceData) -> BivariateModelSamples:
     kappa_s_plot = _extract_posterior(trace, "kappa_s_plot", "plot_id")
     kappa_s_query = _extract_posterior(trace, "kappa_s_query", "query_id")
 
-    # Observed data
-    y_u_obs = np.array(trace.observed_data["y_u_obs"].values, dtype=int)
-    y_s_obs = np.array(trace.observed_data["y_s_obs"].values, dtype=int)
+    # Observed data — expand to full obs_id length with NaN where unobserved
+    obs_u_mask = np.array(trace.constant_data["obs_u_mask"].values, dtype=bool)
+    obs_s_mask = np.array(trace.constant_data["obs_s_mask"].values, dtype=bool)
+    n_obs = len(obs_u_mask)
+
+    y_u_obs_raw = np.array(trace.observed_data["y_u_obs"].values, dtype=float)
+    y_u_obs = np.full(n_obs, np.nan)
+    y_u_obs[obs_u_mask] = y_u_obs_raw
+
+    y_s_obs_raw = np.array(trace.observed_data["y_s_obs"].values, dtype=float)
+    y_s_obs = np.full(n_obs, np.nan)
+    y_s_obs[obs_s_mask] = y_s_obs_raw
 
     # Posterior predictive
     y_u_plot = _extract_posterior_predictive(trace, "y_u_plot", "plot_id")
@@ -700,9 +656,6 @@ def extract_model_samples(trace: InferenceData) -> BivariateModelSamples:
     X_obs = np.array(trace.constant_data["X_obs"].values)
     X_plot = np.array(trace.constant_data["X_plot"].values)
     X_query = np.array(trace.constant_data["X_query"].values)
-
-    obs_u_mask = np.array(trace.constant_data["obs_u_mask"].values, dtype=bool)
-    obs_s_mask = np.array(trace.constant_data["obs_s_mask"].values, dtype=bool)
 
     # Standardised ages
     X_obs_z = _extract_posterior(trace, "z_obs", "obs_id")
@@ -754,7 +707,7 @@ def extract_model_samples(trace: InferenceData) -> BivariateModelSamples:
 # ============================================================
 
 
-def prepare_data(context: ModelFitContext):
+def prepare_data(context: Vg05Context):
     """Load and prepare data. Report descriptive statistics."""
     print(
         "\n[green]------------------------------------------------------------[/green]"
@@ -776,7 +729,7 @@ def prepare_data(context: ModelFitContext):
     )
 
 
-def configure_model(context: ModelFitContext):
+def configure_model(context: Vg05Context):
     """Configure priors and hyperparameters."""
     print(
         "\n[green]------------------------------------------------------------[/green]"
@@ -791,52 +744,68 @@ def configure_model(context: ModelFitContext):
     context.plots["ell_unit_u_dist"] = plot_dist.plot_distribution(
         ell_unit_u_dist, context.reporting.output_dir, "ell_unit_u_dist"
     )
-    print(f"[bold yellow]ell_unit_u_dist:[/bold yellow] {ell_unit_u_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]ell_unit_u_dist:[/bold yellow] {ell_unit_u_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     eta_u_dist = pz.HalfNormal(sigma=0.4)
     context.plots["eta_u_dist"] = plot_dist.plot_distribution(
         eta_u_dist, context.reporting.output_dir, "eta_u_dist"
     )
-    print(f"[bold yellow]eta_u_dist:[/bold yellow] {eta_u_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]eta_u_dist:[/bold yellow] {eta_u_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     # Slope priors for understood (from VG02)
     p_slope_low_u_dist = pz.Beta(alpha=1.0, beta=10)
     context.plots["p_slope_low_u_dist"] = plot_dist.plot_distribution(
         p_slope_low_u_dist, context.reporting.output_dir, "p_slope_low_u_dist"
     )
-    print(f"[bold yellow]p_slope_low_u_dist:[/bold yellow] {p_slope_low_u_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]p_slope_low_u_dist:[/bold yellow] {p_slope_low_u_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     p_slope_hi_u_dist = pz.Beta(alpha=1.1, beta=1.1)
     context.plots["p_slope_hi_u_dist"] = plot_dist.plot_distribution(
         p_slope_hi_u_dist, context.reporting.output_dir, "p_slope_hi_u_dist"
     )
-    print(f"[bold yellow]p_slope_hi_u_dist:[/bold yellow] {p_slope_hi_u_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]p_slope_hi_u_dist:[/bold yellow] {p_slope_hi_u_dist.summary(mass=context.reporting.hdi)}"
+    )
 
-    # --- Production-given-comprehension rate (q) priors ---
+    # --- Production ratio (q) priors ---
 
     ell_unit_q_dist = pz.Beta(alpha=3.0, beta=3.0)
     context.plots["ell_unit_q_dist"] = plot_dist.plot_distribution(
         ell_unit_q_dist, context.reporting.output_dir, "ell_unit_q_dist"
     )
-    print(f"[bold yellow]ell_unit_q_dist:[/bold yellow] {ell_unit_q_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]ell_unit_q_dist:[/bold yellow] {ell_unit_q_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     eta_q_dist = pz.HalfNormal(sigma=0.4)
     context.plots["eta_q_dist"] = plot_dist.plot_distribution(
         eta_q_dist, context.reporting.output_dir, "eta_q_dist"
     )
-    print(f"[bold yellow]eta_q_dist:[/bold yellow] {eta_q_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]eta_q_dist:[/bold yellow] {eta_q_dist.summary(mass=context.reporting.hdi)}"
+    )
 
-    p_slope_low_q_dist = pz.Beta(alpha=2, beta=5)
+    p_slope_low_q_dist = pz.Beta(alpha=1.0, beta=1.2)
     context.plots["p_slope_low_q_dist"] = plot_dist.plot_distribution(
         p_slope_low_q_dist, context.reporting.output_dir, "p_slope_low_q_dist"
     )
-    print(f"[bold yellow]p_slope_low_q_dist:[/bold yellow] {p_slope_low_q_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]p_slope_low_q_dist:[/bold yellow] {p_slope_low_q_dist.summary(mass=context.reporting.hdi)}"
+    )
 
-    p_slope_hi_q_dist = pz.Beta(alpha=1.1, beta=1.1)
+    p_slope_hi_q_dist = pz.Beta(alpha=1.2, beta=1.0)
     context.plots["p_slope_hi_q_dist"] = plot_dist.plot_distribution(
         p_slope_hi_q_dist, context.reporting.output_dir, "p_slope_hi_q_dist"
     )
-    print(f"[bold yellow]p_slope_hi_q_dist:[/bold yellow] {p_slope_hi_q_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]p_slope_hi_q_dist:[/bold yellow] {p_slope_hi_q_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     # --- Kappa priors — understood ---
 
@@ -844,19 +813,25 @@ def configure_model(context: ModelFitContext):
     context.plots["kappa_min_u_dist"] = plot_dist.plot_distribution(
         kappa_min_u_dist, context.reporting.output_dir, "kappa_min_u_dist"
     )
-    print(f"[bold yellow]kappa_min_u_dist:[/bold yellow] {kappa_min_u_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]kappa_min_u_dist:[/bold yellow] {kappa_min_u_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     a_kappa_u_dist = pz.Normal(mu=np.log(8.0), sigma=1.0)
     context.plots["a_kappa_u_dist"] = plot_dist.plot_distribution(
         a_kappa_u_dist, context.reporting.output_dir, "a_kappa_u_dist"
     )
-    print(f"[bold yellow]a_kappa_u_dist:[/bold yellow] {a_kappa_u_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]a_kappa_u_dist:[/bold yellow] {a_kappa_u_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     b_kappa_mag_u_dist = pz.HalfNormal(sigma=0.3)
     context.plots["b_kappa_mag_u_dist"] = plot_dist.plot_distribution(
         b_kappa_mag_u_dist, context.reporting.output_dir, "b_kappa_mag_u_dist"
     )
-    print(f"[bold yellow]b_kappa_mag_u_dist:[/bold yellow] {b_kappa_mag_u_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]b_kappa_mag_u_dist:[/bold yellow] {b_kappa_mag_u_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     # --- Kappa priors — spoken ---
 
@@ -864,19 +839,25 @@ def configure_model(context: ModelFitContext):
     context.plots["kappa_min_s_dist"] = plot_dist.plot_distribution(
         kappa_min_s_dist, context.reporting.output_dir, "kappa_min_s_dist"
     )
-    print(f"[bold yellow]kappa_min_s_dist:[/bold yellow] {kappa_min_s_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]kappa_min_s_dist:[/bold yellow] {kappa_min_s_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     a_kappa_s_dist = pz.Normal(mu=np.log(8.0), sigma=1.0)
     context.plots["a_kappa_s_dist"] = plot_dist.plot_distribution(
         a_kappa_s_dist, context.reporting.output_dir, "a_kappa_s_dist"
     )
-    print(f"[bold yellow]a_kappa_s_dist:[/bold yellow] {a_kappa_s_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]a_kappa_s_dist:[/bold yellow] {a_kappa_s_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     b_kappa_mag_s_dist = pz.HalfNormal(sigma=0.3)
     context.plots["b_kappa_mag_s_dist"] = plot_dist.plot_distribution(
         b_kappa_mag_s_dist, context.reporting.output_dir, "b_kappa_mag_s_dist"
     )
-    print(f"[bold yellow]b_kappa_mag_s_dist:[/bold yellow] {b_kappa_mag_s_dist.summary(mass=context.reporting.hdi)}")
+    print(
+        f"[bold yellow]b_kappa_mag_s_dist:[/bold yellow] {b_kappa_mag_s_dist.summary(mass=context.reporting.hdi)}"
+    )
 
     # --- Configuration object ---
 
@@ -911,7 +892,7 @@ def configure_model(context: ModelFitContext):
     context.set_model_config(config)
 
 
-def prior_predictive_checks(context: ModelFitContext):
+def prior_predictive_checks(context: Vg05Context):
     """Run prior predictive checks."""
     print(
         "\n[green]------------------------------------------------------------[/green]"
@@ -982,22 +963,19 @@ def prior_predictive_checks(context: ModelFitContext):
     X_plot_vals = prior_samples.constant_data["X_plot"].values
     n_curves = min(500, q_plot_samples.shape[1])
     for i in range(n_curves):
-        ax.plot(X_plot_vals, q_plot_samples.values[:, i], alpha=0.01, color="C2")
+        ax.plot(X_plot_vals, q_plot_samples.values[:, i], alpha=0.01)
     ax.set_xlabel("Age (months)")
-    ax.set_ylabel("q(a) = P(speaks | understands)")
+    ax.set_ylabel("q(a) = p_S(a) / p_U(a)")
     ax.set_ylim(0, 1)
-    ax.set_title("Prior samples: production-given-comprehension rate")
     fig.savefig(
         os.path.join(context.reporting.output_dir, "prior_samples_q.png"), dpi=300
     )
-    fig.savefig(
-        os.path.join(context.reporting.output_dir, "prior_samples_q.svg")
-    )
+    fig.savefig(os.path.join(context.reporting.output_dir, "prior_samples_q.svg"))
     context.plots["prior_samples_q"] = fig
     plt.close()
 
 
-def sample(context: ModelFitContext):
+def sample(context: Vg05Context):
     """Draw samples from the posterior using MCMC."""
     print(
         "\n[green]------------------------------------------------------------[/green]"
@@ -1027,7 +1005,7 @@ def sample(context: ModelFitContext):
     print("[bold green]Posterior sampling completed.[/bold green]")
 
 
-def diagnostics(context: ModelFitContext):
+def diagnostics(context: Vg05Context):
     """Run diagnostics on the posterior samples."""
     print(
         "\n[green]------------------------------------------------------------[/green]"
@@ -1098,14 +1076,14 @@ def diagnostics(context: ModelFitContext):
 
     loocv_s = az.loo(context.trace, var_name="y_s_obs")
     loocv_u = az.loo(context.trace, var_name="y_u_obs")
-    context._loocv = {"y_s_obs": loocv_s, "y_u_obs": loocv_u}
+    context.set_loocv({"y_s_obs": loocv_s, "y_u_obs": loocv_u})
     print("LOO-CV (words spoken):")
     print(loocv_s)
     print("\nLOO-CV (words understood):")
     print(loocv_u)
 
 
-def sample_posterior_predictive(context: ModelFitContext):
+def sample_posterior_predictive(context: Vg05Context):
     """Sample from the posterior predictive distribution."""
     print(
         "\n[green]------------------------------------------------------------[/green]"
@@ -1167,8 +1145,12 @@ def sample_posterior_predictive(context: ModelFitContext):
         trace = pm.sample_posterior_predictive(
             context.trace,
             var_names=[
-                "y_u_plot", "y_u_query", "y_u_obs",
-                "y_s_plot", "y_s_query", "y_s_obs",
+                "y_u_plot",
+                "y_u_query",
+                "y_u_obs",
+                "y_s_plot",
+                "y_s_query",
+                "y_s_obs",
             ],
             extend_inferencedata=True,
             random_seed=context.sampling.random_seed,
@@ -1182,7 +1164,7 @@ def sample_posterior_predictive(context: ModelFitContext):
     context.set_model_samples(sample_data)
 
 
-def posterior_summary(context: ModelFitContext):
+def posterior_summary(context: Vg05Context):
     """Compute and store the posterior summary tables at query ages."""
     samples = context.model_samples
     n_trials = context.model_data.n_trials
@@ -1279,12 +1261,12 @@ def plot_joint_trajectory(
 
     # Observed data
     X_obs = samples.X_obs
-    if samples.obs_u_mask.any():
-        obs_u_ages = X_obs[samples.obs_u_mask]
-        ax.scatter(obs_u_ages, samples.y_u_obs, s=10, alpha=0.2, color="C0")
-    if samples.obs_s_mask.any():
-        obs_s_ages = X_obs[samples.obs_s_mask]
-        ax.scatter(obs_s_ages, samples.y_s_obs, s=10, alpha=0.2, color="C1")
+    u_mask = ~np.isnan(samples.y_u_obs)
+    if u_mask.any():
+        ax.scatter(X_obs[u_mask], samples.y_u_obs[u_mask], s=10, alpha=0.2, color="C0")
+    s_mask = ~np.isnan(samples.y_s_obs)
+    if s_mask.any():
+        ax.scatter(X_obs[s_mask], samples.y_s_obs[s_mask], s=10, alpha=0.2, color="C1")
 
     ax.set_xlabel("Age (months)")
     ax.set_ylabel("Word count")
@@ -1304,7 +1286,7 @@ def plot_production_rate(
     output_dir: str | None = None,
     filename: str | None = None,
 ):
-    """Plot the posterior of q(a) = P(speaks | understands) over age."""
+    """Plot the posterior of the production ratio q(a) = p_S(a) / p_U(a) over age."""
     X_plot = samples.X_plot
     q_plot = samples.q_plot
 
@@ -1316,24 +1298,33 @@ def plot_production_rate(
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
 
     ax.fill_between(
-        X_plot, q_hdi[:, 0], q_hdi[:, 1],
-        alpha=0.20, label=f"{int(hdi_prob * 100)}% HDI",
+        X_plot,
+        q_hdi[:, 0],
+        q_hdi[:, 1],
+        alpha=0.20,
+        label=f"{int(hdi_prob * 100)}% HDI",
     )
     ax.fill_between(
-        X_plot, q_hdi_75[:, 0], q_hdi_75[:, 1],
-        alpha=0.25, label="75% HDI",
+        X_plot,
+        q_hdi_75[:, 0],
+        q_hdi_75[:, 1],
+        alpha=0.25,
+        label="75% HDI",
     )
     ax.fill_between(
-        X_plot, q_hdi_50[:, 0], q_hdi_50[:, 1],
-        alpha=0.30, label="50% HDI",
+        X_plot,
+        q_hdi_50[:, 0],
+        q_hdi_50[:, 1],
+        alpha=0.30,
+        label="50% HDI",
     )
     ax.plot(X_plot, q_median, lw=3, label="Median q(a)")
 
     ax.set_xlabel("Age (months)")
-    ax.set_ylabel("q(a) = P(speaks | understands)")
+    ax.set_ylabel("q(a) = p_S(a) / p_U(a)")
     ax.set_ylim(0, 1)
     ax.legend(loc="upper left", frameon=True)
-    ax.set_title("Production-given-comprehension rate")
+    ax.set_title("Production ratio q(a)")
 
     if output_dir is not None and filename is not None:
         fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
@@ -1360,12 +1351,18 @@ def plot_comprehension_production_gap(
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
 
     ax.fill_between(
-        X_plot, gap_hdi[:, 0], gap_hdi[:, 1],
-        alpha=0.20, label=f"{int(hdi_prob * 100)}% HDI",
+        X_plot,
+        gap_hdi[:, 0],
+        gap_hdi[:, 1],
+        alpha=0.20,
+        label=f"{int(hdi_prob * 100)}% HDI",
     )
     ax.fill_between(
-        X_plot, gap_hdi_50[:, 0], gap_hdi_50[:, 1],
-        alpha=0.30, label="50% HDI",
+        X_plot,
+        gap_hdi_50[:, 0],
+        gap_hdi_50[:, 1],
+        alpha=0.30,
+        label="50% HDI",
     )
     ax.plot(X_plot, gap_median, lw=3, label="Median gap")
 
@@ -1386,7 +1383,7 @@ def plot_comprehension_production_gap(
 # ============================================================
 
 
-def report(context: ModelFitContext):
+def report(context: Vg05Context):
     """Copy output artefacts to the report directory."""
 
     REPORT_OUTPUT_DIR = os.path.join(
@@ -1440,7 +1437,7 @@ def report(context: ModelFitContext):
 # ============================================================
 
 
-def fit(config: str) -> ModelFitContext:
+def fit(config: str) -> Vg05Context:
     print(
         "\n[green]============================================================[/green]"
     )
@@ -1467,7 +1464,7 @@ def fit(config: str) -> ModelFitContext:
     print()
     package_metadata.report_package_versions(package_list)
 
-    context = ModelFitContext(
+    context: Vg05Context = ModelFitContext(
         reporting=reporting.ReportingConfiguration(
             model_name="VG05",
             config_name="age-understood-spoken-ds",
@@ -1505,31 +1502,37 @@ def fit(config: str) -> ModelFitContext:
 
     # ---- Joint trajectory plot ----
 
-    plot_joint_trajectory(
+    fig = plot_joint_trajectory(
         samples,
         n_trials=context.model_data.n_trials,
         output_dir=context.reporting.output_dir,
         filename="joint_trajectory",
     )
+    context.plots["joint_trajectory"] = fig
+    plt.close(fig)
 
     # ---- Production rate q(a) ----
 
-    plot_production_rate(
+    fig = plot_production_rate(
         samples,
         hdi_prob=context.reporting.hdi,
         output_dir=context.reporting.output_dir,
         filename="production_rate",
     )
+    context.plots["production_rate"] = fig
+    plt.close(fig)
 
     # ---- Comprehension-production gap ----
 
-    plot_comprehension_production_gap(
+    fig = plot_comprehension_production_gap(
         samples,
         n_trials=context.model_data.n_trials,
         hdi_prob=context.reporting.hdi,
         output_dir=context.reporting.output_dir,
         filename="comprehension_production_gap",
     )
+    context.plots["comprehension_production_gap"] = fig
+    plt.close(fig)
 
     # ---- Per-outcome plots: understood ----
 
@@ -1542,7 +1545,9 @@ def fit(config: str) -> ModelFitContext:
     )
 
     plotting.plot_posterior_predictive_pmf(
-        samples.X_query, samples.X_plot, samples.y_u_plot,
+        samples.X_query,
+        samples.X_plot,
+        samples.y_u_plot,
         context.model_data.n_trials,
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_pmf_u",
@@ -1550,7 +1555,9 @@ def fit(config: str) -> ModelFitContext:
     )
 
     plotting.plot_posterior_predictive_cdf(
-        samples.X_query, samples.X_plot, samples.y_u_plot,
+        samples.X_query,
+        samples.X_plot,
+        samples.y_u_plot,
         context.model_data.n_trials,
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_cdf_u",
@@ -1558,24 +1565,32 @@ def fit(config: str) -> ModelFitContext:
     )
 
     plotting.plot_posterior_predictive_median_trend(
-        samples.X_plot, samples.y_u_plot,
-        analysis_df.loc[has_u, "age"], analysis_df.loc[has_u, "understood"],
+        samples.X_plot,
+        samples.y_u_plot,
+        analysis_df.loc[has_u, "age"],
+        analysis_df.loc[has_u, "understood"],
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_median_trend_u",
         y_label="Predicted words understood",
     )
 
     plotting.plot_posterior_predictive_median_trend(
-        samples.X_plot, samples.y_u_plot,
-        analysis_df.loc[has_u, "age"], analysis_df.loc[has_u, "understood"],
-        smooth=True, savgol_window_length=15, savgol_polyorder=3, smooth_intervals=True,
+        samples.X_plot,
+        samples.y_u_plot,
+        analysis_df.loc[has_u, "age"],
+        analysis_df.loc[has_u, "understood"],
+        smooth=True,
+        savgol_window_length=15,
+        savgol_polyorder=3,
+        smooth_intervals=True,
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_median_trend_u_smoothed",
         y_label="Predicted words understood",
     )
 
     plotting.plot_expected_learning_rate(
-        samples.X_plot, samples.f_u_plot,
+        samples.X_plot,
+        samples.f_u_plot,
         n_trials=context.model_data.n_trials,
         hdi_prob=context.reporting.hdi,
         output_dir=context.reporting.output_dir,
@@ -1584,18 +1599,24 @@ def fit(config: str) -> ModelFitContext:
     )
 
     plotting.plot_expected_learning_rate(
-        samples.X_plot, samples.f_u_plot,
+        samples.X_plot,
+        samples.f_u_plot,
         n_trials=context.model_data.n_trials,
         hdi_prob=context.reporting.hdi,
-        smooth=True, savgol_window_length=15, savgol_polyorder=3, smooth_intervals=True,
+        smooth=True,
+        savgol_window_length=15,
+        savgol_polyorder=3,
+        smooth_intervals=True,
         output_dir=context.reporting.output_dir,
         filename="expected_learning_rate_u_smoothed",
         y_label="Estimated understood word gain per month",
     )
 
     plotting.plot_posterior_kappa(
-        samples.X_plot, samples.kappa_u_plot,
-        samples.X_query, samples.kappa_u_query,
+        samples.X_plot,
+        samples.kappa_u_plot,
+        samples.X_query,
+        samples.kappa_u_query,
         n_trials=context.model_data.n_trials,
         hdi_prob=context.reporting.hdi,
         output_dir=context.reporting.output_dir,
@@ -1613,7 +1634,9 @@ def fit(config: str) -> ModelFitContext:
     )
 
     plotting.plot_posterior_predictive_pmf(
-        samples.X_query, samples.X_plot, samples.y_s_plot,
+        samples.X_query,
+        samples.X_plot,
+        samples.y_s_plot,
         context.model_data.n_trials,
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_pmf_s",
@@ -1621,7 +1644,9 @@ def fit(config: str) -> ModelFitContext:
     )
 
     plotting.plot_posterior_predictive_cdf(
-        samples.X_query, samples.X_plot, samples.y_s_plot,
+        samples.X_query,
+        samples.X_plot,
+        samples.y_s_plot,
         context.model_data.n_trials,
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_cdf_s",
@@ -1629,24 +1654,32 @@ def fit(config: str) -> ModelFitContext:
     )
 
     plotting.plot_posterior_predictive_median_trend(
-        samples.X_plot, samples.y_s_plot,
-        analysis_df.loc[has_s, "age"], analysis_df.loc[has_s, "spoken"],
+        samples.X_plot,
+        samples.y_s_plot,
+        analysis_df.loc[has_s, "age"],
+        analysis_df.loc[has_s, "spoken"],
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_median_trend_s",
         y_label="Predicted words spoken",
     )
 
     plotting.plot_posterior_predictive_median_trend(
-        samples.X_plot, samples.y_s_plot,
-        analysis_df.loc[has_s, "age"], analysis_df.loc[has_s, "spoken"],
-        smooth=True, savgol_window_length=15, savgol_polyorder=3, smooth_intervals=True,
+        samples.X_plot,
+        samples.y_s_plot,
+        analysis_df.loc[has_s, "age"],
+        analysis_df.loc[has_s, "spoken"],
+        smooth=True,
+        savgol_window_length=15,
+        savgol_polyorder=3,
+        smooth_intervals=True,
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_median_trend_s_smoothed",
         y_label="Predicted words spoken",
     )
 
     plotting.plot_expected_learning_rate(
-        samples.X_plot, samples.f_s_plot,
+        samples.X_plot,
+        samples.f_s_plot,
         n_trials=context.model_data.n_trials,
         hdi_prob=context.reporting.hdi,
         output_dir=context.reporting.output_dir,
@@ -1655,18 +1688,24 @@ def fit(config: str) -> ModelFitContext:
     )
 
     plotting.plot_expected_learning_rate(
-        samples.X_plot, samples.f_s_plot,
+        samples.X_plot,
+        samples.f_s_plot,
         n_trials=context.model_data.n_trials,
         hdi_prob=context.reporting.hdi,
-        smooth=True, savgol_window_length=15, savgol_polyorder=3, smooth_intervals=True,
+        smooth=True,
+        savgol_window_length=15,
+        savgol_polyorder=3,
+        smooth_intervals=True,
         output_dir=context.reporting.output_dir,
         filename="expected_learning_rate_s_smoothed",
         y_label="Estimated spoken word gain per month",
     )
 
     plotting.plot_posterior_kappa(
-        samples.X_plot, samples.kappa_s_plot,
-        samples.X_query, samples.kappa_s_query,
+        samples.X_plot,
+        samples.kappa_s_plot,
+        samples.X_query,
+        samples.kappa_s_query,
         n_trials=context.model_data.n_trials,
         hdi_prob=context.reporting.hdi,
         output_dir=context.reporting.output_dir,

--- a/src/vocab_growth/models/model_vg05.py
+++ b/src/vocab_growth/models/model_vg05.py
@@ -1,0 +1,1674 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Model VG05: Joint model of words understood and spoken (A → U, A → S, U → S)
+- children with Down syndrome
+
+Uses a production-given-comprehension reparameterization:
+    p_U(a) = sigmoid(f_U(a))
+    q(a)   = sigmoid(h(a))       # fraction of understood words spoken
+    p_S(a) = p_U(a) * q(a)       # enforces p_S <= p_U by construction
+"""
+
+import os
+import shutil
+from dataclasses import dataclass
+
+import arviz as az
+import dse_research_utils.environment.info as env_info
+import dse_research_utils.math.constants as math_constants
+import dse_research_utils.metadata.packages as package_metadata
+import dse_research_utils.plot.diagnostics_mcmc as plot_diagnostics_mcmc
+import dse_research_utils.plot.distributions as plot_dist
+import dse_research_utils.plot.styles as plot_styles
+import dse_research_utils.statistics.descriptive as descriptive_stats
+import dse_research_utils.statistics.models.data as model_data
+import dse_research_utils.statistics.models.pymc_utils as pymc_utils
+import dse_research_utils.statistics.models.reporting as reporting
+import dse_research_utils.statistics.models.sampling as sampling
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import preliz as pz
+import pymc as pm
+from arviz import InferenceData
+from preliz.distributions.distributions import Continuous
+from rich import print
+from rich.pretty import pprint
+
+import vocab_growth.data_utils as vocab_data_utils
+import vocab_growth.environment as local_env
+import vocab_growth.plotting as plotting
+import vocab_growth.posterior_analysis as posterior_analysis
+from vocab_growth.models.common import ModelFitContext
+
+EPSILON = math_constants.EPSILON
+
+
+# ============================================================
+# VG05-specific dataclasses
+# ============================================================
+
+
+@dataclass
+class BivariateModelConfiguration:
+    """Configuration for the bivariate (understood + spoken) model."""
+
+    slope_anchors: tuple[float, float]
+    """Reference ages (months) for the slope parameterisation."""
+    ell_months_range: tuple[int, int]
+    """Range of length-scales in months for the HSGP prior."""
+
+    # Understood (U) trajectory priors
+    p_slope_low_u_dist: Continuous
+    p_slope_hi_u_dist: Continuous
+    ell_unit_u_dist: Continuous
+    eta_u_dist: Continuous
+
+    # Production-given-comprehension rate (q) priors
+    p_slope_low_q_dist: Continuous
+    p_slope_hi_q_dist: Continuous
+    ell_unit_q_dist: Continuous
+    eta_q_dist: Continuous
+
+    # Kappa priors — understood
+    kappa_min_u_dist: Continuous
+    a_kappa_u_dist: Continuous
+    b_kappa_mag_u_dist: Continuous
+
+    # Kappa priors — spoken
+    kappa_min_s_dist: Continuous
+    a_kappa_s_dist: Continuous
+    b_kappa_mag_s_dist: Continuous
+
+    n_plot: int
+    """Number of points for plotting the developmental trajectory."""
+    ages_query: list[int]
+    """Ages in months for querying the model."""
+
+    def __post_init__(self) -> None:
+        if len(self.slope_anchors) != 2:
+            raise ValueError("slope_anchors must be a tuple of two float values.")
+        if len(self.ell_months_range) != 2:
+            raise ValueError("ell_months_range must be a tuple of two int values.")
+        if self.n_plot <= 0:
+            raise ValueError("n_plot must be a positive integer.")
+        if not isinstance(self.ages_query, list) or len(self.ages_query) == 0:
+            raise ValueError("ages_query must be a non-empty list of integers.")
+
+
+@dataclass
+class BivariateModelSamples:
+    """Posterior and predictive samples from the bivariate model."""
+
+    # Shared age grids
+    X_obs: np.ndarray
+    """Observed ages in months, shape (n,)."""
+    X_plot: np.ndarray
+    """Ages in months for the plot points, shape (n_plot,)."""
+    X_query: np.ndarray
+    """Ages in months for the query points, shape (n_query,)."""
+
+    X_obs_z: np.ndarray
+    """Standardized observed ages, shape (n, n_samples)."""
+    X_plot_z: np.ndarray
+    """Standardized ages for the plot points, shape (n_plot, n_samples)."""
+    X_query_z: np.ndarray
+    """Standardized ages for the query points, shape (n_query, n_samples)."""
+
+    # Understood (U) samples
+    f_u_obs: np.ndarray
+    f_u_plot: np.ndarray
+    f_u_query: np.ndarray
+    p_u_obs: np.ndarray
+    p_u_plot: np.ndarray
+    p_u_query: np.ndarray
+    y_u_obs: np.ndarray
+    y_u_plot: np.ndarray
+    y_u_query: np.ndarray
+    kappa_u_plot: np.ndarray
+    kappa_u_query: np.ndarray
+
+    # Production rate (q) samples
+    h_obs: np.ndarray
+    h_plot: np.ndarray
+    h_query: np.ndarray
+    q_obs: np.ndarray
+    q_plot: np.ndarray
+    q_query: np.ndarray
+
+    # Spoken (S) samples (derived)
+    f_s_obs: np.ndarray
+    f_s_plot: np.ndarray
+    f_s_query: np.ndarray
+    p_s_obs: np.ndarray
+    p_s_plot: np.ndarray
+    p_s_query: np.ndarray
+    y_s_obs: np.ndarray
+    y_s_plot: np.ndarray
+    y_s_query: np.ndarray
+    kappa_s_plot: np.ndarray
+    kappa_s_query: np.ndarray
+
+    # Observation masks (over obs_id)
+    obs_u_mask: np.ndarray
+    """Boolean array: True where understood is observed, shape (n,)."""
+    obs_s_mask: np.ndarray
+    """Boolean array: True where spoken is observed, shape (n,)."""
+
+
+# ============================================================
+# Data preparation
+# ============================================================
+
+
+def prepare_model_data(
+    max_age_months: int | None = None,
+    n_trials: int = 800,
+) -> tuple[model_data.BinomialModelData, pd.DataFrame, pd.DataFrame]:
+    """Load data, keeping rows where at least one of understood/spoken is observed."""
+
+    vocab_df = vocab_data_utils.load_combined_data(max_age_months=max_age_months)
+    analysis_df = vocab_df[["age", "understood", "spoken"]].copy()
+
+    # Keep rows where at least one outcome is observed (and age is present)
+    analysis_df = analysis_df.dropna(subset=["age"])
+    has_u = analysis_df["understood"].notna()
+    has_s = analysis_df["spoken"].notna()
+    analysis_df = analysis_df[has_u | has_s].reset_index(drop=True)
+
+    desc = descriptive_stats.describe_all(analysis_df, alpha=0.05)
+
+    print(
+        "\n[green]------------------------------------------------------------[/green]"
+    )
+    print("[bold green]Descriptive statistics[/bold green]")
+    print("[green]------------------------------------------------------------[/green]")
+
+    pprint(desc)
+
+    n = len(analysis_df)
+    n_u = int(analysis_df["understood"].notna().sum())
+    n_s = int(analysis_df["spoken"].notna().sum())
+    n_both = int((analysis_df["understood"].notna() & analysis_df["spoken"].notna()).sum())
+
+    print(f"\n  Total observations:       {n}")
+    print(f"  Understood observed:      {n_u}")
+    print(f"  Spoken observed:          {n_s}")
+    print(f"  Both observed:            {n_both}")
+    print(f"  Understood only:          {n_u - n_both}")
+    print(f"  Spoken only:              {n_s - n_both}")
+
+    # Create a BinomialModelData for the context interface (using understood as primary)
+    X_obs = np.asarray(analysis_df["age"], dtype=float).reshape(-1, 1)
+    y_u_valid = analysis_df.loc[analysis_df["understood"].notna(), "understood"]
+    y_obs_placeholder = np.zeros(n, dtype=int)
+    y_obs_placeholder[analysis_df["understood"].notna().values] = y_u_valid.values.astype(int)
+
+    bmd = model_data.BinomialModelData(
+        X_obs=X_obs, y_obs=y_obs_placeholder, n_trials=n_trials
+    )
+
+    return bmd, analysis_df, desc
+
+
+# ============================================================
+# Model building
+# ============================================================
+
+
+def build_model(context: ModelFitContext):
+    """Build the bivariate PyMC model."""
+    config = context.model_config
+
+    print(
+        "\n[green]------------------------------------------------------------[/green]"
+    )
+    print("[bold green]Model definition and initialisation[/bold green]")
+    print("[green]------------------------------------------------------------[/green]")
+    print()
+
+    analysis_df = context.analysis_df
+
+    # Observation masks
+    has_u = analysis_df["understood"].notna().values
+    has_s = analysis_df["spoken"].notna().values
+
+    X_obs = np.asarray(analysis_df["age"], dtype=float).reshape(-1, 1)
+    y_u_observed = np.asarray(
+        analysis_df.loc[has_u, "understood"], dtype=int
+    )
+    y_s_observed = np.asarray(
+        analysis_df.loc[has_s, "spoken"], dtype=int
+    )
+
+    idx_u = np.where(has_u)[0]
+    idx_s = np.where(has_s)[0]
+
+    n = len(X_obs)
+    n_u = len(y_u_observed)
+    n_s = len(y_s_observed)
+    n_trials = context.model_data.n_trials
+
+    print(f"  Total observations:   {n}")
+    print(f"  Understood observed:  {n_u}")
+    print(f"  Spoken observed:      {n_s}")
+    print(f"  n_trials:             {n_trials}")
+
+    # Validate
+    if not np.all(y_u_observed >= 0):
+        raise ValueError("y_u contains negative counts.")
+    if not np.all(y_u_observed <= n_trials):
+        raise ValueError("y_u exceeds n_trials.")
+    if not np.all(y_s_observed >= 0):
+        raise ValueError("y_s contains negative counts.")
+    if not np.all(y_s_observed <= n_trials):
+        raise ValueError("y_s exceeds n_trials.")
+
+    # Standardise ages
+    X_obs_mean = float(np.mean(X_obs))
+    X_obs_std = float(np.std(X_obs, ddof=1))
+
+    if not np.isfinite(X_obs_std) or X_obs_std <= 0:
+        raise ValueError("Age standard deviation must be positive.")
+
+    print(f"  Age (months) - mean: {X_obs_mean:.2f}, std: {X_obs_std:.2f}")
+
+    X_obs_z = (X_obs - X_obs_mean) / X_obs_std
+
+    # Plot grid
+    X_plot = np.linspace(X_obs.min(), X_obs.max(), config.n_plot).reshape(-1, 1)
+    X_plot_z = (X_plot - X_obs_mean) / X_obs_std
+
+    # Query grid
+    X_query = np.array(config.ages_query).reshape(-1, 1)
+    X_query_z = (X_query - X_obs_mean) / X_obs_std
+
+    # Stack all
+    X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z])
+
+    n_plot = X_plot_z.shape[0]
+    n_query = X_query_z.shape[0]
+    n_all = X_all_z.shape[0]
+
+    # Length-scale bounds
+    ell_low_months = float(config.ell_months_range[0])
+    ell_high_months = float(config.ell_months_range[1])
+
+    if ell_low_months <= 0 or ell_high_months <= 0:
+        raise ValueError("Length-scale bounds must be positive (in months).")
+    if ell_high_months <= ell_low_months:
+        raise ValueError("ell_months_range must be (low, high) with high > low.")
+
+    ell_low_z = ell_low_months / X_obs_std
+    ell_high_z = ell_high_months / X_obs_std
+    ell_range_z = (ell_low_z, ell_high_z)
+
+    L, M = get_hsgp_hyperparams(X_obs_z, ell_range_z)
+
+    print(f"  HSGP basis size (m): {M}")
+    print(f"  HSGP L: {L}")
+
+    # Slope anchors
+    slope_age_a = float(config.slope_anchors[0])
+    slope_age_b = float(config.slope_anchors[1])
+    slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
+    slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
+
+    print(f"  Slope anchors (z-scores): {slope_age_a_z:.2f}, {slope_age_b_z:.2f}")
+
+    # Slice indices
+    i_obs0, i_obs1 = 0, n
+    i_plot0, i_plot1 = i_obs1, i_obs1 + n_plot
+    i_query0, i_query1 = i_plot1, i_plot1 + n_query
+
+    coords = {
+        "all_id": np.arange(n_all),
+        "obs_id": np.arange(n),
+        "obs_u_id": np.arange(n_u),
+        "obs_s_id": np.arange(n_s),
+        "plot_id": np.arange(n_plot),
+        "query_id": np.arange(n_query),
+        "x_dim": np.arange(1),
+    }
+
+    with pm.Model(coords=coords) as model_pm:
+
+        # ---- Data ----
+
+        X_all_z_data = pm.Data("X_all_z", X_all_z, dims=("all_id", "x_dim"))
+
+        _ = pm.Data("X_obs", X_obs.flatten(), dims=("obs_id",))
+        _ = pm.Data("X_plot", X_plot.flatten(), dims=("plot_id",))
+        _ = pm.Data("X_query", X_query.flatten(), dims=("query_id",))
+
+        # Store masks and indices as constant data for extraction
+        _ = pm.Data("obs_u_mask", has_u.astype(int), dims=("obs_id",))
+        _ = pm.Data("obs_s_mask", has_s.astype(int), dims=("obs_id",))
+
+        # ============================================================
+        # Understood (U) trajectory: f_U(a) -> p_U(a)
+        # ============================================================
+
+        p_slope_low_u = config.p_slope_low_u_dist.to_pymc("p_slope_low_u")
+        p_slope_hi_u = config.p_slope_hi_u_dist.to_pymc("p_slope_hi_u")
+
+        slope_u = pm.Deterministic(
+            "slope_u",
+            (pymc_utils.logit(p_slope_hi_u) - pymc_utils.logit(p_slope_low_u))
+            / (slope_age_b_z - slope_age_a_z),
+        )
+        intercept_u = pm.Deterministic(
+            "intercept_u",
+            pymc_utils.logit(p_slope_low_u) - slope_u * slope_age_a_z,
+        )
+        mean_trend_u = intercept_u + slope_u * X_all_z_data[:, 0]
+
+        # GP for understood
+        ell_unit_u = config.ell_unit_u_dist.to_pymc("ell_unit_u")
+        ell_u = pm.Deterministic(
+            "ell_u", ell_low_z + (ell_high_z - ell_low_z) * ell_unit_u
+        )
+        eta_u = config.eta_u_dist.to_pymc("eta_u")
+
+        cov_u = pm.gp.cov.ExpQuad(1, ls=ell_u)
+        hsgp_u = pm.gp.HSGP(cov_func=cov_u, m=M, L=L)
+        g_unit_u = hsgp_u.prior("g_unit_u", X=X_all_z_data, dims="all_id")
+        g_u = pm.Deterministic("g_u", eta_u * g_unit_u, dims=("all_id",))
+
+        f_u_all = pm.Deterministic(
+            "f_u_all", mean_trend_u + g_u, dims=("all_id",)
+        )
+
+        # ============================================================
+        # Production-given-comprehension rate: h(a) -> q(a) = sigmoid(h(a))
+        # ============================================================
+
+        p_slope_low_q = config.p_slope_low_q_dist.to_pymc("p_slope_low_q")
+        p_slope_hi_q = config.p_slope_hi_q_dist.to_pymc("p_slope_hi_q")
+
+        slope_q = pm.Deterministic(
+            "slope_q",
+            (pymc_utils.logit(p_slope_hi_q) - pymc_utils.logit(p_slope_low_q))
+            / (slope_age_b_z - slope_age_a_z),
+        )
+        intercept_q = pm.Deterministic(
+            "intercept_q",
+            pymc_utils.logit(p_slope_low_q) - slope_q * slope_age_a_z,
+        )
+        mean_trend_q = intercept_q + slope_q * X_all_z_data[:, 0]
+
+        # GP for production rate
+        ell_unit_q = config.ell_unit_q_dist.to_pymc("ell_unit_q")
+        ell_q = pm.Deterministic(
+            "ell_q", ell_low_z + (ell_high_z - ell_low_z) * ell_unit_q
+        )
+        eta_q = config.eta_q_dist.to_pymc("eta_q")
+
+        cov_q = pm.gp.cov.ExpQuad(1, ls=ell_q)
+        hsgp_q = pm.gp.HSGP(cov_func=cov_q, m=M, L=L)
+        g_unit_q = hsgp_q.prior("g_unit_q", X=X_all_z_data, dims="all_id")
+        g_q = pm.Deterministic("g_q", eta_q * g_unit_q, dims=("all_id",))
+
+        h_all = pm.Deterministic(
+            "h_all", mean_trend_q + g_q, dims=("all_id",)
+        )
+
+        # ============================================================
+        # Derived quantities: p_U, q, p_S
+        # ============================================================
+
+        p_u_all = pm.Deterministic(
+            "p_u_all", pm.math.sigmoid(f_u_all), dims=("all_id",)
+        )
+        q_all = pm.Deterministic(
+            "q_all", pm.math.sigmoid(h_all), dims=("all_id",)
+        )
+        p_s_all = pm.Deterministic(
+            "p_s_all", p_u_all * q_all, dims=("all_id",)
+        )
+
+        # f_S derived for diagnostics/plotting
+        p_s_all_clip = pm.math.clip(p_s_all, EPSILON, 1 - EPSILON)
+        f_s_all = pm.Deterministic(
+            "f_s_all",
+            pm.math.log(p_s_all_clip) - pm.math.log(1 - p_s_all_clip),
+            dims=("all_id",),
+        )
+
+        # ---- Slice into obs/plot/query ----
+
+        # Understood
+        _ = pm.Deterministic(
+            "f_u_obs", f_u_all[i_obs0:i_obs1], dims=("obs_id",)
+        )
+        _ = pm.Deterministic(
+            "f_u_plot", f_u_all[i_plot0:i_plot1], dims=("plot_id",)
+        )
+        _ = pm.Deterministic(
+            "f_u_query", f_u_all[i_query0:i_query1], dims=("query_id",)
+        )
+
+        p_u_obs = pm.Deterministic(
+            "p_u_obs", p_u_all[i_obs0:i_obs1], dims=("obs_id",)
+        )
+        _ = pm.Deterministic(
+            "p_u_plot", p_u_all[i_plot0:i_plot1], dims=("plot_id",)
+        )
+        _ = pm.Deterministic(
+            "p_u_query", p_u_all[i_query0:i_query1], dims=("query_id",)
+        )
+
+        # Production rate
+        _ = pm.Deterministic("h_obs", h_all[i_obs0:i_obs1], dims=("obs_id",))
+        _ = pm.Deterministic("h_plot", h_all[i_plot0:i_plot1], dims=("plot_id",))
+        _ = pm.Deterministic(
+            "h_query", h_all[i_query0:i_query1], dims=("query_id",)
+        )
+
+        _ = pm.Deterministic("q_obs", q_all[i_obs0:i_obs1], dims=("obs_id",))
+        _ = pm.Deterministic("q_plot", q_all[i_plot0:i_plot1], dims=("plot_id",))
+        _ = pm.Deterministic(
+            "q_query", q_all[i_query0:i_query1], dims=("query_id",)
+        )
+
+        # Spoken (derived)
+        p_s_obs = pm.Deterministic(
+            "p_s_obs", p_s_all[i_obs0:i_obs1], dims=("obs_id",)
+        )
+        _ = pm.Deterministic(
+            "p_s_plot", p_s_all[i_plot0:i_plot1], dims=("plot_id",)
+        )
+        _ = pm.Deterministic(
+            "p_s_query", p_s_all[i_query0:i_query1], dims=("query_id",)
+        )
+
+        _ = pm.Deterministic(
+            "f_s_obs", f_s_all[i_obs0:i_obs1], dims=("obs_id",)
+        )
+        _ = pm.Deterministic(
+            "f_s_plot", f_s_all[i_plot0:i_plot1], dims=("plot_id",)
+        )
+        _ = pm.Deterministic(
+            "f_s_query", f_s_all[i_query0:i_query1], dims=("query_id",)
+        )
+
+        # ---- Shared standardised ages ----
+
+        z_obs = pm.Deterministic(
+            "z_obs", X_all_z_data[i_obs0:i_obs1, 0], dims=("obs_id",)
+        )
+        z_plot = pm.Deterministic(
+            "z_plot", X_all_z_data[i_plot0:i_plot1, 0], dims=("plot_id",)
+        )
+        z_query = pm.Deterministic(
+            "z_query", X_all_z_data[i_query0:i_query1, 0], dims=("query_id",)
+        )
+
+        # ============================================================
+        # Kappa — understood
+        # ============================================================
+
+        kappa_min_u = config.kappa_min_u_dist.to_pymc("kappa_min_u")
+        a_kappa_u = config.a_kappa_u_dist.to_pymc("a_kappa_u")
+        b_kappa_mag_u = config.b_kappa_mag_u_dist.to_pymc("b_kappa_mag_u")
+        b_kappa_u = pm.Deterministic("b_kappa_u", -b_kappa_mag_u)
+
+        def kappa_u_of_z(z):
+            return kappa_min_u + pm.math.exp(a_kappa_u + b_kappa_u * z)
+
+        kappa_u_obs = pm.Deterministic(
+            "kappa_u_obs", kappa_u_of_z(z_obs), dims="obs_id"
+        )
+        _ = pm.Deterministic(
+            "kappa_u_plot", kappa_u_of_z(z_plot), dims="plot_id"
+        )
+        _ = pm.Deterministic(
+            "kappa_u_query", kappa_u_of_z(z_query), dims="query_id"
+        )
+
+        # ============================================================
+        # Kappa — spoken
+        # ============================================================
+
+        kappa_min_s = config.kappa_min_s_dist.to_pymc("kappa_min_s")
+        a_kappa_s = config.a_kappa_s_dist.to_pymc("a_kappa_s")
+        b_kappa_mag_s = config.b_kappa_mag_s_dist.to_pymc("b_kappa_mag_s")
+        b_kappa_s = pm.Deterministic("b_kappa_s", -b_kappa_mag_s)
+
+        def kappa_s_of_z(z):
+            return kappa_min_s + pm.math.exp(a_kappa_s + b_kappa_s * z)
+
+        kappa_s_obs = pm.Deterministic(
+            "kappa_s_obs", kappa_s_of_z(z_obs), dims="obs_id"
+        )
+        _ = pm.Deterministic(
+            "kappa_s_plot", kappa_s_of_z(z_plot), dims="plot_id"
+        )
+        _ = pm.Deterministic(
+            "kappa_s_query", kappa_s_of_z(z_query), dims="query_id"
+        )
+
+        # ============================================================
+        # Likelihoods — separate observation indices
+        # ============================================================
+
+        # Understood likelihood (only where observed)
+        p_u_obs_sel = p_u_obs[idx_u]
+        p_u_obs_clip = pm.math.clip(p_u_obs_sel, EPSILON, 1 - EPSILON)
+        alpha_u = p_u_obs_clip * kappa_u_obs[idx_u]
+        beta_u = (1 - p_u_obs_clip) * kappa_u_obs[idx_u]
+
+        _ = pm.BetaBinomial(
+            "y_u_obs",
+            n=n_trials,
+            alpha=alpha_u,
+            beta=beta_u,
+            observed=y_u_observed,
+            dims=("obs_u_id",),
+        )
+
+        # Spoken likelihood (only where observed)
+        p_s_obs_sel = p_s_obs[idx_s]
+        p_s_obs_clip = pm.math.clip(p_s_obs_sel, EPSILON, 1 - EPSILON)
+        alpha_s = p_s_obs_clip * kappa_s_obs[idx_s]
+        beta_s = (1 - p_s_obs_clip) * kappa_s_obs[idx_s]
+
+        _ = pm.BetaBinomial(
+            "y_s_obs",
+            n=n_trials,
+            alpha=alpha_s,
+            beta=beta_s,
+            observed=y_s_observed,
+            dims=("obs_s_id",),
+        )
+
+    variables = pymc_utils.get_variables_dict(model_pm)
+
+    pymc_utils.report_model_summary(model_pm)
+
+    digraph = pymc_utils.model_to_graphviz(model_pm)
+    digraph.render(
+        filename=os.path.join(context.reporting.output_dir, "gp_model_graph"),
+        format="svg",
+        cleanup=True,
+    )
+
+    context.set_model(model_pm, variables)
+
+
+# ============================================================
+# HSGP hyperparameters
+# ============================================================
+
+
+def get_hsgp_hyperparams(X_obs_z, ell_range_z):
+    """Compute HSGP basis size and boundary factor."""
+    x_min = float(np.min(X_obs_z))
+    x_max = float(np.max(X_obs_z))
+
+    ell_low_z = ell_range_z[0]
+    ell_high_z = ell_range_z[1]
+
+    m, c = pm.gp.hsgp_approx.approx_hsgp_hyperparams(
+        x_range=[x_min, x_max],
+        lengthscale_range=[ell_low_z, ell_high_z],
+        cov_func="expquad",
+    )
+
+    S = max(abs(x_min), abs(x_max))
+    L = [S * c]
+    M = [m]
+
+    return L, M
+
+
+# ============================================================
+# Sample extraction
+# ============================================================
+
+
+def _extract_posterior(trace, name, dim_name):
+    """Extract posterior samples, stacking chains and draws."""
+    return np.array(
+        trace.posterior[name]
+        .stack(sample=("chain", "draw"))
+        .transpose(dim_name, "sample")
+        .values
+    )
+
+
+def _extract_posterior_predictive(trace, name, dim_name):
+    """Extract posterior predictive samples, stacking chains and draws."""
+    return np.array(
+        trace.posterior_predictive[name]
+        .stack(sample=("chain", "draw"))
+        .transpose(dim_name, "sample")
+        .values,
+        dtype=int,
+    )
+
+
+def extract_model_samples(trace: InferenceData) -> BivariateModelSamples:
+    """Extract model samples into a structured format for plotting and reporting."""
+
+    # Understood
+    f_u_obs = _extract_posterior(trace, "f_u_obs", "obs_id")
+    f_u_plot = _extract_posterior(trace, "f_u_plot", "plot_id")
+    f_u_query = _extract_posterior(trace, "f_u_query", "query_id")
+
+    p_u_obs = _extract_posterior(trace, "p_u_obs", "obs_id")
+    p_u_plot = _extract_posterior(trace, "p_u_plot", "plot_id")
+    p_u_query = _extract_posterior(trace, "p_u_query", "query_id")
+
+    kappa_u_plot = _extract_posterior(trace, "kappa_u_plot", "plot_id")
+    kappa_u_query = _extract_posterior(trace, "kappa_u_query", "query_id")
+
+    # Production rate
+    h_obs = _extract_posterior(trace, "h_obs", "obs_id")
+    h_plot = _extract_posterior(trace, "h_plot", "plot_id")
+    h_query = _extract_posterior(trace, "h_query", "query_id")
+
+    q_obs = _extract_posterior(trace, "q_obs", "obs_id")
+    q_plot = _extract_posterior(trace, "q_plot", "plot_id")
+    q_query = _extract_posterior(trace, "q_query", "query_id")
+
+    # Spoken (derived)
+    f_s_obs = _extract_posterior(trace, "f_s_obs", "obs_id")
+    f_s_plot = _extract_posterior(trace, "f_s_plot", "plot_id")
+    f_s_query = _extract_posterior(trace, "f_s_query", "query_id")
+
+    p_s_obs = _extract_posterior(trace, "p_s_obs", "obs_id")
+    p_s_plot = _extract_posterior(trace, "p_s_plot", "plot_id")
+    p_s_query = _extract_posterior(trace, "p_s_query", "query_id")
+
+    kappa_s_plot = _extract_posterior(trace, "kappa_s_plot", "plot_id")
+    kappa_s_query = _extract_posterior(trace, "kappa_s_query", "query_id")
+
+    # Observed data
+    y_u_obs = np.array(trace.observed_data["y_u_obs"].values, dtype=int)
+    y_s_obs = np.array(trace.observed_data["y_s_obs"].values, dtype=int)
+
+    # Posterior predictive
+    y_u_plot = _extract_posterior_predictive(trace, "y_u_plot", "plot_id")
+    y_u_query = _extract_posterior_predictive(trace, "y_u_query", "query_id")
+    y_s_plot = _extract_posterior_predictive(trace, "y_s_plot", "plot_id")
+    y_s_query = _extract_posterior_predictive(trace, "y_s_query", "query_id")
+
+    # Constant data
+    X_obs = np.array(trace.constant_data["X_obs"].values)
+    X_plot = np.array(trace.constant_data["X_plot"].values)
+    X_query = np.array(trace.constant_data["X_query"].values)
+
+    obs_u_mask = np.array(trace.constant_data["obs_u_mask"].values, dtype=bool)
+    obs_s_mask = np.array(trace.constant_data["obs_s_mask"].values, dtype=bool)
+
+    # Standardised ages
+    X_obs_z = _extract_posterior(trace, "z_obs", "obs_id")
+    X_plot_z = _extract_posterior(trace, "z_plot", "plot_id")
+    X_query_z = _extract_posterior(trace, "z_query", "query_id")
+
+    return BivariateModelSamples(
+        X_obs=X_obs,
+        X_plot=X_plot,
+        X_query=X_query,
+        X_obs_z=X_obs_z,
+        X_plot_z=X_plot_z,
+        X_query_z=X_query_z,
+        f_u_obs=f_u_obs,
+        f_u_plot=f_u_plot,
+        f_u_query=f_u_query,
+        p_u_obs=p_u_obs,
+        p_u_plot=p_u_plot,
+        p_u_query=p_u_query,
+        y_u_obs=y_u_obs,
+        y_u_plot=y_u_plot,
+        y_u_query=y_u_query,
+        kappa_u_plot=kappa_u_plot,
+        kappa_u_query=kappa_u_query,
+        h_obs=h_obs,
+        h_plot=h_plot,
+        h_query=h_query,
+        q_obs=q_obs,
+        q_plot=q_plot,
+        q_query=q_query,
+        f_s_obs=f_s_obs,
+        f_s_plot=f_s_plot,
+        f_s_query=f_s_query,
+        p_s_obs=p_s_obs,
+        p_s_plot=p_s_plot,
+        p_s_query=p_s_query,
+        y_s_obs=y_s_obs,
+        y_s_plot=y_s_plot,
+        y_s_query=y_s_query,
+        kappa_s_plot=kappa_s_plot,
+        kappa_s_query=kappa_s_query,
+        obs_u_mask=obs_u_mask,
+        obs_s_mask=obs_s_mask,
+    )
+
+
+# ============================================================
+# Pipeline steps
+# ============================================================
+
+
+def prepare_data(context: ModelFitContext):
+    """Load and prepare data. Report descriptive statistics."""
+    print(
+        "\n[green]------------------------------------------------------------[/green]"
+    )
+    print("[bold green]Prepare data[/bold green]")
+    print("[green]------------------------------------------------------------[/green]")
+    print()
+
+    data, analysis_df, desc_stats = prepare_model_data(
+        max_age_months=None, n_trials=800
+    )
+
+    context.set_model_data(data, analysis_df)
+    context.dataframes["descriptive_stats"] = desc_stats
+
+    desc_stats.to_csv(
+        os.path.join(context.reporting.output_dir, "descriptive_statistics.csv"),
+        index=True,
+    )
+
+
+def configure_model(context: ModelFitContext):
+    """Configure priors and hyperparameters."""
+    print(
+        "\n[green]------------------------------------------------------------[/green]"
+    )
+    print("[bold green]Priors and hyperparameters[/bold green]")
+    print("[green]------------------------------------------------------------[/green]")
+    print()
+
+    # --- Understood (U) trajectory priors ---
+
+    ell_unit_u_dist = pz.Beta(alpha=3.0, beta=3.0)
+    context.plots["ell_unit_u_dist"] = plot_dist.plot_distribution(
+        ell_unit_u_dist, context.reporting.output_dir, "ell_unit_u_dist"
+    )
+    print(f"[bold yellow]ell_unit_u_dist:[/bold yellow] {ell_unit_u_dist.summary(mass=context.reporting.hdi)}")
+
+    eta_u_dist = pz.HalfNormal(sigma=0.4)
+    context.plots["eta_u_dist"] = plot_dist.plot_distribution(
+        eta_u_dist, context.reporting.output_dir, "eta_u_dist"
+    )
+    print(f"[bold yellow]eta_u_dist:[/bold yellow] {eta_u_dist.summary(mass=context.reporting.hdi)}")
+
+    # Slope priors for understood (from VG02)
+    p_slope_low_u_dist = pz.Beta(alpha=1.0, beta=10)
+    context.plots["p_slope_low_u_dist"] = plot_dist.plot_distribution(
+        p_slope_low_u_dist, context.reporting.output_dir, "p_slope_low_u_dist"
+    )
+    print(f"[bold yellow]p_slope_low_u_dist:[/bold yellow] {p_slope_low_u_dist.summary(mass=context.reporting.hdi)}")
+
+    p_slope_hi_u_dist = pz.Beta(alpha=1.1, beta=1.1)
+    context.plots["p_slope_hi_u_dist"] = plot_dist.plot_distribution(
+        p_slope_hi_u_dist, context.reporting.output_dir, "p_slope_hi_u_dist"
+    )
+    print(f"[bold yellow]p_slope_hi_u_dist:[/bold yellow] {p_slope_hi_u_dist.summary(mass=context.reporting.hdi)}")
+
+    # --- Production-given-comprehension rate (q) priors ---
+
+    ell_unit_q_dist = pz.Beta(alpha=3.0, beta=3.0)
+    context.plots["ell_unit_q_dist"] = plot_dist.plot_distribution(
+        ell_unit_q_dist, context.reporting.output_dir, "ell_unit_q_dist"
+    )
+    print(f"[bold yellow]ell_unit_q_dist:[/bold yellow] {ell_unit_q_dist.summary(mass=context.reporting.hdi)}")
+
+    eta_q_dist = pz.HalfNormal(sigma=0.4)
+    context.plots["eta_q_dist"] = plot_dist.plot_distribution(
+        eta_q_dist, context.reporting.output_dir, "eta_q_dist"
+    )
+    print(f"[bold yellow]eta_q_dist:[/bold yellow] {eta_q_dist.summary(mass=context.reporting.hdi)}")
+
+    p_slope_low_q_dist = pz.Beta(alpha=1.0, beta=15)
+    context.plots["p_slope_low_q_dist"] = plot_dist.plot_distribution(
+        p_slope_low_q_dist, context.reporting.output_dir, "p_slope_low_q_dist"
+    )
+    print(f"[bold yellow]p_slope_low_q_dist:[/bold yellow] {p_slope_low_q_dist.summary(mass=context.reporting.hdi)}")
+
+    p_slope_hi_q_dist = pz.Beta(alpha=1.1, beta=1.1)
+    context.plots["p_slope_hi_q_dist"] = plot_dist.plot_distribution(
+        p_slope_hi_q_dist, context.reporting.output_dir, "p_slope_hi_q_dist"
+    )
+    print(f"[bold yellow]p_slope_hi_q_dist:[/bold yellow] {p_slope_hi_q_dist.summary(mass=context.reporting.hdi)}")
+
+    # --- Kappa priors — understood ---
+
+    kappa_min_u_dist = pz.LogNormal(mu=np.log(5.0), sigma=0.6)
+    context.plots["kappa_min_u_dist"] = plot_dist.plot_distribution(
+        kappa_min_u_dist, context.reporting.output_dir, "kappa_min_u_dist"
+    )
+    print(f"[bold yellow]kappa_min_u_dist:[/bold yellow] {kappa_min_u_dist.summary(mass=context.reporting.hdi)}")
+
+    a_kappa_u_dist = pz.Normal(mu=np.log(8.0), sigma=1.0)
+    context.plots["a_kappa_u_dist"] = plot_dist.plot_distribution(
+        a_kappa_u_dist, context.reporting.output_dir, "a_kappa_u_dist"
+    )
+    print(f"[bold yellow]a_kappa_u_dist:[/bold yellow] {a_kappa_u_dist.summary(mass=context.reporting.hdi)}")
+
+    b_kappa_mag_u_dist = pz.HalfNormal(sigma=0.3)
+    context.plots["b_kappa_mag_u_dist"] = plot_dist.plot_distribution(
+        b_kappa_mag_u_dist, context.reporting.output_dir, "b_kappa_mag_u_dist"
+    )
+    print(f"[bold yellow]b_kappa_mag_u_dist:[/bold yellow] {b_kappa_mag_u_dist.summary(mass=context.reporting.hdi)}")
+
+    # --- Kappa priors — spoken ---
+
+    kappa_min_s_dist = pz.LogNormal(mu=np.log(5.0), sigma=0.6)
+    context.plots["kappa_min_s_dist"] = plot_dist.plot_distribution(
+        kappa_min_s_dist, context.reporting.output_dir, "kappa_min_s_dist"
+    )
+    print(f"[bold yellow]kappa_min_s_dist:[/bold yellow] {kappa_min_s_dist.summary(mass=context.reporting.hdi)}")
+
+    a_kappa_s_dist = pz.Normal(mu=np.log(8.0), sigma=1.0)
+    context.plots["a_kappa_s_dist"] = plot_dist.plot_distribution(
+        a_kappa_s_dist, context.reporting.output_dir, "a_kappa_s_dist"
+    )
+    print(f"[bold yellow]a_kappa_s_dist:[/bold yellow] {a_kappa_s_dist.summary(mass=context.reporting.hdi)}")
+
+    b_kappa_mag_s_dist = pz.HalfNormal(sigma=0.3)
+    context.plots["b_kappa_mag_s_dist"] = plot_dist.plot_distribution(
+        b_kappa_mag_s_dist, context.reporting.output_dir, "b_kappa_mag_s_dist"
+    )
+    print(f"[bold yellow]b_kappa_mag_s_dist:[/bold yellow] {b_kappa_mag_s_dist.summary(mass=context.reporting.hdi)}")
+
+    # --- Configuration object ---
+
+    slope_age_low = 24
+    slope_age_hi = 84
+
+    config = BivariateModelConfiguration(
+        slope_anchors=(slope_age_low, slope_age_hi),
+        ell_months_range=(2, 12),
+        # Understood
+        p_slope_low_u_dist=p_slope_low_u_dist,
+        p_slope_hi_u_dist=p_slope_hi_u_dist,
+        ell_unit_u_dist=ell_unit_u_dist,
+        eta_u_dist=eta_u_dist,
+        # Production rate
+        p_slope_low_q_dist=p_slope_low_q_dist,
+        p_slope_hi_q_dist=p_slope_hi_q_dist,
+        ell_unit_q_dist=ell_unit_q_dist,
+        eta_q_dist=eta_q_dist,
+        # Kappa — understood
+        kappa_min_u_dist=kappa_min_u_dist,
+        a_kappa_u_dist=a_kappa_u_dist,
+        b_kappa_mag_u_dist=b_kappa_mag_u_dist,
+        # Kappa — spoken
+        kappa_min_s_dist=kappa_min_s_dist,
+        a_kappa_s_dist=a_kappa_s_dist,
+        b_kappa_mag_s_dist=b_kappa_mag_s_dist,
+        n_plot=500,
+        ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
+    )
+
+    context.set_model_config(config)
+
+
+def prior_predictive_checks(context: ModelFitContext):
+    """Run prior predictive checks."""
+    print(
+        "\n[green]------------------------------------------------------------[/green]"
+    )
+    print("[bold green]Prior predictive checks[/bold green]")
+    print("[green]------------------------------------------------------------[/green]")
+    print()
+
+    with context.model:
+        prior_samples = pm.sample_prior_predictive(
+            draws=2000, random_seed=context.sampling.random_seed
+        )
+
+    context.set_prior_samples(prior_samples)
+
+    analysis_df = context.analysis_df
+    has_u = analysis_df["understood"].notna()
+    has_s = analysis_df["spoken"].notna()
+
+    # Prior samples for understood trajectory
+    p_u_plot_samples = (
+        prior_samples.prior["p_u_plot"]
+        .stack(sample=("chain", "draw"))
+        .transpose("plot_id", "sample")
+    )
+
+    plotting.plot_prior_samples(
+        prior_samples.constant_data["X_plot"].values,
+        p_u_plot_samples.values,
+        analysis_df.loc[has_u, "age"],
+        analysis_df.loc[has_u, "understood"],
+        n_trials=context.model_data.n_trials,
+        n_curves=1000,
+        x_label="Age (months)",
+        y_label="Words understood",
+        filename="prior_samples_u",
+        output_dir=context.reporting.output_dir,
+    )
+
+    # Prior samples for spoken trajectory
+    p_s_plot_samples = (
+        prior_samples.prior["p_s_plot"]
+        .stack(sample=("chain", "draw"))
+        .transpose("plot_id", "sample")
+    )
+
+    plotting.plot_prior_samples(
+        prior_samples.constant_data["X_plot"].values,
+        p_s_plot_samples.values,
+        analysis_df.loc[has_s, "age"],
+        analysis_df.loc[has_s, "spoken"],
+        n_trials=context.model_data.n_trials,
+        n_curves=1000,
+        x_label="Age (months)",
+        y_label="Words spoken",
+        filename="prior_samples_s",
+        output_dir=context.reporting.output_dir,
+    )
+
+    # Prior samples for production rate q(a)
+    q_plot_samples = (
+        prior_samples.prior["q_plot"]
+        .stack(sample=("chain", "draw"))
+        .transpose("plot_id", "sample")
+    )
+
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+    X_plot_vals = prior_samples.constant_data["X_plot"].values
+    n_curves = min(500, q_plot_samples.shape[1])
+    for i in range(n_curves):
+        ax.plot(X_plot_vals, q_plot_samples.values[:, i], alpha=0.01, color="C2")
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel("q(a) = P(speaks | understands)")
+    ax.set_ylim(0, 1)
+    ax.set_title("Prior samples: production-given-comprehension rate")
+    fig.savefig(
+        os.path.join(context.reporting.output_dir, "prior_samples_q.png"), dpi=300
+    )
+    fig.savefig(
+        os.path.join(context.reporting.output_dir, "prior_samples_q.svg")
+    )
+    context.plots["prior_samples_q"] = fig
+    plt.close()
+
+
+def sample(context: ModelFitContext):
+    """Draw samples from the posterior using MCMC."""
+    print(
+        "\n[green]------------------------------------------------------------[/green]"
+    )
+    print("[bold green]Posterior sampling[/bold green]")
+    print("[green]------------------------------------------------------------[/green]")
+    print()
+
+    print(context.sampling)
+    print()
+
+    with context.model:
+        trace = pm.sample(
+            context.sampling.draws,
+            tune=context.sampling.tune,
+            chains=context.sampling.chains,
+            cores=context.sampling.cores,
+            target_accept=context.sampling.target_accept,
+            nuts_sampler="nutpie",
+            return_inferencedata=True,
+            random_seed=context.sampling.random_seed,
+        )
+
+    context.set_trace(trace)
+
+    print()
+    print("[bold green]Posterior sampling completed.[/bold green]")
+
+
+def diagnostics(context: ModelFitContext):
+    """Run diagnostics on the posterior samples."""
+    print(
+        "\n[green]------------------------------------------------------------[/green]"
+    )
+    print("[bold green]Diagnostics[/bold green]")
+    print("[green]------------------------------------------------------------[/green]")
+    print()
+
+    var_names = [
+        var.name for var in context.model.unobserved_RVs if var.size.eval() <= 2
+    ]
+    diagnostics_df = az.summary(
+        context.trace, var_names=var_names, round_to=3, hdi_prob=context.reporting.hdi
+    )
+
+    diagnostics_df.to_csv(
+        os.path.join(context.reporting.output_dir, "diagnostics.csv"), index=True
+    )
+
+    pprint(diagnostics_df)
+
+    # KDE pair plot
+    plot_diagnostics_mcmc.plot_kde_pair(
+        context.trace,
+        var_names=var_names,
+        output_dir=context.reporting.output_dir,
+        filename="pair_plot",
+    )
+    context.plots["pair_plot"] = plt.gcf()
+    plt.close()
+
+    # Trace plot
+    var_names_ext = var_names + ["kappa_u_obs", "kappa_s_obs"]
+
+    az.plot_trace(
+        context.trace,
+        combined=True,
+        var_names=var_names_ext,
+    )
+    plt.savefig(os.path.join(context.reporting.output_dir, "trace_plot.png"), dpi=300)
+    context.plots["trace_plot"] = plt.gcf()
+    plt.close()
+
+    # Energy plot
+    az.plot_energy(context.trace, figsize=plot_styles.FIGSIZE_SM)
+    plt.savefig(os.path.join(context.reporting.output_dir, "energy_plot.png"), dpi=300)
+    context.plots["energy_plot"] = plt.gcf()
+    plt.close()
+
+    # Posterior densities
+    az.plot_posterior(
+        context.trace.posterior,
+        var_names=var_names,
+        point_estimate="median",
+        hdi_prob=context.reporting.hdi,
+    )
+    plt.savefig(
+        os.path.join(context.reporting.output_dir, "posterior_plot.png"), dpi=300
+    )
+    context.plots["posterior_plot"] = plt.gcf()
+    plt.close()
+
+    # LOO-CV
+    with context.model:
+        trace = pm.compute_log_likelihood(context.trace)
+
+    context.set_trace(trace)
+
+    loocv = az.loo(context.trace)
+    context.set_loocv(loocv)
+    print(loocv)
+
+
+def sample_posterior_predictive(context: ModelFitContext):
+    """Sample from the posterior predictive distribution."""
+    print(
+        "\n[green]------------------------------------------------------------[/green]"
+    )
+    print("[bold green]Posterior predictions[/bold green]")
+    print("[green]------------------------------------------------------------[/green]")
+    print()
+
+    n_trials = context.model_data.n_trials
+
+    p_u_plot = context.model_variables["p_u_plot"]
+    p_u_query = context.model_variables["p_u_query"]
+    kappa_u_plot = context.model_variables["kappa_u_plot"]
+    kappa_u_query = context.model_variables["kappa_u_query"]
+
+    p_s_plot = context.model_variables["p_s_plot"]
+    p_s_query = context.model_variables["p_s_query"]
+    kappa_s_plot = context.model_variables["kappa_s_plot"]
+    kappa_s_query = context.model_variables["kappa_s_query"]
+
+    with context.model:
+        # Understood — plot
+        p_u_plot_clip = pm.math.clip(p_u_plot, EPSILON, 1 - EPSILON)
+        pm.BetaBinomial(
+            "y_u_plot",
+            n=n_trials,
+            alpha=p_u_plot_clip * kappa_u_plot,
+            beta=(1 - p_u_plot_clip) * kappa_u_plot,
+            dims=("plot_id",),
+        )
+        # Understood — query
+        p_u_query_clip = pm.math.clip(p_u_query, EPSILON, 1 - EPSILON)
+        pm.BetaBinomial(
+            "y_u_query",
+            n=n_trials,
+            alpha=p_u_query_clip * kappa_u_query,
+            beta=(1 - p_u_query_clip) * kappa_u_query,
+            dims=("query_id",),
+        )
+        # Spoken — plot
+        p_s_plot_clip = pm.math.clip(p_s_plot, EPSILON, 1 - EPSILON)
+        pm.BetaBinomial(
+            "y_s_plot",
+            n=n_trials,
+            alpha=p_s_plot_clip * kappa_s_plot,
+            beta=(1 - p_s_plot_clip) * kappa_s_plot,
+            dims=("plot_id",),
+        )
+        # Spoken — query
+        p_s_query_clip = pm.math.clip(p_s_query, EPSILON, 1 - EPSILON)
+        pm.BetaBinomial(
+            "y_s_query",
+            n=n_trials,
+            alpha=p_s_query_clip * kappa_s_query,
+            beta=(1 - p_s_query_clip) * kappa_s_query,
+            dims=("query_id",),
+        )
+
+        trace = pm.sample_posterior_predictive(
+            context.trace,
+            var_names=[
+                "y_u_plot", "y_u_query", "y_u_obs",
+                "y_s_plot", "y_s_query", "y_s_obs",
+            ],
+            extend_inferencedata=True,
+            random_seed=context.sampling.random_seed,
+        )
+
+    context.set_trace(trace)
+
+    trace.to_netcdf(os.path.join(context.reporting.output_dir, "trace.nc"))
+
+    sample_data = extract_model_samples(context.trace)
+    context.set_model_samples(sample_data)
+
+
+def posterior_summary(context: ModelFitContext):
+    """Compute and store the posterior summary tables at query ages."""
+    samples = context.model_samples
+    n_trials = context.model_data.n_trials
+    hdi_prob = context.reporting.hdi
+
+    # Understood summary
+    summary_u = posterior_analysis.posterior_summary_table(
+        samples.X_query,
+        samples.p_u_query,
+        samples.y_u_query,
+        n_trials=n_trials,
+        hdi_prob=hdi_prob,
+    )
+    print("\n[bold green]Posterior summary — words understood[/bold green]")
+    pprint(summary_u)
+    context.dataframes["posterior_summary_u"] = summary_u
+    summary_u.to_csv(
+        os.path.join(context.reporting.output_dir, "posterior_summary_u.csv"),
+        index=False,
+    )
+
+    # Spoken summary
+    summary_s = posterior_analysis.posterior_summary_table(
+        samples.X_query,
+        samples.p_s_query,
+        samples.y_s_query,
+        n_trials=n_trials,
+        hdi_prob=hdi_prob,
+    )
+    print("\n[bold green]Posterior summary — words spoken[/bold green]")
+    pprint(summary_s)
+    context.dataframes["posterior_summary_s"] = summary_s
+    summary_s.to_csv(
+        os.path.join(context.reporting.output_dir, "posterior_summary_s.csv"),
+        index=False,
+    )
+
+    # Production rate summary
+    q_query_median = np.median(samples.q_query, axis=1)
+    q_query_hdi = az.hdi(samples.q_query, hdi_prob=hdi_prob)
+
+    summary_q = pd.DataFrame(
+        {
+            "age_months": samples.X_query,
+            "q_median": q_query_median,
+            "q_hdi_lo": q_query_hdi[:, 0],
+            "q_hdi_hi": q_query_hdi[:, 1],
+        }
+    )
+    print("\n[bold green]Posterior summary — production rate q(a)[/bold green]")
+    pprint(summary_q)
+    context.dataframes["posterior_summary_q"] = summary_q
+    summary_q.to_csv(
+        os.path.join(context.reporting.output_dir, "posterior_summary_q.csv"),
+        index=False,
+    )
+
+
+# ============================================================
+# VG05-specific plotting functions
+# ============================================================
+
+
+def plot_joint_trajectory(
+    samples: BivariateModelSamples,
+    n_trials: int,
+    output_dir: str | None = None,
+    filename: str | None = None,
+):
+    """Plot both understood and spoken posterior predictive median trends on one figure."""
+    X_plot = samples.X_plot
+
+    # Understood
+    y_u_median = np.quantile(samples.y_u_plot, 0.50, axis=1)
+    y_u_90 = np.quantile(samples.y_u_plot, [0.05, 0.95], axis=1).T
+    y_u_50 = np.quantile(samples.y_u_plot, [0.25, 0.75], axis=1).T
+
+    # Spoken
+    y_s_median = np.quantile(samples.y_s_plot, 0.50, axis=1)
+    y_s_90 = np.quantile(samples.y_s_plot, [0.05, 0.95], axis=1).T
+    y_s_50 = np.quantile(samples.y_s_plot, [0.25, 0.75], axis=1).T
+
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+
+    # Understood bands
+    ax.fill_between(X_plot, y_u_90[:, 0], y_u_90[:, 1], alpha=0.15, color="C0")
+    ax.fill_between(X_plot, y_u_50[:, 0], y_u_50[:, 1], alpha=0.25, color="C0")
+    ax.plot(X_plot, y_u_median, lw=3, color="C0", label="Words understood (median)")
+
+    # Spoken bands
+    ax.fill_between(X_plot, y_s_90[:, 0], y_s_90[:, 1], alpha=0.15, color="C1")
+    ax.fill_between(X_plot, y_s_50[:, 0], y_s_50[:, 1], alpha=0.25, color="C1")
+    ax.plot(X_plot, y_s_median, lw=3, color="C1", label="Words spoken (median)")
+
+    # Observed data
+    X_obs = samples.X_obs
+    if samples.obs_u_mask.any():
+        obs_u_ages = X_obs[samples.obs_u_mask]
+        ax.scatter(obs_u_ages, samples.y_u_obs, s=10, alpha=0.2, color="C0")
+    if samples.obs_s_mask.any():
+        obs_s_ages = X_obs[samples.obs_s_mask]
+        ax.scatter(obs_s_ages, samples.y_s_obs, s=10, alpha=0.2, color="C1")
+
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel("Word count")
+    ax.legend(loc="upper left", frameon=True)
+    ax.set_ylim(-20, n_trials + 50)
+
+    if output_dir is not None and filename is not None:
+        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
+        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
+
+    return fig
+
+
+def plot_production_rate(
+    samples: BivariateModelSamples,
+    hdi_prob: float = 0.90,
+    output_dir: str | None = None,
+    filename: str | None = None,
+):
+    """Plot the posterior of q(a) = P(speaks | understands) over age."""
+    X_plot = samples.X_plot
+    q_plot = samples.q_plot
+
+    q_median = np.median(q_plot, axis=1)
+    q_hdi = az.hdi(q_plot, hdi_prob=hdi_prob)
+    q_hdi_75 = az.hdi(q_plot, hdi_prob=0.75)
+    q_hdi_50 = az.hdi(q_plot, hdi_prob=0.50)
+
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+
+    ax.fill_between(
+        X_plot, q_hdi[:, 0], q_hdi[:, 1],
+        alpha=0.20, label=f"{int(hdi_prob * 100)}% HDI",
+    )
+    ax.fill_between(
+        X_plot, q_hdi_75[:, 0], q_hdi_75[:, 1],
+        alpha=0.25, label="75% HDI",
+    )
+    ax.fill_between(
+        X_plot, q_hdi_50[:, 0], q_hdi_50[:, 1],
+        alpha=0.30, label="50% HDI",
+    )
+    ax.plot(X_plot, q_median, lw=3, label="Median q(a)")
+
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel("q(a) = P(speaks | understands)")
+    ax.set_ylim(0, 1)
+    ax.legend(loc="upper left", frameon=True)
+    ax.set_title("Production-given-comprehension rate")
+
+    if output_dir is not None and filename is not None:
+        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
+        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
+
+    return fig
+
+
+def plot_comprehension_production_gap(
+    samples: BivariateModelSamples,
+    n_trials: int,
+    hdi_prob: float = 0.90,
+    output_dir: str | None = None,
+    filename: str | None = None,
+):
+    """Plot the posterior of the comprehension-production gap (p_U - p_S) over age."""
+    X_plot = samples.X_plot
+    gap = (samples.p_u_plot - samples.p_s_plot) * n_trials  # in word count units
+
+    gap_median = np.median(gap, axis=1)
+    gap_hdi = az.hdi(gap, hdi_prob=hdi_prob)
+    gap_hdi_50 = az.hdi(gap, hdi_prob=0.50)
+
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+
+    ax.fill_between(
+        X_plot, gap_hdi[:, 0], gap_hdi[:, 1],
+        alpha=0.20, label=f"{int(hdi_prob * 100)}% HDI",
+    )
+    ax.fill_between(
+        X_plot, gap_hdi_50[:, 0], gap_hdi_50[:, 1],
+        alpha=0.30, label="50% HDI",
+    )
+    ax.plot(X_plot, gap_median, lw=3, label="Median gap")
+
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel("E[understood] - E[spoken] (words)")
+    ax.legend(loc="upper left", frameon=True)
+    ax.set_title("Comprehension-production gap")
+
+    if output_dir is not None and filename is not None:
+        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
+        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
+
+    return fig
+
+
+# ============================================================
+# Report
+# ============================================================
+
+
+def report(context: ModelFitContext):
+    """Copy output artefacts to the report directory."""
+
+    REPORT_OUTPUT_DIR = os.path.join(
+        local_env.REPORT_FIGS_DIR, context.reporting.model_label
+    )
+
+    if os.path.exists(REPORT_OUTPUT_DIR):
+        shutil.rmtree(REPORT_OUTPUT_DIR)
+
+    os.makedirs(REPORT_OUTPUT_DIR, exist_ok=True)
+
+    print()
+    print(f"Output: {context.reporting.output_dir}")
+    print(f"Report output: {REPORT_OUTPUT_DIR}")
+
+    for filename in os.listdir(context.reporting.output_dir):
+        if not (
+            filename.endswith(".png")
+            or filename.endswith(".svg")
+            or filename.endswith(".csv")
+        ):
+            continue
+        source_file = os.path.join(context.reporting.output_dir, filename)
+        dest_file = os.path.join(REPORT_OUTPUT_DIR, filename)
+        shutil.copy(source_file, dest_file)
+
+    model_output_md_source = os.path.join(
+        local_env.DOCS_DIR, "models", context.reporting.model_name.lower(), "index.qmd"
+    )
+
+    model_output_md_dest = os.path.join(context.reporting.output_dir, "index.qmd")
+
+    if os.path.exists(model_output_md_source):
+        shutil.copy(model_output_md_source, model_output_md_dest)
+    else:
+        raise FileNotFoundError(
+            f"Source model output markdown file not found: {model_output_md_source}"
+        )
+
+    print(f"[bold green]Report written to: {model_output_md_dest}[/bold green]")
+    print(
+        f"\n[bold yellow]To render, execute:[/bold yellow] [blue]quarto render {model_output_md_dest}[/blue]"
+    )
+    print(
+        f"\n[bold yellow]For live preview (editing), execute:[/bold yellow] [blue]quarto preview {model_output_md_dest}[/blue]"
+    )
+
+
+# ============================================================
+# Fit orchestration
+# ============================================================
+
+
+def fit(config: str) -> ModelFitContext:
+    print(
+        "\n[green]============================================================[/green]"
+    )
+    print(
+        "[bold green]Fitting Model VG05: Joint model of words understood and spoken"
+        " (A → U, A → S, U → S)[/bold green]"
+    )
+    print("[green]============================================================[/green]")
+    print()
+
+    env_info.report_environment_info()
+
+    package_list = [
+        "arviz",
+        "matplotlib",
+        "numba",
+        "numpy",
+        "numpyro",
+        "pandas",
+        "pymc",
+        "pytensor",
+    ]
+
+    print()
+    package_metadata.report_package_versions(package_list)
+
+    context = ModelFitContext(
+        reporting=reporting.ReportingConfiguration(
+            model_name="VG05",
+            config_name="age-understood-spoken-ds",
+            output_root_dir=local_env.OUTPUT_DIR,
+            hdi=0.90,
+        ),
+        sampling=sampling.get_sampling_configuration(config),
+    )
+
+    if os.path.exists(context.reporting.output_dir):
+        shutil.rmtree(context.reporting.output_dir)
+
+    os.makedirs(context.reporting.output_dir, exist_ok=True)
+
+    prepare_data(context)
+
+    configure_model(context)
+
+    build_model(context)
+
+    prior_predictive_checks(context)
+
+    sample(context)
+
+    diagnostics(context)
+
+    sample_posterior_predictive(context)
+
+    posterior_summary(context)
+
+    samples = context.model_samples
+    analysis_df = context.analysis_df
+    has_u = analysis_df["understood"].notna()
+    has_s = analysis_df["spoken"].notna()
+
+    # ---- Joint trajectory plot ----
+
+    plot_joint_trajectory(
+        samples,
+        n_trials=context.model_data.n_trials,
+        output_dir=context.reporting.output_dir,
+        filename="joint_trajectory",
+    )
+
+    # ---- Production rate q(a) ----
+
+    plot_production_rate(
+        samples,
+        hdi_prob=context.reporting.hdi,
+        output_dir=context.reporting.output_dir,
+        filename="production_rate",
+    )
+
+    # ---- Comprehension-production gap ----
+
+    plot_comprehension_production_gap(
+        samples,
+        n_trials=context.model_data.n_trials,
+        hdi_prob=context.reporting.hdi,
+        output_dir=context.reporting.output_dir,
+        filename="comprehension_production_gap",
+    )
+
+    # ---- Per-outcome plots: understood ----
+
+    plotting.plot_posterior_predictive_count_distributions_by_query_age(
+        X_query=samples.X_query,
+        y_query=samples.y_u_query,
+        n_trials=context.model_data.n_trials,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_count_distributions_u",
+    )
+
+    plotting.plot_posterior_predictive_pmf(
+        samples.X_query, samples.X_plot, samples.y_u_plot,
+        context.model_data.n_trials,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_pmf_u",
+        x_label="Words understood (count)",
+    )
+
+    plotting.plot_posterior_predictive_cdf(
+        samples.X_query, samples.X_plot, samples.y_u_plot,
+        context.model_data.n_trials,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_cdf_u",
+        x_label="Words understood (count)",
+    )
+
+    plotting.plot_posterior_predictive_median_trend(
+        samples.X_plot, samples.y_u_plot,
+        analysis_df.loc[has_u, "age"], analysis_df.loc[has_u, "understood"],
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_median_trend_u",
+        y_label="Predicted words understood",
+    )
+
+    plotting.plot_posterior_predictive_median_trend(
+        samples.X_plot, samples.y_u_plot,
+        analysis_df.loc[has_u, "age"], analysis_df.loc[has_u, "understood"],
+        smooth=True, savgol_window_length=15, savgol_polyorder=3, smooth_intervals=True,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_median_trend_u_smoothed",
+        y_label="Predicted words understood",
+    )
+
+    plotting.plot_expected_learning_rate(
+        samples.X_plot, samples.f_u_plot,
+        n_trials=context.model_data.n_trials,
+        hdi_prob=context.reporting.hdi,
+        output_dir=context.reporting.output_dir,
+        filename="expected_learning_rate_u",
+        y_label="Estimated understood word gain per month",
+    )
+
+    plotting.plot_expected_learning_rate(
+        samples.X_plot, samples.f_u_plot,
+        n_trials=context.model_data.n_trials,
+        hdi_prob=context.reporting.hdi,
+        smooth=True, savgol_window_length=15, savgol_polyorder=3, smooth_intervals=True,
+        output_dir=context.reporting.output_dir,
+        filename="expected_learning_rate_u_smoothed",
+        y_label="Estimated understood word gain per month",
+    )
+
+    plotting.plot_posterior_kappa(
+        samples.X_plot, samples.kappa_u_plot,
+        samples.X_query, samples.kappa_u_query,
+        n_trials=context.model_data.n_trials,
+        hdi_prob=context.reporting.hdi,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_kappa_u",
+    )
+
+    # ---- Per-outcome plots: spoken ----
+
+    plotting.plot_posterior_predictive_count_distributions_by_query_age(
+        X_query=samples.X_query,
+        y_query=samples.y_s_query,
+        n_trials=context.model_data.n_trials,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_count_distributions_s",
+    )
+
+    plotting.plot_posterior_predictive_pmf(
+        samples.X_query, samples.X_plot, samples.y_s_plot,
+        context.model_data.n_trials,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_pmf_s",
+        x_label="Words spoken (count)",
+    )
+
+    plotting.plot_posterior_predictive_cdf(
+        samples.X_query, samples.X_plot, samples.y_s_plot,
+        context.model_data.n_trials,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_cdf_s",
+        x_label="Words spoken (count)",
+    )
+
+    plotting.plot_posterior_predictive_median_trend(
+        samples.X_plot, samples.y_s_plot,
+        analysis_df.loc[has_s, "age"], analysis_df.loc[has_s, "spoken"],
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_median_trend_s",
+        y_label="Predicted words spoken",
+    )
+
+    plotting.plot_posterior_predictive_median_trend(
+        samples.X_plot, samples.y_s_plot,
+        analysis_df.loc[has_s, "age"], analysis_df.loc[has_s, "spoken"],
+        smooth=True, savgol_window_length=15, savgol_polyorder=3, smooth_intervals=True,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_predictive_median_trend_s_smoothed",
+        y_label="Predicted words spoken",
+    )
+
+    plotting.plot_expected_learning_rate(
+        samples.X_plot, samples.f_s_plot,
+        n_trials=context.model_data.n_trials,
+        hdi_prob=context.reporting.hdi,
+        output_dir=context.reporting.output_dir,
+        filename="expected_learning_rate_s",
+        y_label="Estimated spoken word gain per month",
+    )
+
+    plotting.plot_expected_learning_rate(
+        samples.X_plot, samples.f_s_plot,
+        n_trials=context.model_data.n_trials,
+        hdi_prob=context.reporting.hdi,
+        smooth=True, savgol_window_length=15, savgol_polyorder=3, smooth_intervals=True,
+        output_dir=context.reporting.output_dir,
+        filename="expected_learning_rate_s_smoothed",
+        y_label="Estimated spoken word gain per month",
+    )
+
+    plotting.plot_posterior_kappa(
+        samples.X_plot, samples.kappa_s_plot,
+        samples.X_query, samples.kappa_s_query,
+        n_trials=context.model_data.n_trials,
+        hdi_prob=context.reporting.hdi,
+        output_dir=context.reporting.output_dir,
+        filename="posterior_kappa_s",
+    )
+
+    report(context)
+
+    return context

--- a/src/vocab_growth/models/model_vg05.py
+++ b/src/vocab_growth/models/model_vg05.py
@@ -1542,6 +1542,7 @@ def fit(config: str) -> Vg05Context:
         n_trials=context.model_data.n_trials,
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_count_distributions_u",
+        x_label="Words understood (count)",
     )
 
     plotting.plot_posterior_predictive_pmf(

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -221,7 +221,9 @@ def plot_posterior_predictive_pmf(
     n_trials: int,
     log_scale: bool = False,
     output_dir: str | None = None,
-    filename: str | None = None) -> Figure:
+    filename: str | None = None,
+    x_label: str = "Words spoken (count)",
+) -> Figure:
     """
     For each query age, plot the posterior predictive distribution of counts as a PMF on a common support.
     """
@@ -252,7 +254,7 @@ def plot_posterior_predictive_pmf(
         # Step line (discrete PMF)
         plt.step(k, pmf, where="mid", lw=2, label=f"{X_plot[j]:.0f}m")
 
-    plt.xlabel("Words spoken (count)")
+    plt.xlabel(x_label)
     plt.ylabel("Posterior predictive probability")
     plt.title("Posterior predictive PMF at selected ages")
     plt.xlim(x_lo, x_hi)
@@ -276,7 +278,9 @@ def plot_posterior_predictive_cdf(
     y_plot: np.ndarray,
     n_trials: int,
     output_dir: str | None = None,
-    filename: str | None = None) -> Figure:
+    filename: str | None = None,
+    x_label: str = "Words spoken (count)",
+) -> Figure:
     draws_by_age = []
     plot_idx_by_age = []
 
@@ -301,7 +305,7 @@ def plot_posterior_predictive_cdf(
         cdf = np.searchsorted(draws_sorted, k, side="right") / draws_sorted.size
         plt.step(k, cdf, where="post", lw=2, label=f"{X_plot[j]:.0f}m")
 
-    plt.xlabel("Words spoken (count)")
+    plt.xlabel(x_label)
     plt.ylabel("Posterior predictive CDF  P(Y ≤ k)")
     plt.title("Posterior predictive CDFs at selected ages")
     plt.xlim(x_lo, x_hi)
@@ -400,6 +404,7 @@ def plot_posterior_predictive_median_trend(
     smooth_intervals: bool = True,
     output_dir: str | None = None,
     filename: str | None = None,
+    y_label: str = "Predicted spoken words",
 ):
     """
     Plot the posterior predictive distribution of counts as a function of age,
@@ -429,6 +434,8 @@ def plot_posterior_predictive_median_trend(
     smooth_intervals
         If True, smooth interval bounds as well as the median curve.
         If False, smooth only the median.
+    y_label
+        Label for the y-axis.
     """
     X_plot = np.asarray(X_plot).reshape(-1)
     y_plot = np.asarray(y_plot)
@@ -549,7 +556,7 @@ def plot_posterior_predictive_median_trend(
     )
 
     plt.xlabel("Age (months)")
-    plt.ylabel("Predicted spoken words")
+    plt.ylabel(y_label)
     plt.legend(loc="upper left", frameon=True)
     plt.ylim(-20, np.max(y_plot) + 50)
 
@@ -571,6 +578,7 @@ def plot_expected_learning_rate(
     savgol_window_length: int | None = None,
     savgol_polyorder: int = 3,
     smooth_intervals: bool = True,
+    y_label: str = "Estimated word score gain per month",
 ):
     """
     Plot the posterior distribution of the estimated learning rate
@@ -608,6 +616,8 @@ def plot_expected_learning_rate(
     smooth_intervals
         If True, smooth HDI bounds as well as the median curve.
         If False, smooth only the median.
+    y_label
+        Label for the y-axis.
 
     Returns
     -------
@@ -739,7 +749,7 @@ def plot_expected_learning_rate(
     )
 
     plt.xlabel("Age (months)")
-    plt.ylabel("Estimated word score gain per month")
+    plt.ylabel(y_label)
     plt.legend(loc="upper left", frameon=True)
 
     if filename is not None and output_dir is not None:

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -222,7 +222,7 @@ def plot_posterior_predictive_pmf(
     log_scale: bool = False,
     output_dir: str | None = None,
     filename: str | None = None,
-    x_label: str = "Words spoken (count)",
+    x_label: str = "Word count",
 ) -> Figure:
     """
     For each query age, plot the posterior predictive distribution of counts as a PMF on a common support.

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -404,7 +404,7 @@ def plot_posterior_predictive_median_trend(
     smooth_intervals: bool = True,
     output_dir: str | None = None,
     filename: str | None = None,
-    y_label: str = "Predicted spoken words",
+    y_label: str = "Predicted word count",
 ):
     """
     Plot the posterior predictive distribution of counts as a function of age,

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -1,17 +1,26 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import mimetypes
 import os
 import uuid
 from urllib.parse import urlparse
 
 from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import BlobServiceClient, ContentSettings
 from rich import print
 
 
-def upload_to_blob_storage(output_dir: str, model_label: str) -> None:
-    """Upload model output directory to Azure Blob Storage."""
+def upload_to_blob_storage(
+    output_dir: str, model_label: str, *, include_traces: bool = False
+) -> None:
+    """Upload model output directory to Azure Blob Storage.
+
+    Parameters
+    ----------
+    include_traces : bool
+        If True, include NetCDF trace files (.nc). Excluded by default due to size.
+    """
     container_url = os.environ.get("DSERESEARCH_BLOB_CONTAINER_URL")
     if not container_url:
         print(
@@ -41,14 +50,30 @@ def upload_to_blob_storage(output_dir: str, model_label: str) -> None:
     container_client = blob_service_client.get_container_client(container_name)
 
     uploaded = 0
+    skipped = 0
     for root, _dirs, files in os.walk(output_dir):
         for filename in files:
+            if not include_traces and filename.endswith(".nc"):
+                skipped += 1
+                continue
+
             local_path = os.path.join(root, filename)
             relative_path = os.path.relpath(local_path, output_dir).replace("\\", "/")
             blob_name = f"{blob_prefix}/{relative_path}"
 
+            content_type, _ = mimetypes.guess_type(filename)
+            if content_type is None:
+                content_type = "application/octet-stream"
+
             with open(local_path, "rb") as f:
-                container_client.upload_blob(blob_name, f, overwrite=True)
+                container_client.upload_blob(
+                    blob_name,
+                    f,
+                    overwrite=True,
+                    content_settings=ContentSettings(content_type=content_type),
+                )
             uploaded += 1
 
+    if skipped:
+        print(f"[yellow]Skipped {skipped} trace file(s) (.nc)[/yellow]")
     print(f"[bold green]Upload complete: {model_label} ({uploaded} files)[/bold green]")


### PR DESCRIPTION
## Summary
- Add model VG05, a joint bivariate model of words understood and spoken for children with Down syndrome, using a production-ratio reparameterization (`p_S = p_U × q`) that enforces `p_S ≤ p_U` by construction
- Refactor `ModelFitContext` in `common.py` to support generic configuration and samples types (`BaseModelConfiguration`, `BivariateModelConfiguration`, `BivariateModelSamples`)
- Add `Vg05Context` type alias for strongly-typed access to model config and samples throughout VG05
- Update `upload.py` and `fit_model.py` to support VG05
- Fix blob upload content types (was defaulting to `application/octet-stream` for all files)
- Exclude large trace files (`.nc`) from uploads by default; add `--include-traces` flag to opt in

## Test plan
- [ ] Run `python scripts/fit_model.py vg05 --config dev` to verify model fits
- [ ] Run `python scripts/upload.py vg05` and verify correct content types in blob storage
- [ ] Run `ruff check src/ scripts/` to verify no lint issues
- [ ] Verify `--include-traces` flag includes `.nc` files when specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)