### PR TITLE
Add shared rich-based reporting helpers for fit pipelines

### DIFF
--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -7,10 +7,11 @@ Fits the specified model to the latest data. Saves plots and data, and report to
 import argparse
 import os
 import subprocess
+import sys
+import time
 from multiprocessing import freeze_support
 
 import dse_research_utils.environment.setup as setup
-from rich import print
 
 from vocab_growth.models import (
     model_vg01,
@@ -20,6 +21,13 @@ from vocab_growth.models import (
     model_vg05,
     model_vg06,
     model_vg07,
+)
+from vocab_growth.reporting import (
+    console,
+    format_duration,
+    heading,
+    key_value_table,
+    pipeline_summary,
 )
 from vocab_growth.storage import upload_to_blob_storage
 
@@ -65,19 +73,36 @@ if __name__ == "__main__":
     }
 
     if args.model == "all":
-        to_fit = list(models.values())
+        selected = list(models.items())
     elif args.model in models:
-        to_fit = [models[args.model]]
+        selected = [(args.model, models[args.model])]
     else:
-        print(f"Unknown model: {args.model}")
-        exit(1)
+        console.print(f"[bold red]Unknown model: {args.model}[/bold red]")
+        sys.exit(1)
 
-    contexts = [m.fit(args.config) for m in to_fit]
+    key_value_table(
+        "Run plan",
+        [
+            ("Models to fit", ", ".join(name for name, _ in selected)),
+            ("Sampling config", args.config),
+            ("Render Quarto", args.render),
+            ("Upload to blob storage", args.upload),
+            ("Include traces in upload", args.include_traces),
+        ],
+    )
+
+    run_started = time.perf_counter()
+    per_model_timings: dict[str, float] = {}
+    contexts = []
+    for name, module in selected:
+        model_started = time.perf_counter()
+        contexts.append(module.fit(args.config))
+        per_model_timings[name] = time.perf_counter() - model_started
 
     if args.render:
         for context in contexts:
             qmd_path = os.path.join(context.reporting.output_dir, "index.qmd")
-            print(f"\n[bold green]Rendering Quarto output: {qmd_path}[/bold green]")
+            heading(f"Rendering Quarto output: {qmd_path}")
             subprocess.run(["quarto", "render", qmd_path], check=True)
 
     if args.upload:
@@ -87,3 +112,10 @@ if __name__ == "__main__":
                 context.reporting.model_label,
                 include_traces=args.include_traces,
             )
+
+    if len(selected) > 1:
+        pipeline_summary("Run summary — all models", per_model_timings)
+    console.print(
+        f"[dim]Total run wall time: "
+        f"{format_duration(time.perf_counter() - run_started)}[/dim]"
+    )

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -4,23 +4,49 @@
 # run from repository root with `python scripts/prepare_data.py`
 
 import os
+import time
 
 import duckdb
 import pandas as pd
-from rich import print
 
-print("Preparing data...")
+from vocab_growth.reporting import (
+    console,
+    format_duration,
+    heading,
+    key_value_table,
+)
 
-# Load the datasets
-vocab_ie_01_df = pd.read_csv("./data/vocab_data_ie_01.csv")
-vocab_it_01_df = pd.read_csv("./data/vocab_data_it_01.csv")
-vocab_uk_01_df = pd.read_csv("./data/vocab_data_uk_01.csv")
-vocab_uk_02_df = pd.read_csv("./data/vocab_data_uk_02.csv")
-vocab_uk_03_df = pd.read_csv("./data/vocab_data_uk_03.csv")
-vocab_uk_04_df = pd.read_csv("./data/vocab_data_uk_04.csv")
-vocab_uk_05_df = pd.read_csv("./data/vocab_data_uk_05.csv")
-vocab_us_02_df = pd.read_csv("./data/vocab_data_us_02.csv")
-vocab_uk_06_df = pd.read_csv("./data/vocab_data_uk_06.csv")
+_started = time.perf_counter()
+heading("Preparing vocabulary data")
+
+_sources = {
+    "vocab_ie_01": "./data/vocab_data_ie_01.csv",
+    "vocab_it_01": "./data/vocab_data_it_01.csv",
+    "vocab_uk_01": "./data/vocab_data_uk_01.csv",
+    "vocab_uk_02": "./data/vocab_data_uk_02.csv",
+    "vocab_uk_03": "./data/vocab_data_uk_03.csv",
+    "vocab_uk_04": "./data/vocab_data_uk_04.csv",
+    "vocab_uk_05": "./data/vocab_data_uk_05.csv",
+    "vocab_us_02": "./data/vocab_data_us_02.csv",
+    "vocab_uk_06": "./data/vocab_data_uk_06.csv",
+}
+_loaded = {name: pd.read_csv(path) for name, path in _sources.items()}
+
+key_value_table(
+    "Loaded datasets",
+    [(name, f"{len(df):,} rows × {len(df.columns)} cols") for name, df in _loaded.items()],
+    value_header="Shape",
+)
+
+vocab_ie_01_df = _loaded["vocab_ie_01"]
+vocab_it_01_df = _loaded["vocab_it_01"]
+vocab_uk_01_df = _loaded["vocab_uk_01"]
+vocab_uk_02_df = _loaded["vocab_uk_02"]
+vocab_uk_03_df = _loaded["vocab_uk_03"]
+vocab_uk_04_df = _loaded["vocab_uk_04"]
+vocab_uk_05_df = _loaded["vocab_uk_05"]
+vocab_us_02_df = _loaded["vocab_us_02"]
+vocab_uk_06_df = _loaded["vocab_uk_06"]
 
 # Prepare the data for merging
 vocab_to_merge = vocab_uk_01_df[["subject_id", "age", "understood", "spoken"]].copy()
@@ -103,11 +129,14 @@ merged_df = pd.concat(
     ignore_index=True,
 )
 
-print("Saving merged dataset to CSV...")
+console.print(
+    f"[green]Merged dataset:[/green] {len(merged_df):,} rows × {len(merged_df.columns)} cols"
+)
+console.print("[green]Saving merged dataset to CSV…[/green]")
 
 merged_df.to_csv("./data/vocab_data_merged.csv", index=False)
 
-print("Creating DuckDB database and tables...")
+console.print("[green]Creating DuckDB database and tables…[/green]")
 
 db_path = "./data/vocabulary.duckdb"
 
