### PR TITLE
refactor: rename model VG09B to VG10

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,7 +61,7 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 ```
 
-- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, or `all`.
+- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, `vg10`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
@@ -99,6 +99,7 @@ The models differ in which outcome, population, and structure they target:
 | VG07  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts                                                                   |
 | VG08  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood                         |
 | VG09  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio |
+| VG10  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age |
 
 ### Shared utilities (`dse_research_utils`)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,17 +88,17 @@ Each model is a self-contained module in `src/vocab_growth/models/model_vgNN.py`
 
 The models differ in which outcome, population, and structure they target:
 
-| Model | Outcome                           | Population           | Notes                                                                                     |
-| ----- | --------------------------------- | -------------------- | ----------------------------------------------------------------------------------------- |
-| VG01  | Words spoken                      | Down syndrome        |                                                                                           |
-| VG02  | Words understood                  | Down syndrome        |                                                                                           |
-| VG03  | Words spoken                      | Typically developing |                                                                                           |
-| VG04  | Words understood                  | Typically developing |                                                                                           |
-| VG05  | Words understood + spoken (joint) | Down syndrome        |                                                                                           |
-| VG06  | Words understood + spoken (joint) | Typically developing |                                                                                           |
-| VG07  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts                                                                   |
-| VG08  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood                         |
-| VG09  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio |
+| Model | Outcome                           | Population           | Notes                                                                                                                                              |
+| ----- | --------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| VG01  | Words spoken                      | Down syndrome        |                                                                                                                                                    |
+| VG02  | Words understood                  | Down syndrome        |                                                                                                                                                    |
+| VG03  | Words spoken                      | Typically developing |                                                                                                                                                    |
+| VG04  | Words understood                  | Typically developing |                                                                                                                                                    |
+| VG05  | Words understood + spoken (joint) | Down syndrome        |                                                                                                                                                    |
+| VG06  | Words understood + spoken (joint) | Typically developing |                                                                                                                                                    |
+| VG07  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts                                                                                                                            |
+| VG08  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood                                                                                  |
+| VG09  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio                                                          |
 | VG10  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age |
 
 ### Shared utilities (`dse_research_utils`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 ```
 
-- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, or `all`.
+- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, `vg10`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
@@ -99,6 +99,7 @@ The models differ in which outcome, population, and structure they target:
 | VG07  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts                                                                   |
 | VG08  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood                         |
 | VG09  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio |
+| VG10  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age |
 
 ### Shared utilities (`dse_research_utils`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,17 +88,17 @@ Each model is a self-contained module in `src/vocab_growth/models/model_vgNN.py`
 
 The models differ in which outcome, population, and structure they target:
 
-| Model | Outcome                           | Population           | Notes                                                                                     |
-| ----- | --------------------------------- | -------------------- | ----------------------------------------------------------------------------------------- |
-| VG01  | Words spoken                      | Down syndrome        |                                                                                           |
-| VG02  | Words understood                  | Down syndrome        |                                                                                           |
-| VG03  | Words spoken                      | Typically developing |                                                                                           |
-| VG04  | Words understood                  | Typically developing |                                                                                           |
-| VG05  | Words understood + spoken (joint) | Down syndrome        |                                                                                           |
-| VG06  | Words understood + spoken (joint) | Typically developing |                                                                                           |
-| VG07  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts                                                                   |
-| VG08  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood                         |
-| VG09  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio |
+| Model | Outcome                           | Population           | Notes                                                                                                                                              |
+| ----- | --------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| VG01  | Words spoken                      | Down syndrome        |                                                                                                                                                    |
+| VG02  | Words understood                  | Down syndrome        |                                                                                                                                                    |
+| VG03  | Words spoken                      | Typically developing |                                                                                                                                                    |
+| VG04  | Words understood                  | Typically developing |                                                                                                                                                    |
+| VG05  | Words understood + spoken (joint) | Down syndrome        |                                                                                                                                                    |
+| VG06  | Words understood + spoken (joint) | Typically developing |                                                                                                                                                    |
+| VG07  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts                                                                                                                            |
+| VG08  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood                                                                                  |
+| VG09  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio                                                          |
 | VG10  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age |
 
 ### Shared utilities (`dse_research_utils`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 ```
 
-- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, or `all`.
+- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, `vg10`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
@@ -99,6 +99,7 @@ The models differ in which outcome, population, and structure they target:
 | VG07  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts                                                                   |
 | VG08  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood                         |
 | VG09  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio |
