### PR TITLE
fix(models): use ArviZ 1.1 axis convention for az.hdi in bivariate models

### DIFF
--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -1173,7 +1173,7 @@ def posterior_summary(context: BivariateContext):
 
     # Production rate summary
     q_query_median = np.median(samples.q_query, axis=1)
-    q_query_hdi = az.hdi(samples.q_query.T, prob=hdi_prob)
+    q_query_hdi = az.hdi(samples.q_query, prob=hdi_prob)
 
     summary_q = pd.DataFrame(
         {
@@ -1274,13 +1274,13 @@ def plot_understood_spoken_trajectory_hdi(
 
     # Understood HDI bands
     y_u_median = np.median(samples.y_u_plot, axis=1)
-    y_u_hdi_75 = az.hdi(samples.y_u_plot.T, prob=0.75)
-    y_u_hdi_50 = az.hdi(samples.y_u_plot.T, prob=0.50)
+    y_u_hdi_75 = az.hdi(samples.y_u_plot, prob=0.75)
+    y_u_hdi_50 = az.hdi(samples.y_u_plot, prob=0.50)
 
     # Spoken HDI bands
     y_s_median = np.median(samples.y_s_plot, axis=1)
-    y_s_hdi_75 = az.hdi(samples.y_s_plot.T, prob=0.75)
-    y_s_hdi_50 = az.hdi(samples.y_s_plot.T, prob=0.50)
+    y_s_hdi_75 = az.hdi(samples.y_s_plot, prob=0.75)
+    y_s_hdi_50 = az.hdi(samples.y_s_plot, prob=0.50)
 
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
 
@@ -1330,9 +1330,9 @@ def plot_production_rate(
     q_plot = samples.q_plot
 
     q_median = np.median(q_plot, axis=1)
-    q_hdi = az.hdi(q_plot.T, prob=hdi_prob)
-    q_hdi_75 = az.hdi(q_plot.T, prob=0.75)
-    q_hdi_50 = az.hdi(q_plot.T, prob=0.50)
+    q_hdi = az.hdi(q_plot, prob=hdi_prob)
+    q_hdi_75 = az.hdi(q_plot, prob=0.75)
+    q_hdi_50 = az.hdi(q_plot, prob=0.50)
 
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
 
@@ -1395,9 +1395,9 @@ def plot_production_rate_by_understood(
 
     x_words = np.median(p_u_plot, axis=1) * n_trials
     q_median = np.median(q_plot, axis=1)
-    q_hdi = az.hdi(q_plot.T, prob=hdi_prob)
-    q_hdi_75 = az.hdi(q_plot.T, prob=0.75)
-    q_hdi_50 = az.hdi(q_plot.T, prob=0.50)
+    q_hdi = az.hdi(q_plot, prob=hdi_prob)
+    q_hdi_75 = az.hdi(q_plot, prob=0.75)
+    q_hdi_50 = az.hdi(q_plot, prob=0.50)
 
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
 
@@ -1530,8 +1530,8 @@ def plot_comprehension_production_gap(
     gap = (samples.p_u_plot - samples.p_s_plot) * n_trials  # in word count units
 
     gap_median = np.median(gap, axis=1)
-    gap_hdi = az.hdi(gap.T, prob=hdi_prob)
-    gap_hdi_50 = az.hdi(gap.T, prob=0.50)
+    gap_hdi = az.hdi(gap, prob=hdi_prob)
+    gap_hdi_50 = az.hdi(gap, prob=0.50)
 
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
 


### PR DESCRIPTION
## Summary

A full reporting-config fit of all 10 models surfaced a post-migration bug: **all 6 joint models (VG05–VG10) sampled successfully but crashed *after* sampling** in `posterior_summary` with `ValueError: All arrays must be of the same length`. The single-outcome models (VG01–VG04) were unaffected.

## Root cause

The PyMC 6 / ArviZ 1 migration (#28) brought ArviZ 1.1, which **changed `az.hdi`'s axis convention**. For a plain `(n_points, n_samples)` ndarray, ArviZ 1.1 now expects the **sample axis last** and returns one HDI per leading-axis element.

The bivariate code (`common_bivariate.py`) still called `az.hdi(X.T, ...)` — written for the old samples-first convention — so it produced `n_samples` intervals instead of `n_points`. The resulting `q_hdi_*`/band arrays no longer matched the length of `X_query`/`X_plot`, which blew up when assembling the summary `DataFrame`.

Confirmed empirically in the current env (arviz 1.1.0):
- `az.hdi(arr, prob=0.9)` for `arr` shaped `(n_points, n_samples)` → `(n_points, 2)` ✅
- `az.hdi(arr.T, prob=0.9)` → `(n_samples, 2)` ❌

The single-outcome models summarise via `posterior_analysis.posterior_summary_table`, which already uses the correct convention — hence VG01–VG04 passed.

## Change

Drop the now-incorrect `.T` from all 13 `az.hdi(X.T, prob=...)` calls in `posterior_summary` and the bivariate plotting helpers (`plot_understood_spoken_trajectory_hdi`, `plot_production_rate`, `plot_production_rate_by_understood`, `plot_comprehension_production_gap`). The per-age 1-D `az.hdi(ratio_i, ...)` calls were already correct and are unchanged.

## Verification

- `vg05` (bivariate) and `vg07` (bivariate-RE) now complete end-to-end (dev config), producing `posterior_summary_q.csv` plus all bivariate plots and the report.
- `ruff check` passes.
- Sampling/convergence are unaffected (post-sampling-only change). The full reporting suite shows healthy convergence across all 10 models (max R̂ ≤ 1.008, no ESS < 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)