@@ -335,4 +364,12 @@ con.execute(
 
 con.close()
 
-print("Data preparation complete.")
+key_value_table(
+    "Data preparation complete",
+    [
+        ("Merged CSV", "./data/vocab_data_merged.csv"),
+        ("DuckDB database", db_path),
+        ("Total merged rows", f"{len(merged_df):,}"),
+        ("Elapsed", format_duration(time.perf_counter() - _started)),
+    ],
+)

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -7,6 +7,7 @@ Shared dataclasses and pipeline functions for the vocabulary growth model family
 
 import os
 import shutil
+import time
 from dataclasses import dataclass, field
 from typing import Generic, TypeVar
 
@@ -31,14 +32,23 @@ import pymc as pm
 from arviz import ELPDData, InferenceData
 from matplotlib.figure import Figure
 from preliz.distributions.distributions import Continuous
-from rich import print
-from rich.pretty import pprint
 
 import vocab_growth.data_utils as vocab_data_utils
 import vocab_growth.environment as local_env
 import vocab_growth.plotting as plotting
 import vocab_growth.posterior_analysis as posterior_analysis
+import vocab_growth.reporting as vg_reporting
 from vocab_growth.models.definitions import UnivariateModelDefinition
+from vocab_growth.reporting import (
+    config_table,
+    console,
+    dataframe_table,
+    heading,
+    key_value_table,
+    pipeline_summary,
+    run_banner,
+    section,
+)
 
 
 @dataclass
@@ -134,6 +144,7 @@ class ModelFitContext(Generic[C, S]):
     execution_context: str = field(default_factory=env_info.get_execution_context)
     plots: dict[str, Figure] = field(default_factory=dict)
     dataframes: dict[str, pd.DataFrame] = field(default_factory=dict)
+    timings: dict[str, float] = field(default_factory=dict)
     _model_data: model_data.BinomialModelData | None = None
     _analysis_df: pd.DataFrame | None = None
     _model_config: C | None = None
@@ -430,13 +441,6 @@ def build_model(context: ModelFitContext):
     """
     Builds vocabulary growth model.
     """
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Model definition and initialisation[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     n = len(context.model_data.y_obs)
 
     if context.model_data.X_obs.shape[0] != n:
@@ -446,25 +450,6 @@ def build_model(context: ModelFitContext):
     if not np.all(context.model_data.y_obs <= context.model_data.n_trials):
         raise ValueError("y_obs exceeds n_trials.")
 
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Building vocabulary growth model[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-
-    print(f"  Number of observations: {n}")
-    print(f"  Number of trials (n_trials): {context.model_data.n_trials}")
-    print(f"  Slope anchors (months): {context.model_config.slope_anchors}")
-    print(f"  Length-scale range (months): {context.model_config.ell_months_range}")
-    print(f"  Prior for p_slope_low: {context.model_config.p_slope_low_dist}")
-    print(f"  Prior for p_slope_hi: {context.model_config.p_slope_hi_dist}")
-    print(f"  Prior for ell_unit: {context.model_config.ell_unit_dist}")
-    print(f"  Prior for eta: {context.model_config.eta_dist}")
-    print(f"  Prior for kappa_min: {context.model_config.kappa_min_dist}")
-    print(f"  Prior for a_kappa: {context.model_config.a_kappa_dist}")
-    print(f"  Prior for b_kappa_mag: {context.model_config.b_kappa_mag_dist}")
-    print(f"  Number of plot points: {context.model_config.n_plot}")
-
     X_obs_median = float(np.median(context.model_data.X_obs))
     X_obs_mean = float(np.mean(context.model_data.X_obs))
     X_obs_std = float(np.std(context.model_data.X_obs, ddof=1))
@@ -472,8 +457,34 @@ def build_model(context: ModelFitContext):
     if not np.isfinite(X_obs_std) or X_obs_std <= 0:
         raise ValueError("Age standard deviation must be positive.")
 
-    print(
-        f"  Age (months) - median: {X_obs_median:.2f}, mean: {X_obs_mean:.2f}, std: {X_obs_std:.2f}"
+    key_value_table(
+        "Build configuration",
+        [
+            ("Number of observations", n),
+            ("Number of trials (n_trials)", context.model_data.n_trials),
+            ("Slope anchors (months)", context.model_config.slope_anchors),
+            ("Length-scale range (months)", context.model_config.ell_months_range),
+            ("Number of plot points", context.model_config.n_plot),
+            ("Query ages (months)", context.model_config.ages_query),
+            ("Age median (months)", X_obs_median),
+            ("Age mean (months)", X_obs_mean),
+            ("Age std (months)", X_obs_std),
+        ],
+    )
+
+    key_value_table(
+        "Priors",
+        [
+            ("p_slope_low", context.model_config.p_slope_low_dist),
+            ("p_slope_hi", context.model_config.p_slope_hi_dist),
+            ("ell_unit", context.model_config.ell_unit_dist),
+            ("eta", context.model_config.eta_dist),
+            ("kappa_min", context.model_config.kappa_min_dist),
+            ("a_kappa", context.model_config.a_kappa_dist),
+            ("b_kappa_mag", context.model_config.b_kappa_mag_dist),
+        ],
+        key_header="Parameter",
+        value_header="Distribution",
     )
 
     # Predictor standardised (z-score)
@@ -515,23 +526,24 @@ def build_model(context: ModelFitContext):
         ell_range_z,
     )
 
-    print(f"  HSGP basis size (m): {M}")
-    print(f"  HSGP L: {L}")
-
     slope_age_a = float(context.model_config.slope_anchors[0])
     slope_age_b = float(context.model_config.slope_anchors[1])
     slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
     slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
 
-    print(f"  Slope anchors (z-scores): {slope_age_a_z:.2f}, {slope_age_b_z:.2f}")
+    key_value_table(
+        "Derived quantities",
+        [
+            ("HSGP basis size (m)", M),
+            ("HSGP boundary factor (L)", L),
+            ("Slope anchors (z-score)", (slope_age_a_z, slope_age_b_z)),
+            ("Length-scale range (z-score)", (ell_low_z, ell_high_z)),
+        ],
+    )
 
     i_obs0, i_obs1 = 0, X_obs_z.shape[0]
     i_plot0, i_plot1 = i_obs1, i_obs1 + X_plot_z.shape[0]
     i_query0, i_query1 = i_plot1, i_plot1 + X_query_z.shape[0]
-
-    print(
-        f"  Query points: {', '.join(map(str, context.model_config.ages_query))} (months)"
-    )
 
     coords = {
         "all_id": np.arange(n_all),
@@ -692,13 +704,6 @@ def prior_predictive_checks(
     """
     Run prior predictive checks: sample from the prior, and visualise the implied prior predictive distribution.
     """
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Prior predictive checks[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     with context.model:
         prior_samples = pm.sample_prior_predictive(
             draws=1000,
@@ -757,15 +762,7 @@ def sample(context: ModelFitContext):
     """
     Draw samples from the posterior using MCMC.
     """
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Posterior sampling[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
-    print(context.sampling)
-    print()
+    config_table("Sampling configuration", context.sampling)
 
     with context.model:
         trace = pm.sample(
@@ -781,22 +778,11 @@ def sample(context: ModelFitContext):
 
     context.set_trace(trace)
 
-    print()
-    print()
-    print("[bold green]Posterior sampling completed.[/bold green]")
-
 
 def diagnostics(context: ModelFitContext):
     """
     Run diagnostics on the posterior samples, including convergence diagnostics and posterior predictive checks.
     """
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Diagnostics[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     # Summary diagnostic statistics
 
     var_names = [
@@ -810,7 +796,8 @@ def diagnostics(context: ModelFitContext):
         os.path.join(context.reporting.output_dir, "diagnostics.csv"), index=True
     )
 
-    pprint(diagnostics_df)
+    dataframe_table(diagnostics_df, title="Posterior diagnostics")
+    _report_diagnostic_warnings(diagnostics_df)
 
     # Kernel density estimates (KDE) of the joint posterior, and marginals
 
@@ -864,20 +851,14 @@ def diagnostics(context: ModelFitContext):
 
     loocv = az.loo(context.trace)
     context.set_loocv(loocv)
-    print(loocv)
+    heading("LOO-CV", style="bold cyan")
+    console.print(loocv)
 
 
 def sample_posterior_predictive(context: ModelFitContext):
     """
     Sample from the posterior predictive distribution.
     """
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Posterior predictions[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     p_plot = context.model_variables["p_plot"]
     p_query = context.model_variables["p_query"]
     kappa_plot = context.model_variables["kappa_plot"]
@@ -936,7 +917,11 @@ def posterior_summary(context: ModelFitContext):
         hdi_prob=context.reporting.hdi,
     )
 
-    pprint(posterior_summary_df)
+    dataframe_table(
+        posterior_summary_df,
+        title="Posterior summary at query ages",
+        show_index=False,
+    )
 
     context.dataframes["posterior_summary"] = posterior_summary_df
 
@@ -1047,10 +1032,7 @@ def report(context: ModelFitContext):
 
     os.makedirs(REPORT_OUTPUT_DIR, exist_ok=True)
 
-    print()
-    print(f"Output: {context.reporting.output_dir}")
-    print(f"Report output: {REPORT_OUTPUT_DIR}")
-
+    copied = 0
     for filename in os.listdir(context.reporting.output_dir):
         if not (
             filename.endswith(".png")
@@ -1061,6 +1043,7 @@ def report(context: ModelFitContext):
         source_file = os.path.join(context.reporting.output_dir, filename)
         dest_file = os.path.join(REPORT_OUTPUT_DIR, filename)
         shutil.copy(source_file, dest_file)
+        copied += 1
 
     model_output_md_source = os.path.join(
         local_env.DOCS_DIR, "models", context.reporting.model_name.lower(), "index.qmd"
@@ -1075,14 +1058,23 @@ def report(context: ModelFitContext):
             f"Source model output markdown file not found: {model_output_md_source}"
         )
 
-    print(f"[bold green]Report written to: {model_output_md_dest}[/bold green]")
-
-    print(
-        f"\n[bold yellow]To render, execute:[/bold yellow] [blue]quarto render {model_output_md_dest}[/blue]"
+    key_value_table(
+        "Artefacts",
+        [
+            ("Output directory", context.reporting.output_dir),
+            ("Report figures directory", REPORT_OUTPUT_DIR),
+            ("Figures / tables copied", copied),
+            ("Quarto document", model_output_md_dest),
+        ],
     )
 
-    print(
-        f"\n[bold yellow]For live preview (editing), execute:[/bold yellow] [blue]quarto preview {model_output_md_dest}[/blue]"
+    console.print(
+        f"\n[bold yellow]Render report:[/bold yellow]  "
+        f"[blue]quarto render {model_output_md_dest}[/blue]"
+    )
+    console.print(
+        f"[bold yellow]Live preview:[/bold yellow]   "
+        f"[blue]quarto preview {model_output_md_dest}[/blue]"
     )
 
 
@@ -1091,9 +1083,46 @@ def _plot_and_print_dist(context, dist, name):
     context.plots[name] = plot_dist.plot_distribution(
         dist, context.reporting.output_dir, name
     )
-    print(
-        f"[bold yellow]{name}:[/bold yellow] {dist.summary(mass=context.reporting.hdi)}"
-    )
+    summary = dist.summary(mass=context.reporting.hdi)
+    console.print(f"  [yellow]{name}[/yellow]: {summary}")
+
+
+_RHAT_WARN = 1.01
+_ESS_WARN = 400
+_DIAGNOSTIC_COLS = {"r_hat", "ess_bulk", "ess_tail"}
+
+
+def _report_diagnostic_warnings(diagnostics_df: pd.DataFrame) -> None:
+    """Flag MCMC convergence issues visible in the summary frame."""
+    cols = set(diagnostics_df.columns)
+    if not _DIAGNOSTIC_COLS.intersection(cols):
+        return
+
+    problems: list[str] = []
+    if "r_hat" in cols:
+        bad = diagnostics_df["r_hat"].dropna()
+        bad = bad[bad > _RHAT_WARN]
+        if len(bad):
+            problems.append(
+                f"{len(bad)} parameter(s) with r_hat > {_RHAT_WARN} (max {bad.max():.3f})"
+            )
+    for ess_col in ("ess_bulk", "ess_tail"):
+        if ess_col in cols:
+            bad = diagnostics_df[ess_col].dropna()
+            bad = bad[bad < _ESS_WARN]
+            if len(bad):
+                problems.append(
+                    f"{len(bad)} parameter(s) with {ess_col} < {_ESS_WARN} (min {bad.min():.0f})"
+                )
+
+    if problems:
+        console.print()
+        for line in problems:
+            console.print(f"[bold yellow]⚠ {line}[/bold yellow]")
+    else:
+        console.print(
+            "[green]✓ r_hat ≤ 1.01 and ESS ≥ 400 across reported parameters.[/green]"
+        )
 
 
 def prepare_univariate_data(
@@ -1101,13 +1130,6 @@ def prepare_univariate_data(
     definition: UnivariateModelDefinition,
 ):
     """Load and prepare data for a univariate model from its definition."""
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Prepare data[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     y_col = definition.outcome.value
     df = vocab_data_utils.load_data(
         population=definition.population,
@@ -1119,13 +1141,16 @@ def prepare_univariate_data(
 
     desc = descriptive_stats.describe_all(analysis_df, alpha=0.05)
 
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
+    key_value_table(
+        "Data",
+        [
+            ("Population", definition.population.name),
+            ("Outcome column", y_col),
+            ("Rows after NA drop", len(analysis_df)),
+            ("Sample fraction", definition.sample_fraction),
+        ],
     )
-    print("[bold green]Descriptive statistics[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-
-    pprint(desc)
+    dataframe_table(desc, title="Descriptive statistics")
 
     X_obs = np.asarray(analysis_df["age"], dtype=float).reshape(-1, 1)
     y_obs = np.asarray(analysis_df[y_col], dtype=int)
@@ -1148,13 +1173,6 @@ def configure_univariate_priors(
     definition: UnivariateModelDefinition,
 ):
     """Configure priors and hyperparameters from a univariate model definition."""
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Priors and hyperparameters[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     ell_unit_dist = pz.Beta(alpha=definition.ell_unit_alpha, beta=definition.ell_unit_beta)
     _plot_and_print_dist(context, ell_unit_dist, "ell_unit_dist")
 
@@ -1201,18 +1219,11 @@ def fit_single_outcome_model(
     """
     Shared fit pipeline for single-outcome models (VG01-VG04).
     """
-    print(
-        "\n[green]============================================================[/green]"
-    )
-    print(
-        f"[bold green]{definition.banner}[/bold green]"
-    )
-    print("[green]============================================================[/green]")
-    print()
+    run_banner(definition.banner, subtitle=f"sampling config: {config}")
 
     env_info.report_environment_info()
 
-    print()
+    console.print()
     package_metadata.report_package_versions(PACKAGE_LIST)
 
     context = ModelFitContext(
@@ -1230,27 +1241,50 @@ def fit_single_outcome_model(
 
     os.makedirs(context.reporting.output_dir, exist_ok=True)
 
-    prepare_univariate_data(context, definition)
-
-    configure_univariate_priors(context, definition)
-
-    build_model(context)
+    timings = context.timings
+    run_started = time.perf_counter()
 
     y_col = definition.outcome.value
     outcome_label = definition.outcome_label
 
-    prior_predictive_checks(context, outcome_col=y_col, outcome_label=outcome_label)
+    with section("Prepare data", timings=timings):
+        prepare_univariate_data(context, definition)
 
-    sample(context)
+    with section("Priors and hyperparameters", timings=timings):
+        configure_univariate_priors(context, definition)
 
-    diagnostics(context)
+    with section("Model definition and initialisation", timings=timings):
+        build_model(context)
 
-    sample_posterior_predictive(context)
+    with section("Prior predictive checks", timings=timings):
+        prior_predictive_checks(
+            context, outcome_col=y_col, outcome_label=outcome_label
+        )
 
-    posterior_summary(context)
+    with section("Posterior sampling", timings=timings):
+        sample(context)
 
-    run_standard_plots(context, outcome_label=outcome_label)
+    with section("Diagnostics", timings=timings):
+        diagnostics(context)
 
-    report(context)
+    with section("Posterior predictions", timings=timings):
+        sample_posterior_predictive(context)
+
+    with section("Posterior summary", timings=timings):
+        posterior_summary(context)
+
+    with section("Plots", timings=timings):
+        run_standard_plots(context, outcome_label=outcome_label)
+
+    with section("Report", timings=timings):
+        report(context)
+
+    pipeline_summary(
+        f"Pipeline summary — {context.reporting.model_label}", timings
+    )
+    console.print(
+        f"[dim]Total wall time: "
+        f"{vg_reporting.format_duration(time.perf_counter() - run_started)}[/dim]"
+    )
 
     return context

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -13,6 +13,7 @@ Uses a production-ratio reparameterization:
 
 import os
 import shutil
+import time
 from dataclasses import dataclass
 
 import arviz as az
@@ -33,23 +34,33 @@ import preliz as pz
 import pymc as pm
 from arviz import InferenceData
 from preliz.distributions.distributions import Continuous
-from rich import print
-from rich.pretty import pprint
 
 import vocab_growth.data_utils as vocab_data_utils
 import vocab_growth.environment as local_env
 import vocab_growth.plotting as plotting
 import vocab_growth.posterior_analysis as posterior_analysis
+import vocab_growth.reporting as vg_reporting
 from vocab_growth.models.common import (
     PACKAGE_LIST,
     BaseModelConfiguration,
     ModelFitContext,
     _plot_and_print_dist,
+    _report_diagnostic_warnings,
     get_hsgp_hyperparams,
     report,
 )
 from vocab_growth.models.definitions import BivariateModelDefinition
 from vocab_growth.plotting import _save_csv
+from vocab_growth.reporting import (
+    config_table,
+    console,
+    dataframe_table,
+    heading,
+    key_value_table,
+    pipeline_summary,
+    run_banner,
+    section,
+)
 
 EPSILON = math_constants.EPSILON
 
@@ -159,13 +170,6 @@ def prepare_bivariate_data(
     definition: BivariateModelDefinition,
 ):
     """Load and prepare data for a bivariate model from its definition."""
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Prepare data[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     df = vocab_data_utils.load_data(
         population=definition.population,
         columns=["age", "understood", "spoken"],
@@ -182,14 +186,6 @@ def prepare_bivariate_data(
 
     desc = descriptive_stats.describe_all(analysis_df, alpha=0.05)
 
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Descriptive statistics[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-
-    pprint(desc)
-
     n = len(analysis_df)
     n_u = int(analysis_df["understood"].notna().sum())
     n_s = int(analysis_df["spoken"].notna().sum())
@@ -197,12 +193,18 @@ def prepare_bivariate_data(
         (analysis_df["understood"].notna() & analysis_df["spoken"].notna()).sum()
     )
 
-    print(f"\n  Total observations:       {n}")
-    print(f"  Understood observed:      {n_u}")
-    print(f"  Spoken observed:          {n_s}")
-    print(f"  Both observed:            {n_both}")
-    print(f"  Understood only:          {n_u - n_both}")
-    print(f"  Spoken only:              {n_s - n_both}")
+    key_value_table(
+        "Observation counts",
+        [
+            ("Total observations", n),
+            ("Understood observed", n_u),
+            ("Spoken observed", n_s),
+            ("Both observed", n_both),
+            ("Understood only", n_u - n_both),
+            ("Spoken only", n_s - n_both),
+        ],
+    )
+    dataframe_table(desc, title="Descriptive statistics")
 
     # Create a BinomialModelData for the context interface (using understood as primary)
     X_obs = np.asarray(analysis_df["age"], dtype=float).reshape(-1, 1)
@@ -235,13 +237,7 @@ def configure_bivariate_priors(
     definition: BivariateModelDefinition,
 ):
     """Configure priors and hyperparameters from a bivariate model definition."""
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Priors and hyperparameters[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
+    heading("Understood trajectory priors", style="bold cyan")
     # --- Understood (U) trajectory priors ---
 
     ell_unit_u_dist = pz.Beta(
@@ -264,6 +260,7 @@ def configure_bivariate_priors(
     _plot_and_print_dist(context, p_slope_hi_u_dist, "p_slope_hi_u_dist")
 
     # --- Production ratio (q) priors ---
+    heading("Production ratio priors", style="bold cyan")
 
     ell_unit_q_dist = pz.Beta(
         alpha=definition.ell_unit_q_alpha, beta=definition.ell_unit_q_beta
@@ -284,6 +281,7 @@ def configure_bivariate_priors(
     _plot_and_print_dist(context, p_slope_hi_q_dist, "p_slope_hi_q_dist")
 
     # --- Kappa priors — understood ---
+    heading("Kappa priors — understood", style="bold cyan")
 
     kp_u = definition.kappa_u
     kappa_min_u_dist = pz.LogNormal(mu=kp_u.kappa_min_mu, sigma=kp_u.kappa_min_sigma)
@@ -296,6 +294,7 @@ def configure_bivariate_priors(
     _plot_and_print_dist(context, b_kappa_mag_u_dist, "b_kappa_mag_u_dist")
 
     # --- Kappa priors — spoken ---
+    heading("Kappa priors — spoken", style="bold cyan")
 
     kp_s = definition.kappa_s
     kappa_min_s_dist = pz.LogNormal(mu=kp_s.kappa_min_mu, sigma=kp_s.kappa_min_sigma)
@@ -346,13 +345,6 @@ def build_model(context: BivariateContext):
     """Build the bivariate PyMC model."""
     config = context.model_config
 
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Model definition and initialisation[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     analysis_df = context.analysis_df
 
     # Observation masks
@@ -371,11 +363,6 @@ def build_model(context: BivariateContext):
     n_s = len(y_s_observed)
     n_trials = context.model_data.n_trials
 
-    print(f"  Total observations:   {n}")
-    print(f"  Understood observed:  {n_u}")
-    print(f"  Spoken observed:      {n_s}")
-    print(f"  n_trials:             {n_trials}")
-
     # Validate
     if not np.all(y_u_observed >= 0):
         raise ValueError("y_u contains negative counts.")
@@ -393,7 +380,20 @@ def build_model(context: BivariateContext):
     if not np.isfinite(X_obs_std) or X_obs_std <= 0:
         raise ValueError("Age standard deviation must be positive.")
 
-    print(f"  Age (months) - mean: {X_obs_mean:.2f}, std: {X_obs_std:.2f}")
+    key_value_table(
+        "Build configuration",
+        [
+            ("Total observations", n),
+            ("Understood observed", n_u),
+            ("Spoken observed", n_s),
+            ("n_trials", n_trials),
+            ("Age mean (months)", X_obs_mean),
+            ("Age std (months)", X_obs_std),
+            ("Slope anchors (months)", config.slope_anchors),
+            ("Length-scale range (months)", config.ell_months_range),
+            ("Query ages (months)", config.ages_query),
+        ],
+    )
 
     X_obs_z = (X_obs - X_obs_mean) / X_obs_std
 
@@ -427,16 +427,21 @@ def build_model(context: BivariateContext):
 
     L, M = get_hsgp_hyperparams(X_obs_z, ell_range_z)
 
-    print(f"  HSGP basis size (m): {M}")
-    print(f"  HSGP L: {L}")
-
     # Slope anchors
     slope_age_a = float(config.slope_anchors[0])
     slope_age_b = float(config.slope_anchors[1])
     slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
     slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
 
-    print(f"  Slope anchors (z-scores): {slope_age_a_z:.2f}, {slope_age_b_z:.2f}")
+    key_value_table(
+        "Derived quantities",
+        [
+            ("HSGP basis size (m)", M),
+            ("HSGP boundary factor (L)", L),
+            ("Slope anchors (z-score)", (slope_age_a_z, slope_age_b_z)),
+            ("Length-scale range (z-score)", (ell_low_z, ell_high_z)),
+        ],
+    )
 
     # Slice indices
     i_obs0, i_obs1 = 0, n
@@ -820,13 +825,6 @@ def extract_model_samples(trace: InferenceData) -> BivariateModelSamples:
 
 def prior_predictive_checks(context: BivariateContext):
     """Run prior predictive checks."""
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Prior predictive checks[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     with context.model:
         prior_samples = pm.sample_prior_predictive(
             draws=1000,
@@ -905,15 +903,7 @@ def prior_predictive_checks(context: BivariateContext):
 
 def sample(context: BivariateContext):
     """Draw samples from the posterior using MCMC."""
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Posterior sampling[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
-    print(context.sampling)
-    print()
+    config_table("Sampling configuration", context.sampling)
 
     with context.model:
         trace = pm.sample(
@@ -929,19 +919,9 @@ def sample(context: BivariateContext):
 
     context.set_trace(trace)
 
-    print()
-    print("[bold green]Posterior sampling completed.[/bold green]")
-
 
 def diagnostics(context: BivariateContext):
     """Run diagnostics on the posterior samples."""
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Diagnostics[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     var_names = [
         var.name for var in context.model.unobserved_RVs if var.size.eval() <= 2
     ]
@@ -953,7 +933,8 @@ def diagnostics(context: BivariateContext):
         os.path.join(context.reporting.output_dir, "diagnostics.csv"), index=True
     )
 
-    pprint(diagnostics_df)
+    dataframe_table(diagnostics_df, title="Posterior diagnostics")
+    _report_diagnostic_warnings(diagnostics_df)
 
     # KDE pair plot
     plot_diagnostics_mcmc.plot_kde_pair(
@@ -1005,21 +986,14 @@ def diagnostics(context: BivariateContext):
     loocv_s = az.loo(context.trace, var_name="y_s_obs")
     loocv_u = az.loo(context.trace, var_name="y_u_obs")
     context.set_loocv({"y_s_obs": loocv_s, "y_u_obs": loocv_u})
-    print("LOO-CV (words spoken):")
-    print(loocv_s)
-    print("\nLOO-CV (words understood):")
-    print(loocv_u)
+    heading("LOO-CV — words spoken", style="bold cyan")
+    console.print(loocv_s)
+    heading("LOO-CV — words understood", style="bold cyan")
+    console.print(loocv_u)
 
 
 def sample_posterior_predictive(context: BivariateContext):
     """Sample from the posterior predictive distribution."""
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Posterior predictions[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     n_trials = context.model_data.n_trials
 
     p_u_plot = context.model_variables["p_u_plot"]
@@ -1106,8 +1080,9 @@ def posterior_summary(context: BivariateContext):
         n_trials=n_trials,
         hdi_prob=hdi_prob,
     )
-    print("\n[bold green]Posterior summary — words understood[/bold green]")
-    pprint(summary_u)
+    dataframe_table(
+        summary_u, title="Posterior summary — words understood", show_index=False
+    )
     context.dataframes["posterior_summary_u"] = summary_u
     summary_u.to_csv(
         os.path.join(context.reporting.output_dir, "posterior_summary_u.csv"),
@@ -1122,8 +1097,9 @@ def posterior_summary(context: BivariateContext):
         n_trials=n_trials,
         hdi_prob=hdi_prob,
     )
-    print("\n[bold green]Posterior summary — words spoken[/bold green]")
-    pprint(summary_s)
+    dataframe_table(
+        summary_s, title="Posterior summary — words spoken", show_index=False
+    )
     context.dataframes["posterior_summary_s"] = summary_s
     summary_s.to_csv(
         os.path.join(context.reporting.output_dir, "posterior_summary_s.csv"),
@@ -1142,8 +1118,9 @@ def posterior_summary(context: BivariateContext):
             "q_hdi_hi": q_query_hdi[:, 1],
         }
     )
-    print("\n[bold green]Posterior summary — production rate q(a)[/bold green]")
-    pprint(summary_q)
+    dataframe_table(
+        summary_q, title="Posterior summary — production rate q(a)", show_index=False
+    )
     context.dataframes["posterior_summary_q"] = summary_q
     summary_q.to_csv(
         os.path.join(context.reporting.output_dir, "posterior_summary_q.csv"),
@@ -1882,18 +1859,11 @@ def fit_bivariate_model(
     """
     Shared fit pipeline for bivariate models (VG05-VG06).
     """
-    print(
-        "\n[green]============================================================[/green]"
-    )
-    print(
-        f"[bold green]{definition.banner}[/bold green]"
-    )
-    print("[green]============================================================[/green]")
-    print()
+    run_banner(definition.banner, subtitle=f"sampling config: {config}")
 
     env_info.report_environment_info()
 
-    print()
+    console.print()
     package_metadata.report_package_versions(PACKAGE_LIST)
 
     context: BivariateContext = ModelFitContext(
@@ -1911,24 +1881,45 @@ def fit_bivariate_model(
 
     os.makedirs(context.reporting.output_dir, exist_ok=True)
 
-    prepare_bivariate_data(context, definition)
+    timings = context.timings
+    run_started = time.perf_counter()
 
-    configure_bivariate_priors(context, definition)
+    with section("Prepare data", timings=timings):
+        prepare_bivariate_data(context, definition)
 
-    build_model(context)
+    with section("Priors and hyperparameters", timings=timings):
+        configure_bivariate_priors(context, definition)
 
-    prior_predictive_checks(context)
+    with section("Model definition and initialisation", timings=timings):
+        build_model(context)
 
-    sample(context)
+    with section("Prior predictive checks", timings=timings):
+        prior_predictive_checks(context)
 
-    diagnostics(context)
+    with section("Posterior sampling", timings=timings):
+        sample(context)
 
-    sample_posterior_predictive(context)
+    with section("Diagnostics", timings=timings):
+        diagnostics(context)
 
-    posterior_summary(context)
+    with section("Posterior predictions", timings=timings):
+        sample_posterior_predictive(context)
 
-    _run_bivariate_joint_plots(context, definition)
+    with section("Posterior summary", timings=timings):
+        posterior_summary(context)
 
-    report(context)
+    with section("Plots", timings=timings):
+        _run_bivariate_joint_plots(context, definition)
+
+    with section("Report", timings=timings):
+        report(context)
+
+    pipeline_summary(
+        f"Pipeline summary — {context.reporting.model_label}", timings
+    )
+    console.print(
+        f"[dim]Total wall time: "
+        f"{vg_reporting.format_duration(time.perf_counter() - run_started)}[/dim]"
+    )
 
     return context

--- a/src/vocab_growth/models/common_bivariate_re.py
+++ b/src/vocab_growth/models/common_bivariate_re.py
@@ -19,20 +19,22 @@ Plot and query predictions use the population-level trajectory (delta=0).
 
 import os
 import shutil
+import time
 
 import dse_research_utils.environment.info as env_info
 import dse_research_utils.math.constants as math_constants
 import dse_research_utils.metadata.packages as package_metadata
+import dse_research_utils.statistics.descriptive as descriptive_stats
 import dse_research_utils.statistics.models.data as model_data
 import dse_research_utils.statistics.models.pymc_utils as pymc_utils
 import dse_research_utils.statistics.models.reporting as reporting
 import dse_research_utils.statistics.models.sampling as sampling
 import numpy as np
 import pymc as pm
-from rich import print
 
 import vocab_growth.data_utils as vocab_data_utils
 import vocab_growth.environment as local_env
+import vocab_growth.reporting as vg_reporting
 from vocab_growth.models.common import (
     PACKAGE_LIST,
     ModelFitContext,
@@ -50,6 +52,14 @@ from vocab_growth.models.common_bivariate import (
     sample_posterior_predictive,
 )
 from vocab_growth.models.definitions import BivariateModelDefinition
+from vocab_growth.reporting import (
+    console,
+    dataframe_table,
+    key_value_table,
+    pipeline_summary,
+    run_banner,
+    section,
+)
 
 EPSILON = math_constants.EPSILON
 
@@ -66,16 +76,6 @@ def prepare_bivariate_re_data(
     definition: BivariateModelDefinition,
 ):
     """Load and prepare data for a bivariate model with study random effects."""
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Prepare data[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
-    import dse_research_utils.statistics.descriptive as descriptive_stats
-    from rich.pretty import pprint
-
     df = vocab_data_utils.load_data(
         population=definition.population,
         columns=["age", "understood", "spoken", "study"],
@@ -99,14 +99,6 @@ def prepare_bivariate_re_data(
         analysis_df[["age", "understood", "spoken"]], alpha=0.05
     )
 
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Descriptive statistics[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-
-    pprint(desc)
-
     n = len(analysis_df)
     n_u = int(analysis_df["understood"].notna().sum())
     n_s = int(analysis_df["spoken"].notna().sum())
@@ -115,13 +107,19 @@ def prepare_bivariate_re_data(
     )
     n_studies = len(unique_studies)
 
-    print(f"\n  Total observations:       {n}")
-    print(f"  Understood observed:      {n_u}")
-    print(f"  Spoken observed:          {n_s}")
-    print(f"  Both observed:            {n_both}")
-    print(f"  Understood only:          {n_u - n_both}")
-    print(f"  Spoken only:              {n_s - n_both}")
-    print(f"  Studies:                  {n_studies} {unique_studies}")
+    key_value_table(
+        "Observation counts",
+        [
+            ("Total observations", n),
+            ("Understood observed", n_u),
+            ("Spoken observed", n_s),
+            ("Both observed", n_both),
+            ("Understood only", n_u - n_both),
+            ("Spoken only", n_s - n_both),
+            ("Studies", f"{n_studies} ({', '.join(map(str, unique_studies))})"),
+        ],
+    )
+    dataframe_table(desc, title="Descriptive statistics")
 
     # Create a BinomialModelData for the context interface
     X_obs = np.asarray(analysis_df["age"], dtype=float).reshape(-1, 1)
@@ -156,13 +154,6 @@ def build_model_re(
     """Build the bivariate PyMC model with study-level random intercepts."""
     config = context.model_config
 
-    print(
-        "\n[green]------------------------------------------------------------[/green]"
-    )
-    print("[bold green]Model definition and initialisation[/bold green]")
-    print("[green]------------------------------------------------------------[/green]")
-    print()
-
     analysis_df = context.analysis_df
 
     # Observation masks
@@ -183,12 +174,6 @@ def build_model_re(
     n_trials = context.model_data.n_trials
     n_studies = int(study_codes.max()) + 1
 
-    print(f"  Total observations:   {n}")
-    print(f"  Understood observed:  {n_u}")
-    print(f"  Spoken observed:      {n_s}")
-    print(f"  n_trials:             {n_trials}")
-    print(f"  n_studies:            {n_studies}")
-
     # Validate
     if not np.all(y_u_observed >= 0):
         raise ValueError("y_u contains negative counts.")
@@ -206,7 +191,21 @@ def build_model_re(
     if not np.isfinite(X_obs_std) or X_obs_std <= 0:
         raise ValueError("Age standard deviation must be positive.")
 
-    print(f"  Age (months) - mean: {X_obs_mean:.2f}, std: {X_obs_std:.2f}")
+    key_value_table(
+        "Build configuration",
+        [
+            ("Total observations", n),
+            ("Understood observed", n_u),
+            ("Spoken observed", n_s),
+            ("n_trials", n_trials),
+            ("n_studies", n_studies),
+            ("Age mean (months)", X_obs_mean),
+            ("Age std (months)", X_obs_std),
+            ("Slope anchors (months)", config.slope_anchors),
+            ("Length-scale range (months)", config.ell_months_range),
+            ("Query ages (months)", config.ages_query),
+        ],
+    )
 
     X_obs_z = (X_obs - X_obs_mean) / X_obs_std
 
@@ -240,16 +239,21 @@ def build_model_re(
 
     L, M = get_hsgp_hyperparams(X_obs_z, ell_range_z)
 
-    print(f"  HSGP basis size (m): {M}")
-    print(f"  HSGP L: {L}")
-
     # Slope anchors
     slope_age_a = float(config.slope_anchors[0])
     slope_age_b = float(config.slope_anchors[1])
     slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
     slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
 
-    print(f"  Slope anchors (z-scores): {slope_age_a_z:.2f}, {slope_age_b_z:.2f}")
+    key_value_table(
+        "Derived quantities",
+        [
+            ("HSGP basis size (m)", M),
+            ("HSGP boundary factor (L)", L),
+            ("Slope anchors (z-score)", (slope_age_a_z, slope_age_b_z)),
+            ("Length-scale range (z-score)", (ell_low_z, ell_high_z)),
+        ],
+    )
 
     # Slice indices
     i_obs0, i_obs1 = 0, n
@@ -540,18 +544,11 @@ def fit_bivariate_re_model(
     """
     Fit pipeline for bivariate model with study random intercepts (VG07).
     """
-    print(
-        "\n[green]============================================================[/green]"
-    )
-    print(
-        f"[bold green]{definition.banner}[/bold green]"
-    )
-    print("[green]============================================================[/green]")
-    print()
+    run_banner(definition.banner, subtitle=f"sampling config: {config}")
 
     env_info.report_environment_info()
 
-    print()
+    console.print()
     package_metadata.report_package_versions(PACKAGE_LIST)
 
     context: BivariateREContext = ModelFitContext(
@@ -569,24 +566,45 @@ def fit_bivariate_re_model(
 
     os.makedirs(context.reporting.output_dir, exist_ok=True)
 
-    prepare_bivariate_re_data(context, definition)
+    timings = context.timings
+    run_started = time.perf_counter()
 
-    configure_bivariate_priors(context, definition)
+    with section("Prepare data", timings=timings):
+        prepare_bivariate_re_data(context, definition)
 
-    build_model_re(context, definition)
+    with section("Priors and hyperparameters", timings=timings):
+        configure_bivariate_priors(context, definition)
 
-    prior_predictive_checks(context)
+    with section("Model definition and initialisation", timings=timings):
+        build_model_re(context, definition)
 
-    sample(context)
+    with section("Prior predictive checks", timings=timings):
+        prior_predictive_checks(context)
 
-    diagnostics(context)
+    with section("Posterior sampling", timings=timings):
+        sample(context)
 
-    sample_posterior_predictive(context)
+    with section("Diagnostics", timings=timings):
+        diagnostics(context)
 
-    posterior_summary(context)
+    with section("Posterior predictions", timings=timings):
+        sample_posterior_predictive(context)
 
-    _run_bivariate_joint_plots(context, definition)
+    with section("Posterior summary", timings=timings):
+        posterior_summary(context)
 
-    report(context)
+    with section("Plots", timings=timings):
+        _run_bivariate_joint_plots(context, definition)
+
+    with section("Report", timings=timings):
+        report(context)
+
+    pipeline_summary(
+        f"Pipeline summary — {context.reporting.model_label}", timings
+    )
+    console.print(
+        f"[dim]Total wall time: "
+        f"{vg_reporting.format_duration(time.perf_counter() - run_started)}[/dim]"
+    )
 
     return context

--- a/src/vocab_growth/reporting.py
+++ b/src/vocab_growth/reporting.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Console reporting helpers for the vocab_growth pipelines.
+
+Provides a small set of rich-based primitives used by the fit pipelines to emit
+consistently formatted, easy-to-scan diagnostics while a model fit is running.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterable, Mapping
+from contextlib import contextmanager
+from dataclasses import is_dataclass
+from typing import Any
+
+import pandas as pd
+from rich.console import Console
+from rich.panel import Panel
+from rich.rule import Rule
+from rich.table import Table
+from rich.text import Text
+
+console = Console(highlight=False)
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, float):
+        if abs(value) >= 1e4 or (value != 0 and abs(value) < 1e-3):
+            return f"{value:.3e}"
+        return f"{value:.4g}"
+    if isinstance(value, (list, tuple)):
+        return ", ".join(_format_value(v) for v in value)
+    return str(value)
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds < 1:
+        return f"{seconds * 1000:.0f} ms"
+    if seconds < 60:
+        return f"{seconds:.2f} s"
+    minutes, secs = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{int(minutes)}m {secs:04.1f}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{int(hours)}h {int(minutes):02d}m {secs:04.1f}s"
+
+
+def run_banner(title: str, subtitle: str | None = None) -> None:
+    """Top-of-run banner. Use once per model fit."""
+    body = Text(title, style="bold green", justify="center")
+    if subtitle:
+        body.append("\n")
+        body.append(subtitle, style="dim")
+    console.print()
+    console.print(Panel(body, border_style="green", expand=True))
+
+
+def heading(title: str, *, style: str = "bold green") -> None:
+    """Section heading without timing. Use for non-stage sub-sections."""
+    console.print()
+    console.print(Rule(Text(title, style=style), style=style))
+
+
+@contextmanager
+def section(
+    title: str,
+    *,
+    timings: dict[str, float] | None = None,
+    key: str | None = None,
+    style: str = "bold green",
+):
+    """
+    Emit a section heading, run the block, and record its wall time.
+
+    If ``timings`` is provided, records elapsed seconds under ``key`` (defaulting
+    to ``title``). On exit, prints the stage duration so it is visible inline.
+    """
+    heading(title, style=style)
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed = time.perf_counter() - start
+        if timings is not None:
+            timings[key or title] = elapsed
+        console.print(
+            Text(f"  ✓ {title} — {_format_duration(elapsed)}", style="dim green")
+        )
+
+
+def key_value_table(
+    title: str,
+    pairs: Iterable[tuple[str, Any]] | Mapping[str, Any],
+    *,
+    key_header: str = "Parameter",
+    value_header: str = "Value",
+) -> None:
+    """Render a two-column table of (name, value) pairs."""
+    items = pairs.items() if isinstance(pairs, Mapping) else list(pairs)
+
+    table = Table(
+        title=title,
+        title_style="bold",
+        title_justify="left",
+        show_header=True,
+        header_style="bold cyan",
+        expand=False,
+        pad_edge=False,
+    )
+    table.add_column(key_header, style="cyan", no_wrap=True)
+    table.add_column(value_header, style="white")
+
+    for k, v in items:
+        table.add_row(str(k), _format_value(v))
+
+    console.print(table)
+
+
+def dataframe_table(
+    df: pd.DataFrame,
+    *,
+    title: str | None = None,
+    max_rows: int | None = None,
+    float_format: str = ".4g",
+    show_index: bool = True,
+) -> None:
+    """
+    Render a pandas DataFrame as a rich Table.
+
+    Long frames are truncated to ``max_rows`` (head/tail split) with a note.
+    """
+    if df.empty:
+        console.print(Text(title or "(empty)", style="dim"))
+        return
+
+    truncated = False
+    display_df = df
+    if max_rows is not None and len(df) > max_rows:
+        half = max(1, max_rows // 2)
+        display_df = pd.concat([df.head(half), df.tail(max_rows - half)])
+        truncated = True
+
+    table = Table(
+        title=title,
+        title_style="bold",
+        title_justify="left",
+        show_header=True,
+        header_style="bold cyan",
+        expand=False,
+        pad_edge=False,
+    )
+
+    if show_index:
+        index_name = df.index.name or ""
+        table.add_column(str(index_name), style="cyan", no_wrap=True)
+
+    for col in display_df.columns:
+        table.add_column(str(col), justify="right")
+
+    def _fmt(value: Any) -> str:
+        if pd.isna(value):
+            return "—"
+        if isinstance(value, float):
+            return format(value, float_format)
+        return str(value)
+
+    for idx, row in display_df.iterrows():
+        cells = [_fmt(row[c]) for c in display_df.columns]
+        if show_index:
+            cells = [str(idx)] + cells
+        table.add_row(*cells)
+
+    console.print(table)
+    if truncated:
+        console.print(
+            Text(
+                f"  … showing {max_rows} of {len(df)} rows (head/tail) …",
+                style="dim",
+            )
+        )
+
+
+def config_table(title: str, config: Any) -> None:
+    """Render a dataclass (or mapping) as a key/value table."""
+    if isinstance(config, Mapping):
+        pairs = list(config.items())
+    elif is_dataclass(config):
+        pairs = [
+            (f.name, getattr(config, f.name))
+            for f in config.__dataclass_fields__.values()
+        ]
+    else:
+        console.print(config)
+        return
+    key_value_table(title, pairs)
+
+
+def pipeline_summary(
+    title: str,
+    timings: Mapping[str, float],
+    *,
+    total_label: str = "Total",
+) -> None:
+    """Render a summary table of per-stage timings."""
+    if not timings:
+        return
+
+    total = sum(timings.values())
+
+    table = Table(
+        title=title,
+        title_style="bold green",
+        title_justify="left",
+        show_header=True,
+        header_style="bold cyan",
+        expand=False,
+        pad_edge=False,
+    )
+    table.add_column("Stage", style="cyan")
+    table.add_column("Duration", justify="right")
+    table.add_column("% total", justify="right", style="dim")
+
+    for stage, seconds in timings.items():
+        pct = (seconds / total * 100) if total > 0 else 0.0
+        table.add_row(stage, _format_duration(seconds), f"{pct:5.1f}%")
+
+    table.add_section()
+    table.add_row(
+        Text(total_label, style="bold"),
+        Text(_format_duration(total), style="bold"),
+        "",
+    )
+
+    console.print()
+    console.print(table)
+
+
+def format_duration(seconds: float) -> str:
+    """Public alias for the internal duration formatter."""
+    return _format_duration(seconds)

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -3,12 +3,19 @@
 
 import mimetypes
 import os
+import time
 import uuid
 from urllib.parse import urlparse
 
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient, ContentSettings
-from rich import print
+
+from vocab_growth.reporting import (
+    console,
+    format_duration,
+    heading,
+    key_value_table,
+)
 
 
 def upload_to_blob_storage(
@@ -23,11 +30,11 @@ def upload_to_blob_storage(
     """
     container_url = os.environ.get("DSERESEARCH_BLOB_CONTAINER_URL")
     if not container_url:
-        print(
+        console.print(
             "[bold red]Error: DSERESEARCH_BLOB_CONTAINER_URL environment variable is not set.[/bold red]"
         )
-        print("Set it to your Azure Blob container URL, e.g.:")
-        print(
+        console.print("Set it to your Azure Blob container URL, e.g.:")
+        console.print(
             "  export DSERESEARCH_BLOB_CONTAINER_URL='https://<account>.blob.core.windows.net/<container>'"
         )
         raise RuntimeError(
@@ -41,9 +48,16 @@ def upload_to_blob_storage(
     run_id = uuid.uuid7()
     blob_prefix = f"projects/vocabulary-growth/output/{run_id}/{model_label}"
 
-    print(f"\n[bold green]Uploading to Azure Blob Storage: {model_label}[/bold green]")
-    print(f"  Source: {output_dir}")
-    print(f"  Destination: {container_name}/{blob_prefix}/")
+    heading(f"Uploading {model_label} to Azure Blob Storage")
+    key_value_table(
+        "Upload target",
+        [
+            ("Source", output_dir),
+            ("Container", container_name),
+            ("Prefix", f"{blob_prefix}/"),
+            ("Include traces", include_traces),
+        ],
+    )
 
     credential = DefaultAzureCredential()
     blob_service_client = BlobServiceClient(account_url, credential=credential)
@@ -51,6 +65,8 @@ def upload_to_blob_storage(
 
     uploaded = 0
     skipped = 0
+    bytes_sent = 0
+    started = time.perf_counter()
     for root, _dirs, files in os.walk(output_dir):
         for filename in files:
             if not include_traces and filename.endswith(".nc"):
@@ -65,6 +81,7 @@ def upload_to_blob_storage(
             if content_type is None:
                 content_type = "application/octet-stream"
 
+            bytes_sent += os.path.getsize(local_path)
             with open(local_path, "rb") as f:
                 container_client.upload_blob(
                     blob_name,
@@ -74,6 +91,12 @@ def upload_to_blob_storage(
                 )
             uploaded += 1
 
-    if skipped:
-        print(f"[yellow]Skipped {skipped} trace file(s) (.nc)[/yellow]")
-    print(f"[bold green]Upload complete: {model_label} ({uploaded} files)[/bold green]")
+    key_value_table(
+        f"Upload complete — {model_label}",
+        [
+            ("Files uploaded", uploaded),
+            ("Files skipped (.nc)", skipped),
+            ("Bytes uploaded", f"{bytes_sent / 1_000_000:.1f} MB"),
+            ("Elapsed", format_duration(time.perf_counter() - started)),
+        ],
+    )


### PR DESCRIPTION
## Summary
- New `vocab_growth.reporting` module: shared rich `Console`, a timed `section` context manager, `run_banner`, `heading`, `key_value_table`, `dataframe_table`, `config_table`, `pipeline_summary`, `format_duration`.
- Univariate, bivariate, and bivariate-RE fit pipelines now use the helpers: repeated banner blocks are gone, each stage is timed, priors / build config / sampling config render as tables, `az.summary` renders as a `rich.Table`, and each fit ends with a per-stage timing summary. MCMC diagnostics grew a small r_hat / ESS warning pass.
- `scripts/fit_model.py` prints a run plan up front, times every model, and emits a multi-model summary when fitting `all`. `scripts/prepare_data.py` and `storage.py` use the same helpers for loading summaries and upload results.

## Test plan
- [ ] `ruff check src/ scripts/` — passes on the touched files.
- [ ] Smoke-run `python scripts/fit_model.py vg01 --config dev` and confirm the banner, per-stage timings, tables, and pipeline summary render as expected in the terminal.
- [ ] Smoke-run `python scripts/fit_model.py all --config dev` and confirm the "Run summary — all models" table appears at the end.
- [ ] `python scripts/prepare_data.py` — confirm the dataset-sources and completion tables render and the DuckDB/CSV outputs are produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)