+| VG10  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age |
 
 ### Shared utilities (`dse_research_utils`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,17 +88,17 @@ Each model is a self-contained module in `src/vocab_growth/models/model_vgNN.py`
 
 The models differ in which outcome, population, and structure they target:
 
-| Model | Outcome                           | Population           | Notes                                                                                     |
-| ----- | --------------------------------- | -------------------- | ----------------------------------------------------------------------------------------- |
-| VG01  | Words spoken                      | Down syndrome        |                                                                                           |
-| VG02  | Words understood                  | Down syndrome        |                                                                                           |
-| VG03  | Words spoken                      | Typically developing |                                                                                           |
-| VG04  | Words understood                  | Typically developing |                                                                                           |
-| VG05  | Words understood + spoken (joint) | Down syndrome        |                                                                                           |
-| VG06  | Words understood + spoken (joint) | Typically developing |                                                                                           |
-| VG07  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts                                                                   |
-| VG08  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood                         |
-| VG09  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio |
+| Model | Outcome                           | Population           | Notes                                                                                                                                              |
+| ----- | --------------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| VG01  | Words spoken                      | Down syndrome        |                                                                                                                                                    |
+| VG02  | Words understood                  | Down syndrome        |                                                                                                                                                    |
+| VG03  | Words spoken                      | Typically developing |                                                                                                                                                    |
+| VG04  | Words understood                  | Typically developing |                                                                                                                                                    |
+| VG05  | Words understood + spoken (joint) | Down syndrome        |                                                                                                                                                    |
+| VG06  | Words understood + spoken (joint) | Typically developing |                                                                                                                                                    |
+| VG07  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts                                                                                                                            |
+| VG08  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood                                                                                  |
+| VG09  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio                                                          |
 | VG10  | Words understood + spoken (joint) | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age |
 
 ### Shared utilities (`dse_research_utils`)

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Model VG09B: VG09 + tighter q anchor priors + GP anchored at reference age - children with Down syndrome"
+title: "Model VG10: VG09 + tighter q anchor priors + GP anchored at reference age - children with Down syndrome"
 
 date: last-modified
 date-format: "YYYY-MM-DD HH:mm:ss Z"
@@ -22,7 +22,7 @@ This model output is preliminary and likely to change as the model evolves and f
 If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
 :::
 
-VG09B is a structural variant of VG09 introduced to test whether the marginal `r_hat` / `ess_tail` issues observed on the q-trajectory hyperparameters under VG09 reflect a redundancy between the linear mean trend, the HSGP correction, and the subject random intercepts.
+VG10 is a structural variant of VG09 introduced to test whether the marginal `r_hat` / `ess_tail` issues observed on the q-trajectory hyperparameters under VG09 reflect a redundancy between the linear mean trend, the HSGP correction, and the subject random intercepts.
 
 Two changes relative to VG09:
 

--- a/scripts/aggregate_summary.py
+++ b/scripts/aggregate_summary.py
@@ -42,7 +42,7 @@ MODELS = [
     ("VG07", "VG07-age-understood-spoken-ds-re"),
     ("VG08", "VG08-age-understood-spoken-ds-re-subj"),
     ("VG09", "VG09-age-understood-spoken-ds-re-subj-uq"),
-    ("VG09B", "VG09B-age-understood-spoken-ds-re-subj-uq-anchored"),
+    ("VG10", "VG10-age-understood-spoken-ds-re-subj-uq-anchored"),
 ]
 
 LOG_DIR = "output/logs"

--- a/scripts/compare_ds_td_latency.py
+++ b/scripts/compare_ds_td_latency.py
@@ -3,7 +3,7 @@
 """
 Reframe the comprehension-production gap as a learn-to-say latency.
 
-For each population (DS via VG09B, TD via VG06) and each target vocabulary
+For each population (DS via VG10, TD via VG06) and each target vocabulary
 count N:
 
 - a_U(N) = first age at which the latent expected U(a) reaches N
@@ -32,12 +32,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-DS_DIR = "output/models/VG09B-age-understood-spoken-ds-re-subj-uq-anchored"
+DS_DIR = "output/models/VG10-age-understood-spoken-ds-re-subj-uq-anchored"
 TD_DIR = "output/models/VG06-age-understood-spoken-td"
 OUT_DIR = "output/comparisons"
 
 # n_trials is model-specific. See src/vocab_growth/models/definitions.py.
-# VG09B: 800-item DS inventory.
+# VG10: 800-item DS inventory.
 # VG06: 800-item TD reference inventory. WG and Oxford CDI contribute
 #       bivariate observations; WS is production-only in Wordbank and
 #       contributes spoken observations only.
@@ -211,7 +211,7 @@ def main() -> None:
     fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
     ax = axes[0]
-    plot_population_panel(ax, da_ds, "DS (VG09B)", plot_styles.COLOUR_BLUE)
+    plot_population_panel(ax, da_ds, "DS (VG10)", plot_styles.COLOUR_BLUE)
     plot_population_panel(ax, da_td, "TD (VG06)", plot_styles.COLOUR_ORANGE)
     ax.set_xlabel("Vocabulary count N (words)")
     ax.set_ylabel(r"$\Delta A(N) = a_S(N) - a_U(N)$  (months)")
@@ -221,7 +221,7 @@ def main() -> None:
     ax.grid(True, which="both", alpha=0.3)
 
     ax = axes[1]
-    plot_population_panel(ax, extra_ds, "DS (VG09B)", plot_styles.COLOUR_BLUE)
+    plot_population_panel(ax, extra_ds, "DS (VG10)", plot_styles.COLOUR_BLUE)
     plot_population_panel(ax, extra_td, "TD (VG06)", plot_styles.COLOUR_ORANGE)
     ax.set_xlabel("Spoken count N (words)")
     ax.set_ylabel("Extra words understood when first saying N  (= U(a_S(N)) - N)")
@@ -231,7 +231,7 @@ def main() -> None:
     ax.grid(True, which="both", alpha=0.3)
 
     fig.suptitle(
-        "Modeling the gap as a learn-to-say latency — DS (VG09B) vs TD (VG06)",
+        "Modeling the gap as a learn-to-say latency — DS (VG10) vs TD (VG06)",
         fontsize=12,
     )
     fig.tight_layout()

--- a/scripts/compare_ds_td_q_overlap.py
+++ b/scripts/compare_ds_td_q_overlap.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-Population-level posterior overlap of q(a) = S/U for DS (VG09B) and TD (VG06).
+Population-level posterior overlap of q(a) = S/U for DS (VG10) and TD (VG06).
 
 Two views:
 
@@ -177,7 +177,7 @@ def main() -> None:
     gs = fig.add_gridspec(2, 2, height_ratios=[3, 1], hspace=0.28, wspace=0.22)
 
     ax_qU = fig.add_subplot(gs[0, 0])
-    plot_overlay_panel(ax_qU, qU_ds_sum, "N", "DS (VG09B)", plot_styles.COLOUR_BLUE)
+    plot_overlay_panel(ax_qU, qU_ds_sum, "N", "DS (VG10)", plot_styles.COLOUR_BLUE)
     plot_overlay_panel(ax_qU, qU_td_sum, "N", "TD (VG06)", plot_styles.COLOUR_ORANGE)
     ax_qU.set_xscale("log")
     ax_qU.set_xlabel("Comprehension N (words)")
@@ -188,7 +188,7 @@ def main() -> None:
     ax_qU.set_ylim(0, 1.05)
 
     ax_qa = fig.add_subplot(gs[0, 1])
-    plot_overlay_panel(ax_qa, qa_ds_sum, "age_months", "DS (VG09B)", plot_styles.COLOUR_BLUE)
+    plot_overlay_panel(ax_qa, qa_ds_sum, "age_months", "DS (VG10)", plot_styles.COLOUR_BLUE)
     plot_overlay_panel(ax_qa, qa_td_sum, "age_months", "TD (VG06)", plot_styles.COLOUR_ORANGE)
     ax_qa.set_xlabel("Age (months)")
     ax_qa.set_ylabel("q(a) = E[S(a)] / E[U(a)]")
@@ -215,7 +215,7 @@ def main() -> None:
     ax_pa.grid(True, alpha=0.3)
 
     fig.suptitle(
-        "Posterior overlap of population q = S/U — DS (VG09B) vs TD (VG06)",
+        "Posterior overlap of population q = S/U — DS (VG10) vs TD (VG06)",
         fontsize=13,
     )
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_overlap.png"), dpi=300, bbox_inches="tight")

--- a/scripts/compare_ds_td_q_vs_understood.py
+++ b/scripts/compare_ds_td_q_vs_understood.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-Overlay DS (VG09B) and TD (VG06) median production ratio q(U) = E[S]/E[U]
+Overlay DS (VG10) and TD (VG06) median production ratio q(U) = E[S]/E[U]
 as a function of words understood, with HDI bands. This is the bivariate
 equivalent of Figure 25 in each model's report (`production_rate_by_understood`),
 overlaid on a single axis.
@@ -10,7 +10,7 @@ Reads `production_rate_by_understood.csv` directly from each model's
 output directory.
 
 Output:
-- `output/comparisons/ds_td_q_vs_understood_vg09b.{png,svg}`
+- `output/comparisons/ds_td_q_vs_understood_vg10.{png,svg}`
 """
 
 from __future__ import annotations
@@ -21,7 +21,7 @@ import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
 import pandas as pd
 
-DS_DIR = "output/models/VG09B-age-understood-spoken-ds-re-subj-uq-anchored"
+DS_DIR = "output/models/VG10-age-understood-spoken-ds-re-subj-uq-anchored"
 TD_DIR = "output/models/VG06-age-understood-spoken-td"
 OUT_DIR = "output/comparisons"
 
@@ -56,16 +56,16 @@ def main() -> None:
     ax.fill_between(
         ds["words_understood"], ds["hdi_lo"], ds["hdi_hi"],
         color=ds_colour, alpha=0.15, linewidth=0,
-        label="DS (VG09B) 90% HDI",
+        label="DS (VG10) 90% HDI",
     )
     ax.fill_between(
         ds["words_understood"], ds["hdi50_lo"], ds["hdi50_hi"],
         color=ds_colour, alpha=0.30, linewidth=0,
-        label="DS (VG09B) 50% HDI",
+        label="DS (VG10) 50% HDI",
     )
     ax.plot(
         ds["words_understood"], ds["q_median"],
-        color=ds_colour, lw=2.5, label="DS (VG09B) median",
+        color=ds_colour, lw=2.5, label="DS (VG10) median",
     )
 
     for thresh in (0.5, 0.9):
@@ -76,20 +76,20 @@ def main() -> None:
     ax.set_xlabel("Expected words understood")
     ax.set_ylabel(r"Production ratio  q = $E[S] / E[U]$")
     ax.set_title(
-        "Production ratio against words understood — DS (VG09B) vs TD (VG06)"
+        "Production ratio against words understood — DS (VG10) vs TD (VG06)"
     )
     ax.legend(loc="lower right", frameon=True, fontsize=10)
     ax.grid(True, alpha=0.3)
 
     fig.tight_layout()
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg09b.png"), dpi=300)
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg09b.svg"))
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg10.png"), dpi=300)
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg10.svg"))
     plt.close(fig)
 
     print(
         f"Saved:\n"
-        f"  {os.path.join(OUT_DIR, 'ds_td_q_vs_understood_vg09b.png')}\n"
-        f"  {os.path.join(OUT_DIR, 'ds_td_q_vs_understood_vg09b.svg')}"
+        f"  {os.path.join(OUT_DIR, 'ds_td_q_vs_understood_vg10.png')}\n"
+        f"  {os.path.join(OUT_DIR, 'ds_td_q_vs_understood_vg10.svg')}"
     )
     print(
         f"\nDS U range covered: {ds['words_understood'].min():.0f} – "

--- a/scripts/compare_ds_td_trajectories.py
+++ b/scripts/compare_ds_td_trajectories.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-Side-by-side DS (VG09B) vs TD (VG06) comparison plots for the joint
+Side-by-side DS (VG10) vs TD (VG06) comparison plots for the joint
 trajectory (Figure 22 equivalent) and the comprehension-production gap
 (Figure 27 equivalent).
 
@@ -26,7 +26,7 @@ import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
 import pandas as pd
 
-DS_DIR = "output/models/VG09B-age-understood-spoken-ds-re-subj-uq-anchored"
+DS_DIR = "output/models/VG10-age-understood-spoken-ds-re-subj-uq-anchored"
 TD_DIR = "output/models/VG06-age-understood-spoken-td"
 OUT_DIR = "output/comparisons"
 
@@ -101,7 +101,7 @@ def main() -> None:
 
     # ---- Joint trajectory: DS vs TD ----
     fig, axes = plt.subplots(1, 2, figsize=(14, 5), sharey=True)
-    plot_joint_panel(axes[0], ds_joint, "Down syndrome (VG09B)")
+    plot_joint_panel(axes[0], ds_joint, "Down syndrome (VG10)")
     plot_joint_panel(axes[1], td_joint, "Typically developing (VG06)")
     fig.suptitle(
         "Joint posterior predictive trajectory — words understood vs words spoken",
@@ -114,7 +114,7 @@ def main() -> None:
 
     # ---- Comprehension-production gap: DS vs TD ----
     fig, axes = plt.subplots(1, 2, figsize=(14, 5))
-    plot_gap_panel(axes[0], ds_gap, "Down syndrome (VG09B)")
+    plot_gap_panel(axes[0], ds_gap, "Down syndrome (VG10)")
     plot_gap_panel(axes[1], td_gap, "Typically developing (VG06)")
     fig.suptitle(
         "Comprehension-production gap — E[understood] - E[spoken]",

--- a/scripts/compare_models.py
+++ b/scripts/compare_models.py
@@ -13,14 +13,14 @@ Produces the following figures under `output/comparisons/`:
 - `ds_td_q_vs_understood.{png,svg}` — q vs words understood (DS VG09 / TD
   VG06) — the headline matched-comprehension comparison; the
   corresponding crossings CSV lives in this directory too.
-- `vg07_vg09_vg09b_q_by_age.{png,svg}` — production ratio q(age) three-way
+- `vg07_vg09_vg10_q_by_age.{png,svg}` — production ratio q(age) three-way
   overlay: VG07 (no subject REs), VG09 (subject REs on U and q,
-  unanchored GP), VG09B (subject REs on U and q, GP anchored at the
+  unanchored GP), VG10 (subject REs on U and q, GP anchored at the
   reference age).
-- `ds_td_q_by_age_vg09b.{png,svg}` — production ratio q(age) DS (VG09B)
+- `ds_td_q_by_age_vg10.{png,svg}` — production ratio q(age) DS (VG10)
   vs TD (VG06). Visualises the chronological production lag.
-- `ds_td_q_vs_understood_vg09b.{png,svg}` — matched-comprehension q
-  overlay using VG09B for DS instead of VG09.
+- `ds_td_q_vs_understood_vg10.{png,svg}` — matched-comprehension q
+  overlay using VG10 for DS instead of VG09.
 
 CSVs of the underlying data are also written.
 
@@ -199,12 +199,12 @@ def ds_td_q_vs_understood() -> None:
                               index=False)
 
 
-def vg07_vg09_vg09b_q_by_age() -> None:
-    """Three-way overlay of q(age) for VG07, VG09 and VG09B.
+def vg07_vg09_vg10_q_by_age() -> None:
+    """Three-way overlay of q(age) for VG07, VG09 and VG10.
 
     VG07 has no subject REs on q (the pre-redundancy baseline).
     VG09 adds subject REs on U and q with an unanchored GP.
-    VG09B is VG09 with tighter q-anchor priors and the GP anchored
+    VG10 is VG09 with tighter q-anchor priors and the GP anchored
     to zero at the reference age (see notes/202605131500-...).
     """
     vg07 = pd.read_csv(
@@ -215,10 +215,10 @@ def vg07_vg09_vg09b_q_by_age() -> None:
         os.path.join(MODELS_DIR, "VG09-age-understood-spoken-ds-re-subj-uq",
                      "posterior_summary_q.csv")
     )
-    vg09b = pd.read_csv(
+    vg10 = pd.read_csv(
         os.path.join(
             MODELS_DIR,
-            "VG09B-age-understood-spoken-ds-re-subj-uq-anchored",
+            "VG10-age-understood-spoken-ds-re-subj-uq-anchored",
             "posterior_summary_q.csv",
         )
     )
@@ -226,7 +226,7 @@ def vg07_vg09_vg09b_q_by_age() -> None:
     series = [
         ("VG07 (no subject RE on q)", vg07, plot_styles.COLOUR_PURPLE),
         ("VG09 (subj REs, GP unanchored)", vg09, plot_styles.COLOUR_BLUE),
-        ("VG09B (subj REs, GP anchored at 54mo)", vg09b, plot_styles.COLOUR_GREEN),
+        ("VG10 (subj REs, GP anchored at 54mo)", vg10, plot_styles.COLOUR_GREEN),
     ]
 
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
@@ -246,11 +246,11 @@ def vg07_vg09_vg09b_q_by_age() -> None:
     ax.set_ylabel(r"Production ratio  q = $p_S$ / $p_U$")
     ax.set_ylim(0, 1)
     ax.set_title(
-        "Production ratio q(age) — VG07 vs VG09 vs VG09B (DS, rep config)"
+        "Production ratio q(age) — VG07 vs VG09 vs VG10 (DS, rep config)"
     )
     ax.legend(loc="lower right", frameon=True, fontsize="small")
-    fig.savefig(os.path.join(OUT_DIR, "vg07_vg09_vg09b_q_by_age.png"))
-    fig.savefig(os.path.join(OUT_DIR, "vg07_vg09_vg09b_q_by_age.svg"))
+    fig.savefig(os.path.join(OUT_DIR, "vg07_vg09_vg10_q_by_age.png"))
+    fig.savefig(os.path.join(OUT_DIR, "vg07_vg09_vg10_q_by_age.svg"))
     plt.close(fig)
 
     merged = vg07[["age_months", "q_median", "q_hdi_lo", "q_hdi_hi"]].rename(
@@ -267,21 +267,21 @@ def vg07_vg09_vg09b_q_by_age() -> None:
         on="age_months",
     )
     merged = merged.merge(
-        vg09b[["age_months", "q_median", "q_hdi_lo", "q_hdi_hi"]].rename(
-            columns={"q_median": "vg09b_median",
-                     "q_hdi_lo": "vg09b_hdi_lo",
-                     "q_hdi_hi": "vg09b_hdi_hi"}
+        vg10[["age_months", "q_median", "q_hdi_lo", "q_hdi_hi"]].rename(
+            columns={"q_median": "vg10_median",
+                     "q_hdi_lo": "vg10_hdi_lo",
+                     "q_hdi_hi": "vg10_hdi_hi"}
         ),
         on="age_months",
     )
     merged.to_csv(
-        os.path.join(OUT_DIR, "vg07_vg09_vg09b_q_by_age.csv"),
+        os.path.join(OUT_DIR, "vg07_vg09_vg10_q_by_age.csv"),
         index=False,
     )
 
 
-def ds_td_q_by_age_vg09b() -> None:
-    """DS (VG09B) vs TD (VG06) production-ratio overlay against age.
+def ds_td_q_by_age_vg10() -> None:
+    """DS (VG10) vs TD (VG06) production-ratio overlay against age.
 
     Visualises the chronological production lag: at any given age the
     DS curve sits well below the TD curve, and reaches the same
@@ -290,7 +290,7 @@ def ds_td_q_by_age_vg09b() -> None:
     ds = pd.read_csv(
         os.path.join(
             MODELS_DIR,
-            "VG09B-age-understood-spoken-ds-re-subj-uq-anchored",
+            "VG10-age-understood-spoken-ds-re-subj-uq-anchored",
             "posterior_summary_q.csv",
         )
     )
@@ -309,7 +309,7 @@ def ds_td_q_by_age_vg09b() -> None:
     ax.plot(td["age_months"], td["q_median"], color=TD_COLOUR, lw=2.5,
             label="TD median q (VG06)")
     ax.plot(ds["age_months"], ds["q_median"], color=DS_COLOUR, lw=2.5,
-            label="DS median q (VG09B)")
+            label="DS median q (VG10)")
     for thresh in (0.5, 0.9):
         ax.axhline(thresh, color=plot_styles.LINE_COLOUR, lw=0.6,
                    linestyle="--")
@@ -318,10 +318,10 @@ def ds_td_q_by_age_vg09b() -> None:
     ax.set_ylim(0, 1)
     ax.set_xlabel("Age (months)")
     ax.set_ylabel(r"Production ratio  q = $p_S$ / $p_U$")
-    ax.set_title("Production ratio by age — DS (VG09B) vs TD (VG06)")
+    ax.set_title("Production ratio by age — DS (VG10) vs TD (VG06)")
     ax.legend(loc="lower right", frameon=True)
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_by_age_vg09b.png"))
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_by_age_vg09b.svg"))
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_by_age_vg10.png"))
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_by_age_vg10.svg"))
     plt.close(fig)
 
     merged = (
@@ -340,22 +340,22 @@ def ds_td_q_by_age_vg09b() -> None:
         .sort_values("age_months")
     )
     merged.to_csv(
-        os.path.join(OUT_DIR, "ds_td_q_by_age_vg09b.csv"),
+        os.path.join(OUT_DIR, "ds_td_q_by_age_vg10.csv"),
         index=False,
     )
 
 
-def ds_td_q_vs_understood_vg09b() -> None:
-    """DS (VG09B) vs TD (VG06) production-ratio against words understood.
+def ds_td_q_vs_understood_vg10() -> None:
+    """DS (VG10) vs TD (VG06) production-ratio against words understood.
 
-    Updated matched-comprehension overlay using VG09B as the headline
+    Updated matched-comprehension overlay using VG10 as the headline
     DS joint model. Preserves the original VG09-based figure for
     backward compatibility.
     """
     ds = pd.read_csv(
         os.path.join(
             MODELS_DIR,
-            "VG09B-age-understood-spoken-ds-re-subj-uq-anchored",
+            "VG10-age-understood-spoken-ds-re-subj-uq-anchored",
             "production_rate_by_understood.csv",
         )
     )
@@ -374,7 +374,7 @@ def ds_td_q_vs_understood_vg09b() -> None:
     ax.plot(td["words_understood"], td["q_median"], color=TD_COLOUR, lw=2.5,
             label="TD median q (VG06)")
     ax.plot(ds["words_understood"], ds["q_median"], color=DS_COLOUR, lw=2.5,
-            label="DS median q (VG09B)")
+            label="DS median q (VG10)")
     for thresh in (0.5, 0.9):
         ax.axhline(thresh, color=plot_styles.LINE_COLOUR, lw=0.6,
                    linestyle="--")
@@ -384,11 +384,11 @@ def ds_td_q_vs_understood_vg09b() -> None:
     ax.set_xlabel("Expected words understood")
     ax.set_ylabel(r"Production ratio  q = $p_S$ / $p_U$")
     ax.set_title(
-        "Production ratio against words understood — DS (VG09B) vs TD (VG06)"
+        "Production ratio against words understood — DS (VG10) vs TD (VG06)"
     )
     ax.legend(loc="lower right", frameon=True)
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg09b.png"))
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg09b.svg"))
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg10.png"))
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg10.svg"))
     plt.close(fig)
 
 
@@ -400,9 +400,9 @@ def main() -> None:
     ds_td_understood_by_age()
     vg05_vs_vg07()
     ds_td_q_vs_understood()
-    vg07_vg09_vg09b_q_by_age()
-    ds_td_q_by_age_vg09b()
-    ds_td_q_vs_understood_vg09b()
+    vg07_vg09_vg10_q_by_age()
+    ds_td_q_by_age_vg10()
+    ds_td_q_vs_understood_vg10()
 
     print(f"Comparisons written to: {OUT_DIR}")
 

--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -23,7 +23,7 @@ from vocab_growth.models import (
     model_vg07,
     model_vg08,
     model_vg09,
-    model_vg09b,
+    model_vg10,
 )
 from vocab_growth.reporting import (
     console,
@@ -75,7 +75,7 @@ if __name__ == "__main__":
         "vg07": model_vg07,
         "vg08": model_vg08,
         "vg09": model_vg09,
-        "vg09b": model_vg09b,
+        "vg10": model_vg10,
     }
 
     if args.model == "all":

--- a/scripts/loo_compare.py
+++ b/scripts/loo_compare.py
@@ -48,7 +48,7 @@ BIVARIATE = {
     "VG07": "VG07-age-understood-spoken-ds-re",
     "VG08": "VG08-age-understood-spoken-ds-re-subj",
     "VG09": "VG09-age-understood-spoken-ds-re-subj-uq",
-    "VG09B": "VG09B-age-understood-spoken-ds-re-subj-uq-anchored",
+    "VG10": "VG10-age-understood-spoken-ds-re-subj-uq-anchored",
 }
 
 MODEL_LABELS = {**UNIVARIATE, **BIVARIATE}

--- a/scripts/prior_vs_posterior.py
+++ b/scripts/prior_vs_posterior.py
@@ -36,7 +36,7 @@ from vocab_growth.models.definitions import (
     VG07,
     VG08,
     VG09,
-    VG09B,
+    VG10,
     BivariateModelDefinition,
     UnivariateModelDefinition,
 )
@@ -53,7 +53,7 @@ MODEL_LABELS = {
     "VG07": ("VG07-age-understood-spoken-ds-re", VG07),
     "VG08": ("VG08-age-understood-spoken-ds-re-subj", VG08),
     "VG09": ("VG09-age-understood-spoken-ds-re-subj-uq", VG09),
-    "VG09B": ("VG09B-age-understood-spoken-ds-re-subj-uq-anchored", VG09B),
+    "VG10": ("VG10-age-understood-spoken-ds-re-subj-uq-anchored", VG10),
 }
 
 

--- a/scripts/time_to_milestone.py
+++ b/scripts/time_to_milestone.py
@@ -52,7 +52,7 @@ BIVARIATE = {
     "VG07": ("VG07-age-understood-spoken-ds-re", "DS"),
     "VG08": ("VG08-age-understood-spoken-ds-re-subj", "DS"),
     "VG09": ("VG09-age-understood-spoken-ds-re-subj-uq", "DS"),
-    "VG09B": ("VG09B-age-understood-spoken-ds-re-subj-uq-anchored", "DS"),
+    "VG10": ("VG10-age-understood-spoken-ds-re-subj-uq-anchored", "DS"),
 }
 
 

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -22,7 +22,7 @@ MODEL_CONFIGS = {
     "vg07": ("VG07", "age-understood-spoken-ds-re"),
     "vg08": ("VG08", "age-understood-spoken-ds-re-subj"),
     "vg09": ("VG09", "age-understood-spoken-ds-re-subj-uq"),
-    "vg09b": ("VG09B", "age-understood-spoken-ds-re-subj-uq-anchored"),
+    "vg10": ("VG10", "age-understood-spoken-ds-re-subj-uq-anchored"),
 }
 
 if __name__ == "__main__":
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "model",
         type=str,
-        help="Model id (vg01, vg02, vg03, vg04, vg05, vg06, vg07, vg08, vg09, vg09b) or 'all'.",
+        help="Model id (vg01, vg02, vg03, vg04, vg05, vg06, vg07, vg08, vg09, vg10) or 'all'.",
     )
     parser.add_argument(
         "--include-traces",

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -378,11 +378,11 @@ VG09 = BivariateModelDefinition(
     tau_subj_q_sigma=0.5,
 )
 
-VG09B = BivariateModelDefinition(
-    model_id="VG09B",
+VG10 = BivariateModelDefinition(
+    model_id="VG10",
     config_name="age-understood-spoken-ds-re-subj-uq-anchored",
     banner=(
-        "Fitting Model VG09B: VG09 + tighter q anchor priors + GP anchored at"
+        "Fitting Model VG10: VG09 + tighter q anchor priors + GP anchored at"
         " reference age (A -> U, A -> S, U -> S) - Down syndrome"
     ),
     population=Population.DOWN_SYNDROME,
@@ -420,5 +420,5 @@ MODEL_REGISTRY: dict[str, UnivariateModelDefinition | BivariateModelDefinition] 
     "vg07": VG07,
     "vg08": VG08,
     "vg09": VG09,
-    "vg09b": VG09B,
+    "vg10": VG10,
 }

--- a/src/vocab_growth/models/model_vg10.py
+++ b/src/vocab_growth/models/model_vg10.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 """
-Model VG09B: VG09 variant with tighter q-anchor priors (Option A) and the
+Model VG10: VG09 variant with tighter q-anchor priors (Option A) and the
 HSGP correction terms anchored to zero at a reference age (Option D).
 
 Variant of VG09 introduced to test whether the marginal r_hat / ess_tail
@@ -15,8 +15,8 @@ from vocab_growth.models.common_bivariate_re import (
     BivariateREContext,
     fit_bivariate_re_model,
 )
-from vocab_growth.models.definitions import VG09B
+from vocab_growth.models.definitions import VG10
 
 
 def fit(config: str) -> BivariateREContext:
-    return fit_bivariate_re_model(config, VG09B)
+    return fit_bivariate_re_model(config, VG10)


### PR DESCRIPTION
## Summary

- Renames `model_vg09b.py` → `model_vg10.py` and updates the module docstring
- Updates `definitions.py`: `VG09B` constant → `VG10`, dict key `"vg09b"` → `"vg10"`, output directory slug prefix `VG09B-` → `VG10-`
- Updates all scripts that reference the model: `fit_model.py`, `upload.py`, `compare_models.py`, `compare_ds_td_q_vs_understood.py`, `compare_ds_td_trajectories.py`, `compare_ds_td_latency.py`, `compare_ds_td_q_overlap.py`, `aggregate_summary.py`, `time_to_milestone.py`, `prior_vs_posterior.py`, `loo_compare.py`
- Renames `docs/models/vg09b/` → `docs/models/vg10/` and updates the Quarto report title and prose
- Adds VG10 to the model table and model ID list in `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md`
- Historical research notes (`notes/202605141200-vg09b-findings.md` etc.) intentionally retain the VG09B name

## After merging

Re-fit and re-upload under the new name:

\`\`\`bash
python scripts/fit_model.py vg10 --config rep
python scripts/upload.py vg10
\`\`\`

Any existing `VG09B-...` blobs in Azure can be deleted manually once the new output is confirmed.