### PR TITLE
refactor: consolidate model-comparison code into vocab_growth.comparison

### DIFF
--- a/scripts/compare_ds_td.py
+++ b/scripts/compare_ds_td.py
@@ -1,18 +1,13 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-Builds overlay comparisons between the Down-syndrome bivariate model with
-study random intercepts (VG07) and the typically-developing bivariate
-model (VG06).
+DEPRECATED — superseded by ``scripts/compare_models.py``.
 
-Reads `production_rate_by_understood.csv` from both model output
-directories and produces:
-
-- `output/comparisons/ds_td_q_vs_understood.{svg,png}` — overlay plot of the
-  production ratio q against words understood for both populations.
-- `output/comparisons/ds_td_q_crossings.csv` — words understood at which each
-  population reaches q = 0.25, 0.50, 0.75, 0.90, with the same threshold
-  applied to the 5% and 95% HDI bands.
+This one-off produced the early VG07-vs-VG06 ``ds_td_q_vs_understood`` overlay
+and ``ds_td_q_crossings.csv``. The canonical figure (DS VG09 vs TD VG06, with
+VG07 as a dashed reference) is now produced by
+``compare_models.ds_td_q_vs_understood``. This shim delegates there so the
+output files stay in sync; please call ``compare_models.py`` directly.
 """
 
 from __future__ import annotations
@@ -20,122 +15,18 @@ from __future__ import annotations
 import os
 
 import dse_research_utils.plot.styles as plot_styles
-import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
-
-VG06_DIR = "output/models/VG06-age-understood-spoken-td"
-VG07_DIR = "output/models/VG07-age-understood-spoken-ds-re"
-OUT_DIR = "output/comparisons"
-
-DS_COLOUR = plot_styles.COLOUR_BLUE
-DS_FILL = plot_styles.COLOUR_BLUE
-TD_COLOUR = plot_styles.COLOUR_ORANGE
-TD_FILL = plot_styles.COLOUR_ORANGE
+from compare_models import OUT_DIR, ds_td_q_vs_understood
 
 
-def first_crossing(x: np.ndarray, y: np.ndarray, threshold: float) -> float | None:
-    """Return the x value at which a monotone-ish curve y first crosses
-    `threshold`, using linear interpolation. Returns None if no crossing."""
-    above = y >= threshold
-    if not above.any():
-        return None
-    if above.all():
-        return float(x[0])
-    i = int(np.argmax(above))
-    if i == 0:
-        return float(x[0])
-    x0, x1 = float(x[i - 1]), float(x[i])
-    y0, y1 = float(y[i - 1]), float(y[i])
-    if y1 == y0:
-        return x1
-    return x0 + (threshold - y0) * (x1 - x0) / (y1 - y0)
-
-
-def main() -> None:
+def _main() -> None:
+    print(
+        "[deprecated] compare_ds_td.py is superseded by compare_models.py; "
+        "delegating to compare_models.ds_td_q_vs_understood().",
+    )
     plot_styles.set_matplotlib_default_style()
     os.makedirs(OUT_DIR, exist_ok=True)
-
-    ds = pd.read_csv(os.path.join(VG07_DIR, "production_rate_by_understood.csv"))
-    td = pd.read_csv(os.path.join(VG06_DIR, "production_rate_by_understood.csv"))
-
-    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-
-    ax.fill_between(
-        td["words_understood"],
-        td["hdi_lo"],
-        td["hdi_hi"],
-        color=TD_FILL,
-        alpha=0.18,
-        linewidth=0,
-        label="TD 90% HDI",
-    )
-    ax.fill_between(
-        ds["words_understood"],
-        ds["hdi_lo"],
-        ds["hdi_hi"],
-        color=DS_FILL,
-        alpha=0.18,
-        linewidth=0,
-        label="DS 90% HDI",
-    )
-    ax.plot(
-        td["words_understood"], td["q_median"], color=TD_COLOUR, lw=2.5,
-        label="TD median q (VG06)",
-    )
-    ax.plot(
-        ds["words_understood"], ds["q_median"], color=DS_COLOUR, lw=2.5,
-        label="DS median q (VG07)",
-    )
-
-    for thresh in (0.5, 0.9):
-        ax.axhline(thresh, color=plot_styles.LINE_COLOUR, lw=0.6, linestyle="--")
-
-    ax.set_xlim(0, max(td["words_understood"].max(), ds["words_understood"].max()))
-    ax.set_ylim(0, 1)
-    ax.set_xlabel("Expected words understood")
-    ax.set_ylabel(r"Production ratio  q = $p_S$ / $p_U$")
-    ax.set_title(
-        "Production ratio against words understood — DS (VG07) vs TD (VG06)"
-    )
-    ax.legend(loc="lower right", frameon=True)
-
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood.png"))
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood.svg"))
-
-    rows = []
-    for label, df in (("DS (VG07)", ds), ("TD (VG06)", td)):
-        for thresh in (0.25, 0.5, 0.75, 0.90):
-            rows.append({
-                "population": label,
-                "threshold": thresh,
-                "n_understood_at_median": first_crossing(
-                    df["words_understood"].to_numpy(),
-                    df["q_median"].to_numpy(),
-                    thresh,
-                ),
-                "n_understood_at_hdi_lo": first_crossing(
-                    df["words_understood"].to_numpy(),
-                    df["hdi_lo"].to_numpy(),
-                    thresh,
-                ),
-                "n_understood_at_hdi_hi": first_crossing(
-                    df["words_understood"].to_numpy(),
-                    df["hdi_hi"].to_numpy(),
-                    thresh,
-                ),
-            })
-    crossings = pd.DataFrame(rows)
-    crossings.to_csv(os.path.join(OUT_DIR, "ds_td_q_crossings.csv"), index=False)
-
-    print(crossings.to_string(index=False))
-    print(
-        "\nSaved: "
-        f"{os.path.join(OUT_DIR, 'ds_td_q_vs_understood.svg')}\n"
-        f"       {os.path.join(OUT_DIR, 'ds_td_q_vs_understood.png')}\n"
-        f"       {os.path.join(OUT_DIR, 'ds_td_q_crossings.csv')}"
-    )
+    ds_td_q_vs_understood()
 
 
 if __name__ == "__main__":
-    main()
+    _main()

--- a/scripts/compare_ds_td_latency.py
+++ b/scripts/compare_ds_td_latency.py
@@ -12,175 +12,57 @@ count N:
 - extra(N) = U(a_S(N)) - N          (extra words understood when S first hits N)
 
 Both quantities are computed per posterior draw on each model's population-
-level latent trajectory (no study or subject REs, i.e. matching Figure 22 /
-27 in the report). Results are summarised as median + 50% / 90% HDI across
-draws and written as CSVs, then plotted as a two-panel DS-vs-TD figure.
+level latent trajectory (no study or subject REs). Results are summarised as
+median + 50% / 90% HDI across draws and written as CSVs, then plotted as a
+two-panel DS-vs-TD figure.
 
-Outputs in `output/comparisons/`:
-- `ds_td_learn_to_say_latency_DA.csv`
-- `ds_td_learn_to_say_latency_extra.csv`
-- `ds_td_learn_to_say_latency.{png,svg}`
+The numerical helpers live in ``vocab_growth.comparison``; this script is a thin
+CLI wrapper. Model pairs are resolved from ``MODEL_REGISTRY`` keys, so changing
+the compared models is a one-line edit here (or add a new registry entry).
+
+Outputs in ``output/comparisons/``:
+- ``ds_td_learn_to_say_latency_DA.csv``
+- ``ds_td_learn_to_say_latency_extra.csv``
+- ``ds_td_learn_to_say_latency.{png,svg}``
 """
 
 from __future__ import annotations
 
 import os
 
-import arviz as az
 import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
-DS_DIR = "output/models/VG10-age-understood-spoken-ds-re-subj-uq-anchored"
-TD_DIR = "output/models/VG06-age-understood-spoken-td"
-OUT_DIR = "output/comparisons"
+from vocab_growth import comparison
 
-# n_trials is model-specific. See src/vocab_growth/models/definitions.py.
-# VG10: 800-item DS inventory.
-# VG06: 800-item TD reference inventory. WG and Oxford CDI contribute
-#       bivariate observations; WS is production-only in Wordbank and
-#       contributes spoken observations only.
-N_TRIALS_DS = 800
-N_TRIALS_TD = 800
-MIN_COVERAGE = 0.80  # require at least 80% of draws to have a valid crossing
+# Re-exported for backward compatibility with verify_ds_td_latency.py and
+# compare_ds_td_q_overlap.py, which import these names from this module.
+from vocab_growth.comparison import (  # noqa: F401
+    compute_latency,
+    evaluate_at_ages,
+    first_crossing_age,
+    hdi_from_samples,
+    load_population_trajectory,
+    summarise_per_N,
+)
+
+DS_KEY = "vg10"
+TD_KEY = "vg06"
+
+DS_DIR = comparison.model_dir(DS_KEY)
+TD_DIR = comparison.model_dir(TD_KEY)
+OUT_DIR = os.path.join("output", "comparisons")
+
+N_TRIALS_DS = comparison.n_trials(DS_KEY)
+N_TRIALS_TD = comparison.n_trials(TD_KEY)
+MIN_COVERAGE = 0.80
 N_GRID = np.array(
     [5, 10, 15, 20, 25, 30, 40, 50, 75, 100, 125, 150, 175, 200,
      250, 300, 350, 400, 450, 500, 550, 600],
     dtype=float,
 )
-
-
-def load_population_trajectory(trace_path: str, n_trials: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Return (ages, U, S) where U and S are (n_draw, n_age) word counts at the population level.
-
-    ``n_trials`` must match the inventory size used when the model was fit
-    (see src/vocab_growth/models/definitions.py).
-    """
-    d = az.from_netcdf(trace_path)
-    p_u = d.posterior["p_u_plot"].values  # (chain, draw, n_age)
-    p_s = d.posterior["p_s_plot"].values
-    n_chain, n_draw, n_age = p_u.shape
-    p_u = p_u.reshape(n_chain * n_draw, n_age)
-    p_s = p_s.reshape(n_chain * n_draw, n_age)
-    ages = d.constant_data["X_plot"].values.astype(float)
-    U = p_u * n_trials
-    S = p_s * n_trials
-    # Ensure ages are sorted (they are by construction, but guard)
-    order = np.argsort(ages)
-    return ages[order], U[:, order], S[:, order]
-
-
-def first_crossing_age(Y: np.ndarray, ages: np.ndarray, N: float) -> np.ndarray:
-    """For each row of Y (a draw), return the first age where Y >= N.
-
-    Linear interpolation between adjacent grid points. NaN where never reached.
-    """
-    mask = Y >= N  # (n_draw, n_age)
-    any_above = mask.any(axis=1)
-    first_idx = mask.argmax(axis=1)  # 0 if no crossing or already-above at idx 0
-
-    j = first_idx
-    j_prev = np.maximum(j - 1, 0)
-    y0 = np.take_along_axis(Y, j_prev[:, None], axis=1).squeeze(1)
-    y1 = np.take_along_axis(Y, j[:, None], axis=1).squeeze(1)
-    a0 = ages[j_prev]
-    a1 = ages[j]
-
-    with np.errstate(invalid="ignore", divide="ignore"):
-        denom = y1 - y0
-        interp = np.where(denom == 0, a1, a0 + (N - y0) * (a1 - a0) / denom)
-
-    crossing = np.where(j == 0, ages[0], interp)
-    crossing = np.where(any_above, crossing, np.nan)
-    return crossing
-
-
-def evaluate_at_ages(Y: np.ndarray, ages: np.ndarray, target_ages: np.ndarray) -> np.ndarray:
-    """Linearly interpolate each row of Y at target_ages (per-row), returning NaN out of range."""
-    n_draw, n_age = Y.shape
-    idx = np.searchsorted(ages, target_ages, side="right")
-    idx = np.clip(idx, 1, n_age - 1)
-    a_lo = ages[idx - 1]
-    a_hi = ages[idx]
-    Y_lo = np.take_along_axis(Y, (idx - 1)[:, None], axis=1).squeeze(1)
-    Y_hi = np.take_along_axis(Y, idx[:, None], axis=1).squeeze(1)
-    with np.errstate(invalid="ignore", divide="ignore"):
-        t = (target_ages - a_lo) / (a_hi - a_lo)
-        out = Y_lo + t * (Y_hi - Y_lo)
-    out_of_range = (target_ages < ages[0]) | (target_ages > ages[-1]) | np.isnan(target_ages)
-    return np.where(out_of_range, np.nan, out)
-
-
-def hdi_from_samples(x: np.ndarray, prob: float) -> tuple[float, float]:
-    """Return HDI bounds of 1-D array x at given probability, ignoring NaN."""
-    x = x[~np.isnan(x)]
-    if x.size == 0:
-        return np.nan, np.nan
-    x_sorted = np.sort(x)
-    n = x_sorted.size
-    k = int(np.floor(prob * n))
-    if k >= n:
-        return float(x_sorted[0]), float(x_sorted[-1])
-    widths = x_sorted[k:] - x_sorted[: n - k]
-    i = int(np.argmin(widths))
-    return float(x_sorted[i]), float(x_sorted[i + k])
-
-
-def summarise_per_N(samples: np.ndarray, N_grid: np.ndarray) -> pd.DataFrame:
-    """Median + 50% / 90% HDI across draws (axis=0), with coverage fraction."""
-    rows = []
-    n_draw = samples.shape[0]
-    for i, N in enumerate(N_grid):
-        col = samples[:, i]
-        valid = ~np.isnan(col)
-        n_valid = int(valid.sum())
-        cov = n_valid / n_draw
-        if n_valid == 0:
-            rows.append({"N": N, "coverage": cov, "median": np.nan,
-                         "hdi50_lo": np.nan, "hdi50_hi": np.nan,
-                         "hdi90_lo": np.nan, "hdi90_hi": np.nan})
-            continue
-        med = float(np.nanmedian(col))
-        l50, u50 = hdi_from_samples(col, 0.50)
-        l90, u90 = hdi_from_samples(col, 0.90)
-        rows.append({"N": N, "coverage": cov, "median": med,
-                     "hdi50_lo": l50, "hdi50_hi": u50,
-                     "hdi90_lo": l90, "hdi90_hi": u90})
-    return pd.DataFrame(rows)
-
-
-def compute_latency(ages: np.ndarray, U: np.ndarray, S: np.ndarray,
-                    N_grid: np.ndarray) -> tuple[pd.DataFrame, pd.DataFrame]:
-    """Compute DA(N) and extra(N) per draw, then summarise."""
-    n_draw = U.shape[0]
-    n_N = len(N_grid)
-    DA = np.full((n_draw, n_N), np.nan)
-    extra = np.full((n_draw, n_N), np.nan)
-    for i, N in enumerate(N_grid):
-        a_U = first_crossing_age(U, ages, N)
-        a_S = first_crossing_age(S, ages, N)
-        DA[:, i] = a_S - a_U
-        U_at_a_S = evaluate_at_ages(U, ages, a_S)
-        extra[:, i] = U_at_a_S - N
-    da_df = summarise_per_N(DA, N_grid)
-    extra_df = summarise_per_N(extra, N_grid)
-    return da_df, extra_df
-
-
-def plot_population_panel(ax, df: pd.DataFrame, label: str, colour: str) -> None:
-    df_ok = df[df["coverage"] >= MIN_COVERAGE].copy()
-    if df_ok.empty:
-        return
-    ax.fill_between(
-        df_ok["N"], df_ok["hdi90_lo"], df_ok["hdi90_hi"],
-        color=colour, alpha=0.15, linewidth=0, label=f"{label} 90% HDI",
-    )
-    ax.fill_between(
-        df_ok["N"], df_ok["hdi50_lo"], df_ok["hdi50_hi"],
-        color=colour, alpha=0.30, linewidth=0, label=f"{label} 50% HDI",
-    )
-    ax.plot(df_ok["N"], df_ok["median"], color=colour, lw=2.5, label=f"{label} median")
 
 
 def main() -> None:
@@ -211,8 +93,8 @@ def main() -> None:
     fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
     ax = axes[0]
-    plot_population_panel(ax, da_ds, "DS (VG10)", plot_styles.COLOUR_BLUE)
-    plot_population_panel(ax, da_td, "TD (VG06)", plot_styles.COLOUR_ORANGE)
+    comparison.plot_summary_band(ax, da_ds, "N", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
+    comparison.plot_summary_band(ax, da_td, "N", "TD (VG06)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
     ax.set_xlabel("Vocabulary count N (words)")
     ax.set_ylabel(r"$\Delta A(N) = a_S(N) - a_U(N)$  (months)")
     ax.set_title("Age lag between understanding and saying N words")
@@ -221,8 +103,8 @@ def main() -> None:
     ax.grid(True, which="both", alpha=0.3)
 
     ax = axes[1]
-    plot_population_panel(ax, extra_ds, "DS (VG10)", plot_styles.COLOUR_BLUE)
-    plot_population_panel(ax, extra_td, "TD (VG06)", plot_styles.COLOUR_ORANGE)
+    comparison.plot_summary_band(ax, extra_ds, "N", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
+    comparison.plot_summary_band(ax, extra_td, "N", "TD (VG06)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
     ax.set_xlabel("Spoken count N (words)")
     ax.set_ylabel("Extra words understood when first saying N  (= U(a_S(N)) - N)")
     ax.set_title("Vocabulary lag at production-matched points")
@@ -248,18 +130,11 @@ def main() -> None:
     ]:
         print(f"  {os.path.join(OUT_DIR, f)}")
 
-    print("\n--- DS DA(N) summary (months) ---")
-    print(da_ds[da_ds["coverage"] >= MIN_COVERAGE]
-          [["N", "median", "hdi50_lo", "hdi50_hi", "coverage"]].to_string(index=False))
-    print("\n--- TD DA(N) summary (months) ---")
-    print(da_td[da_td["coverage"] >= MIN_COVERAGE]
-          [["N", "median", "hdi50_lo", "hdi50_hi", "coverage"]].to_string(index=False))
-    print("\n--- DS extra(N) summary (words) ---")
-    print(extra_ds[extra_ds["coverage"] >= MIN_COVERAGE]
-          [["N", "median", "hdi50_lo", "hdi50_hi", "coverage"]].to_string(index=False))
-    print("\n--- TD extra(N) summary (words) ---")
-    print(extra_td[extra_td["coverage"] >= MIN_COVERAGE]
-          [["N", "median", "hdi50_lo", "hdi50_hi", "coverage"]].to_string(index=False))
+    for name, df in (("DS DA(N)", da_ds), ("TD DA(N)", da_td),
+                     ("DS extra(N)", extra_ds), ("TD extra(N)", extra_td)):
+        print(f"\n--- {name} summary ---")
+        print(df[df["coverage"] >= MIN_COVERAGE]
+              [["N", "median", "hdi50_lo", "hdi50_hi", "coverage"]].to_string(index=False))
 
 
 if __name__ == "__main__":

--- a/scripts/compare_ds_td_q_overlap.py
+++ b/scripts/compare_ds_td_q_overlap.py
@@ -7,22 +7,21 @@ Two views:
 
   (A) q at matched **comprehension** level U = N — strips age out, asking
       "given that a child understands N words, what fraction do they say?".
-      This is the natural quantitative complement to Figure 28.
 
   (B) q at matched **age** a — direct chronological comparison.
 
-For each posterior draw and each grid point (N or a), we compute q as a
-deterministic function of the latent expected probabilities (no Beta-
-Binomial sampling and no subject REs — this is **population-level**
-posterior overlap, not predictive overlap of individual children). For
-predictive overlap of individuals, a TD bivariate model with subject
-random effects would be needed first.
+For each posterior draw and each grid point (N or a), q is computed as a
+deterministic function of the latent expected probabilities (no Beta-Binomial
+sampling and no subject REs — this is **population-level** posterior overlap).
 
-Outputs in `output/comparisons/`:
-  - `ds_td_q_at_U_summary.csv` and `ds_td_q_at_age_summary.csv`
-  - `ds_td_q_overlap.{png,svg}` — two-panel median+HDI + P(DS>TD) panel
-  - `ds_td_q_density_slices.{png,svg}` — small multiples of full posterior
-    densities at selected N values
+Numerical helpers live in ``vocab_growth.comparison``; this is a thin CLI
+wrapper. Model pairs are resolved from ``MODEL_REGISTRY`` keys.
+
+Outputs in ``output/comparisons/``:
+  - ``ds_td_q_at_U_summary.csv`` and ``ds_td_q_at_age_summary.csv``
+  - ``ds_td_q_at_U_P_DS_gt_TD.csv`` and ``ds_td_q_at_age_P_DS_gt_TD.csv``
+  - ``ds_td_q_overlap.{png,svg}`` — two-panel median+HDI + P(DS>TD) panel
+  - ``ds_td_q_density_slices.{png,svg}`` — posterior densities at selected N
 """
 
 from __future__ import annotations
@@ -33,152 +32,79 @@ import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from compare_ds_td_latency import (
-    DS_DIR,
-    N_TRIALS_DS,
-    N_TRIALS_TD,
-    TD_DIR,
-    evaluate_at_ages,
-    first_crossing_age,
-    load_population_trajectory,
-    summarise_per_N,
-)
 from scipy.stats import gaussian_kde
 
-OUT_DIR = "output/comparisons"
+from vocab_growth import comparison
+from vocab_growth.comparison import (
+    compute_q_at_age,
+    compute_q_at_U,
+    load_population_trajectory,
+    prob_a_greater_b,
+    summarise_per_N,
+)
 
-# Grid for the q(U=N) view. Avoid the very small N tail (S/U noisy when U
-# is barely above N) and the very large tail where TD coverage drops.
+DS_KEY = "vg10"
+TD_KEY = "vg06"
+DS_DIR = comparison.model_dir(DS_KEY)
+TD_DIR = comparison.model_dir(TD_KEY)
+N_TRIALS_DS = comparison.n_trials(DS_KEY)
+N_TRIALS_TD = comparison.n_trials(TD_KEY)
+OUT_DIR = os.path.join("output", "comparisons")
+
+# Grid for the q(U=N) view. Avoid the very small N tail (S/U noisy when U is
+# barely above N) and the very large tail where TD coverage drops.
 N_GRID_Q = np.array(
     [10, 15, 20, 25, 30, 40, 50, 75, 100, 125, 150, 175, 200,
      250, 300, 350, 400, 450],
     dtype=float,
 )
-
 # Grid for the q(a) view. TD model fits ages 8-30 months only.
 AGE_GRID_Q = np.linspace(8.0, 30.0, 45)
-
 # N values at which to render full posterior density slices.
 N_SLICES = [25.0, 50.0, 100.0, 200.0, 400.0]
-
 MIN_COVERAGE = 0.80
-RNG = np.random.default_rng(0)
-
-
-def compute_q_at_U(ages: np.ndarray, U: np.ndarray, S: np.ndarray,
-                   N_grid: np.ndarray) -> np.ndarray:
-    """Per-draw q at comprehension level N. Shape (n_draw, n_N). NaN where
-    U(a) never reaches N for that draw."""
-    n_draw = U.shape[0]
-    q = np.full((n_draw, len(N_grid)), np.nan)
-    for i, N in enumerate(N_grid):
-        a_U = first_crossing_age(U, ages, N)
-        S_at_a_U = evaluate_at_ages(S, ages, a_U)
-        # Where a_U is the left edge (already-above case) compute q anyway
-        with np.errstate(invalid="ignore"):
-            q[:, i] = S_at_a_U / N
-    return q
-
-
-def compute_q_at_age(ages: np.ndarray, U: np.ndarray, S: np.ndarray,
-                     age_grid: np.ndarray) -> np.ndarray:
-    """Per-draw q at chronological age a. Shape (n_draw, n_age_grid)."""
-    n_draw = U.shape[0]
-    q = np.full((n_draw, len(age_grid)), np.nan)
-    for j, a in enumerate(age_grid):
-        target = np.full(n_draw, a)
-        U_at = evaluate_at_ages(U, ages, target)
-        S_at = evaluate_at_ages(S, ages, target)
-        with np.errstate(invalid="ignore", divide="ignore"):
-            q[:, j] = S_at / U_at
-    return q
-
-
-def prob_a_greater_b(a: np.ndarray, b: np.ndarray) -> np.ndarray:
-    """For each column index i, MC estimate of P(a[:, i] > b[:, i]) treating
-    a and b as independent posteriors. NaN where either column has no data."""
-    n_iter = 20000
-    p = np.full(a.shape[1], np.nan)
-    for i in range(a.shape[1]):
-        a_i = a[~np.isnan(a[:, i]), i]
-        b_i = b[~np.isnan(b[:, i]), i]
-        if a_i.size == 0 or b_i.size == 0:
-            continue
-        a_s = RNG.choice(a_i, size=n_iter, replace=True)
-        b_s = RNG.choice(b_i, size=n_iter, replace=True)
-        p[i] = float(np.mean(a_s > b_s))
-    return p
-
-
-def plot_overlay_panel(ax, df: pd.DataFrame, x_col: str, label: str,
-                       colour: str) -> None:
-    df_ok = df[df["coverage"] >= MIN_COVERAGE]
-    if df_ok.empty:
-        return
-    ax.fill_between(df_ok[x_col], df_ok["hdi90_lo"], df_ok["hdi90_hi"],
-                    alpha=0.15, color=colour, linewidth=0,
-                    label=f"{label} 90% HDI")
-    ax.fill_between(df_ok[x_col], df_ok["hdi50_lo"], df_ok["hdi50_hi"],
-                    alpha=0.30, color=colour, linewidth=0,
-                    label=f"{label} 50% HDI")
-    ax.plot(df_ok[x_col], df_ok["median"], color=colour, lw=2.5,
-            label=f"{label} median")
 
 
 def main() -> None:
     plot_styles.set_matplotlib_default_style()
     os.makedirs(OUT_DIR, exist_ok=True)
+    rng = np.random.default_rng(0)
 
     print("Loading traces …", flush=True)
-    ages_ds, U_ds, S_ds = load_population_trajectory(
-        os.path.join(DS_DIR, "trace.nc"), N_TRIALS_DS)
-    ages_td, U_td, S_td = load_population_trajectory(
-        os.path.join(TD_DIR, "trace.nc"), N_TRIALS_TD)
+    ages_ds, U_ds, S_ds = load_population_trajectory(os.path.join(DS_DIR, "trace.nc"), N_TRIALS_DS)
+    ages_td, U_td, S_td = load_population_trajectory(os.path.join(TD_DIR, "trace.nc"), N_TRIALS_TD)
 
-    print("Computing q(U=N) for DS …", flush=True)
+    print("Computing q(U=N) and q(a) …", flush=True)
     qU_ds = compute_q_at_U(ages_ds, U_ds, S_ds, N_GRID_Q)
-    print("Computing q(U=N) for TD …", flush=True)
     qU_td = compute_q_at_U(ages_td, U_td, S_td, N_GRID_Q)
-    print("Computing q(a) for DS …", flush=True)
     qa_ds = compute_q_at_age(ages_ds, U_ds, S_ds, AGE_GRID_Q)
-    print("Computing q(a) for TD …", flush=True)
     qa_td = compute_q_at_age(ages_td, U_td, S_td, AGE_GRID_Q)
 
     print("Summarising and computing P(DS > TD) …", flush=True)
-    qU_ds_sum = summarise_per_N(qU_ds, N_GRID_Q).rename(columns={"N": "N"})
-    qU_td_sum = summarise_per_N(qU_td, N_GRID_Q).rename(columns={"N": "N"})
+    qU_ds_sum = summarise_per_N(qU_ds, N_GRID_Q)
+    qU_td_sum = summarise_per_N(qU_td, N_GRID_Q)
     qa_ds_sum = summarise_per_N(qa_ds, AGE_GRID_Q).rename(columns={"N": "age_months"})
     qa_td_sum = summarise_per_N(qa_td, AGE_GRID_Q).rename(columns={"N": "age_months"})
 
-    pU = prob_a_greater_b(qU_ds, qU_td)
-    pa = prob_a_greater_b(qa_ds, qa_td)
+    pU = prob_a_greater_b(qU_ds, qU_td, rng=rng)
+    pa = prob_a_greater_b(qa_ds, qa_td, rng=rng)
 
-    qU = pd.concat([
-        qU_ds_sum.assign(population="DS"),
-        qU_td_sum.assign(population="TD"),
-    ], ignore_index=True)
-    qU.to_csv(os.path.join(OUT_DIR, "ds_td_q_at_U_summary.csv"), index=False)
-
-    qa = pd.concat([
-        qa_ds_sum.assign(population="DS"),
-        qa_td_sum.assign(population="TD"),
-    ], ignore_index=True)
-    qa.to_csv(os.path.join(OUT_DIR, "ds_td_q_at_age_summary.csv"), index=False)
-
+    pd.concat([qU_ds_sum.assign(population="DS"), qU_td_sum.assign(population="TD")],
+              ignore_index=True).to_csv(os.path.join(OUT_DIR, "ds_td_q_at_U_summary.csv"), index=False)
+    pd.concat([qa_ds_sum.assign(population="DS"), qa_td_sum.assign(population="TD")],
+              ignore_index=True).to_csv(os.path.join(OUT_DIR, "ds_td_q_at_age_summary.csv"), index=False)
     pd.DataFrame({"N": N_GRID_Q, "P(q_DS_gt_q_TD)": pU}).to_csv(
         os.path.join(OUT_DIR, "ds_td_q_at_U_P_DS_gt_TD.csv"), index=False)
     pd.DataFrame({"age_months": AGE_GRID_Q, "P(q_DS_gt_q_TD)": pa}).to_csv(
         os.path.join(OUT_DIR, "ds_td_q_at_age_P_DS_gt_TD.csv"), index=False)
 
-    # ============================================================
-    # Figure 1: median + HDI overlay + P(DS > TD)
-    # ============================================================
+    # ---- Figure 1: median + HDI overlay + P(DS > TD) ----
     fig = plt.figure(figsize=(15, 9))
     gs = fig.add_gridspec(2, 2, height_ratios=[3, 1], hspace=0.28, wspace=0.22)
 
     ax_qU = fig.add_subplot(gs[0, 0])
-    plot_overlay_panel(ax_qU, qU_ds_sum, "N", "DS (VG10)", plot_styles.COLOUR_BLUE)
-    plot_overlay_panel(ax_qU, qU_td_sum, "N", "TD (VG06)", plot_styles.COLOUR_ORANGE)
+    comparison.plot_summary_band(ax_qU, qU_ds_sum, "N", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
+    comparison.plot_summary_band(ax_qU, qU_td_sum, "N", "TD (VG06)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
     ax_qU.set_xscale("log")
     ax_qU.set_xlabel("Comprehension N (words)")
     ax_qU.set_ylabel("q(U=N) = E[S] / N")
@@ -188,8 +114,8 @@ def main() -> None:
     ax_qU.set_ylim(0, 1.05)
 
     ax_qa = fig.add_subplot(gs[0, 1])
-    plot_overlay_panel(ax_qa, qa_ds_sum, "age_months", "DS (VG10)", plot_styles.COLOUR_BLUE)
-    plot_overlay_panel(ax_qa, qa_td_sum, "age_months", "TD (VG06)", plot_styles.COLOUR_ORANGE)
+    comparison.plot_summary_band(ax_qa, qa_ds_sum, "age_months", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
+    comparison.plot_summary_band(ax_qa, qa_td_sum, "age_months", "TD (VG06)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
     ax_qa.set_xlabel("Age (months)")
     ax_qa.set_ylabel("q(a) = E[S(a)] / E[U(a)]")
     ax_qa.set_title("Production ratio at matched age")
@@ -214,20 +140,13 @@ def main() -> None:
     ax_pa.set_ylim(0, 1)
     ax_pa.grid(True, alpha=0.3)
 
-    fig.suptitle(
-        "Posterior overlap of population q = S/U — DS (VG10) vs TD (VG06)",
-        fontsize=13,
-    )
+    fig.suptitle("Posterior overlap of population q = S/U — DS (VG10) vs TD (VG06)", fontsize=13)
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_overlap.png"), dpi=300, bbox_inches="tight")
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_overlap.svg"), bbox_inches="tight")
     plt.close(fig)
 
-    # ============================================================
-    # Figure 2: full posterior densities of q at selected N
-    # ============================================================
-    fig, axes = plt.subplots(
-        1, len(N_SLICES), figsize=(3.0 * len(N_SLICES), 4.5), sharey=True,
-    )
+    # ---- Figure 2: full posterior densities of q at selected N ----
+    fig, axes = plt.subplots(1, len(N_SLICES), figsize=(3.0 * len(N_SLICES), 4.5), sharey=True)
     if len(N_SLICES) == 1:
         axes = [axes]
     q_grid = np.linspace(0.0, 1.0, 401)
@@ -240,54 +159,25 @@ def main() -> None:
             valid = samples[~np.isnan(samples)]
             if valid.size < 50:
                 continue
-            kde = gaussian_kde(valid, bw_method="scott")
-            density = kde(q_grid)
+            density = gaussian_kde(valid, bw_method="scott")(q_grid)
             ax.fill_between(q_grid, 0, density, color=colour, alpha=0.35, label=label)
             ax.plot(q_grid, density, color=colour, lw=1.5)
-            med = float(np.median(valid))
-            ax.axvline(med, color=colour, lw=1, ls="--")
+            ax.axvline(float(np.median(valid)), color=colour, lw=1, ls="--")
         ax.set_xlim(0, 1)
         ax.set_xlabel("q = S / U")
         ax.set_title(f"N = {int(N)}")
         ax.grid(True, alpha=0.3)
     axes[0].set_ylabel("Posterior density")
     axes[0].legend(loc="upper left", frameon=True, fontsize=9)
-    fig.suptitle(
-        "Posterior of q at matched comprehension levels — DS vs TD",
-        fontsize=13,
-    )
+    fig.suptitle("Posterior of q at matched comprehension levels — DS vs TD", fontsize=13)
     fig.tight_layout()
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_density_slices.png"), dpi=300)
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_density_slices.svg"))
     plt.close(fig)
 
-    # ============================================================
-    # Console summary
-    # ============================================================
-    print("\nSaved:")
-    for f in [
-        "ds_td_q_at_U_summary.csv",
-        "ds_td_q_at_age_summary.csv",
-        "ds_td_q_at_U_P_DS_gt_TD.csv",
-        "ds_td_q_at_age_P_DS_gt_TD.csv",
-        "ds_td_q_overlap.png",
-        "ds_td_q_overlap.svg",
-        "ds_td_q_density_slices.png",
-        "ds_td_q_density_slices.svg",
-    ]:
-        print(f"  {os.path.join(OUT_DIR, f)}")
-
-    print("\n--- DS q(U=N) summary ---")
-    print(qU_ds_sum[qU_ds_sum["coverage"] >= MIN_COVERAGE]
-          [["N", "median", "hdi50_lo", "hdi50_hi", "hdi90_lo", "hdi90_hi", "coverage"]]
-          .to_string(index=False, float_format="%.3f"))
-    print("\n--- TD q(U=N) summary ---")
-    print(qU_td_sum[qU_td_sum["coverage"] >= MIN_COVERAGE]
-          [["N", "median", "hdi50_lo", "hdi50_hi", "hdi90_lo", "hdi90_hi", "coverage"]]
-          .to_string(index=False, float_format="%.3f"))
+    print("\nSaved q-overlap CSVs and figures to", OUT_DIR)
     print("\n--- P(q_DS > q_TD | U=N) ---")
-    print(pd.DataFrame({"N": N_GRID_Q, "P(DS>TD)": pU})
-          .to_string(index=False, float_format="%.4f"))
+    print(pd.DataFrame({"N": N_GRID_Q, "P(DS>TD)": pU}).to_string(index=False, float_format="%.4f"))
 
 
 if __name__ == "__main__":

--- a/scripts/compare_ds_td_q_vs_understood.py
+++ b/scripts/compare_ds_td_q_vs_understood.py
@@ -21,8 +21,10 @@ import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
 import pandas as pd
 
-DS_DIR = "output/models/VG10-age-understood-spoken-ds-re-subj-uq-anchored"
-TD_DIR = "output/models/VG06-age-understood-spoken-td"
+from vocab_growth import comparison
+
+DS_DIR = comparison.model_dir("vg10")
+TD_DIR = comparison.model_dir("vg06")
 OUT_DIR = "output/comparisons"
 
 

--- a/scripts/compare_ds_td_trajectories.py
+++ b/scripts/compare_ds_td_trajectories.py
@@ -26,8 +26,10 @@ import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
 import pandas as pd
 
-DS_DIR = "output/models/VG10-age-understood-spoken-ds-re-subj-uq-anchored"
-TD_DIR = "output/models/VG06-age-understood-spoken-td"
+from vocab_growth import comparison
+
+DS_DIR = comparison.model_dir("vg10")
+TD_DIR = comparison.model_dir("vg06")
 OUT_DIR = "output/comparisons"
 
 UNDERSTOOD_COLOUR = "C0"

--- a/scripts/compare_models.py
+++ b/scripts/compare_models.py
@@ -1,30 +1,21 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-Cross-model comparison overlays.
+Cross-model comparison overlays (CSV-based, from per-model output tables).
 
-Produces the following figures under `output/comparisons/`:
+Produces figures under ``output/comparisons/``:
 
-- `ds_td_spoken_by_age.{png,svg}` — VG01 (DS) vs VG03 (TD) — words spoken
-- `ds_td_understood_by_age.{png,svg}` — VG02 (DS) vs VG04 (TD) — words understood
-- `vg05_vs_vg07_understood.{png,svg}` — Simpson's-paradox fix in VG07
-- `vg05_vs_vg07_spoken.{png,svg}` — sanity check that the fix preserves
-  the spoken trajectory
-- `ds_td_q_vs_understood.{png,svg}` — q vs words understood (DS VG09 / TD
-  VG06) — the headline matched-comprehension comparison; the
-  corresponding crossings CSV lives in this directory too.
-- `vg07_vg09_vg10_q_by_age.{png,svg}` — production ratio q(age) three-way
-  overlay: VG07 (no subject REs), VG09 (subject REs on U and q,
-  unanchored GP), VG10 (subject REs on U and q, GP anchored at the
-  reference age).
-- `ds_td_q_by_age_vg10.{png,svg}` — production ratio q(age) DS (VG10)
-  vs TD (VG06). Visualises the chronological production lag.
-- `ds_td_q_vs_understood_vg10.{png,svg}` — matched-comprehension q
-  overlay using VG10 for DS instead of VG09.
+- ``ds_td_spoken_by_age.{png,svg}`` — VG01 (DS) vs VG03 (TD) — words spoken
+- ``ds_td_understood_by_age.{png,svg}`` — VG02 (DS) vs VG04 (TD) — understood
+- ``vg05_vs_vg07_{understood,spoken}.{png,svg}`` — study-RE effect in VG07
+- ``ds_td_q_vs_understood.{png,svg}`` (+ ``ds_td_q_crossings.csv``) — headline
+  matched-comprehension q overlay (DS VG09 / TD VG06, VG07 dashed reference)
+- ``vg07_vg09_vg10_q_by_age.{png,svg}`` — q(age) three-way overlay
+- ``ds_td_q_by_age_vg10.{png,svg}`` — q(age) DS (VG10) vs TD (VG06)
+- ``ds_td_q_vs_understood_vg10.{png,svg}`` — matched-comprehension q with VG10
 
-CSVs of the underlying data are also written.
-
-Replaces the earlier one-off `compare_ds_td.py`.
+Shared helpers (``first_crossing``, ``overlay_age_curves``) and model-path
+resolution (``model_dir``) come from ``vocab_growth.comparison``.
 """
 
 from __future__ import annotations
@@ -33,11 +24,11 @@ import os
 
 import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
 
-MODELS_DIR = "output/models"
-OUT_DIR = "output/comparisons"
+from vocab_growth.comparison import first_crossing, model_dir, overlay_age_curves
+
+OUT_DIR = os.path.join("output", "comparisons")
 
 DS_COLOUR = plot_styles.COLOUR_BLUE
 TD_COLOUR = plot_styles.COLOUR_ORANGE
@@ -45,72 +36,25 @@ NO_RE_COLOUR = plot_styles.COLOUR_RED
 RE_COLOUR = plot_styles.COLOUR_GREEN
 
 
-def overlay_age_curves(
-    title: str,
-    series: list[tuple[str, pd.DataFrame, str]],
-    out_base: str,
-    *,
-    ylabel: str = "Expected words",
-) -> None:
-    """Overlay Y_median + Y_hdi bands from posterior_summary-shaped frames.
-
-    Each series tuple is (label, dataframe, colour). The dataframe must
-    have columns `age_months`, `Ey_median`, `Ey_hdi_lo`, `Ey_hdi_hi`.
-    """
-    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-    for label, df, colour in series:
-        ax.fill_between(
-            df["age_months"], df["Ey_hdi_lo"], df["Ey_hdi_hi"],
-            color=colour, alpha=0.18, linewidth=0,
-            label=f"{label} 90% HDI",
-        )
-        ax.plot(
-            df["age_months"], df["Ey_median"], color=colour, lw=2.5,
-            label=f"{label} median",
-        )
-    ax.set_xlabel("Age (months)")
-    ax.set_ylabel(ylabel)
-    ax.set_title(title)
-    ax.set_ylim(bottom=0)
-    ax.legend(loc="upper left", frameon=True)
-    fig.savefig(out_base + ".png")
-    fig.savefig(out_base + ".svg")
-    plt.close(fig)
-
-
-def first_crossing(x: np.ndarray, y: np.ndarray, threshold: float) -> float | None:
-    above = y >= threshold
-    if not above.any():
-        return None
-    if above.all():
-        return float(x[0])
-    i = int(np.argmax(above))
-    if i == 0:
-        return float(x[0])
-    x0, x1 = float(x[i - 1]), float(x[i])
-    y0, y1 = float(y[i - 1]), float(y[i])
-    if y1 == y0:
-        return x1
-    return x0 + (threshold - y0) * (x1 - x0) / (y1 - y0)
+def _read(key: str, filename: str) -> pd.DataFrame:
+    return pd.read_csv(os.path.join(model_dir(key), filename))
 
 
 def ds_td_spoken_by_age() -> None:
-    ds = pd.read_csv(os.path.join(MODELS_DIR, "VG01-age-spoken-ds", "posterior_summary.csv"))
-    td = pd.read_csv(os.path.join(MODELS_DIR, "VG03-age-spoken-td", "posterior_summary.csv"))
     overlay_age_curves(
         "Expected words spoken by age — DS (VG01) vs TD (VG03)",
-        [("DS (VG01)", ds, DS_COLOUR), ("TD (VG03)", td, TD_COLOUR)],
+        [("DS (VG01)", _read("vg01", "posterior_summary.csv"), DS_COLOUR),
+         ("TD (VG03)", _read("vg03", "posterior_summary.csv"), TD_COLOUR)],
         os.path.join(OUT_DIR, "ds_td_spoken_by_age"),
         ylabel="Expected words spoken",
     )
 
 
 def ds_td_understood_by_age() -> None:
-    ds = pd.read_csv(os.path.join(MODELS_DIR, "VG02-age-understood-ds", "posterior_summary.csv"))
-    td = pd.read_csv(os.path.join(MODELS_DIR, "VG04-age-understood-td", "posterior_summary.csv"))
     overlay_age_curves(
         "Expected words understood by age — DS (VG02) vs TD (VG04)",
-        [("DS (VG02)", ds, DS_COLOUR), ("TD (VG04)", td, TD_COLOUR)],
+        [("DS (VG02)", _read("vg02", "posterior_summary.csv"), DS_COLOUR),
+         ("TD (VG04)", _read("vg04", "posterior_summary.csv"), TD_COLOUR)],
         os.path.join(OUT_DIR, "ds_td_understood_by_age"),
         ylabel="Expected words understood",
     )
@@ -118,72 +62,18 @@ def ds_td_understood_by_age() -> None:
 
 def vg05_vs_vg07() -> None:
     for outcome, suffix in (("understood", "u"), ("spoken", "s")):
-        no_re = pd.read_csv(
-            os.path.join(MODELS_DIR, "VG05-age-understood-spoken-ds",
-                         f"posterior_summary_{suffix}.csv")
-        )
-        re = pd.read_csv(
-            os.path.join(MODELS_DIR, "VG07-age-understood-spoken-ds-re",
-                         f"posterior_summary_{suffix}.csv")
-        )
         overlay_age_curves(
             f"VG05 (no study RE) vs VG07 (with study RE) — words {outcome} (DS)",
-            [("VG05 (no RE)", no_re, NO_RE_COLOUR),
-             ("VG07 (study RE)", re, RE_COLOUR)],
+            [("VG05 (no RE)", _read("vg05", f"posterior_summary_{suffix}.csv"), NO_RE_COLOUR),
+             ("VG07 (study RE)", _read("vg07", f"posterior_summary_{suffix}.csv"), RE_COLOUR)],
             os.path.join(OUT_DIR, f"vg05_vs_vg07_{outcome}"),
             ylabel=f"Expected words {outcome}",
         )
 
 
-def ds_td_q_vs_understood() -> None:
-    """DS-vs-TD matched-comprehension production-ratio overlay.
-
-    Headline DS model is VG09 (study + subject REs on both U and q).
-    VG07 is plotted as a dashed reference line so the shift from the
-    pre-subject-RE estimate is visible.
-    """
-    ds_vg09 = pd.read_csv(
-        os.path.join(MODELS_DIR, "VG09-age-understood-spoken-ds-re-subj-uq",
-                     "production_rate_by_understood.csv")
-    )
-    ds_vg07 = pd.read_csv(
-        os.path.join(MODELS_DIR, "VG07-age-understood-spoken-ds-re",
-                     "production_rate_by_understood.csv")
-    )
-    td = pd.read_csv(
-        os.path.join(MODELS_DIR, "VG06-age-understood-spoken-td",
-                     "production_rate_by_understood.csv")
-    )
-
-    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-    ax.fill_between(td["words_understood"], td["hdi_lo"], td["hdi_hi"],
-                    color=TD_COLOUR, alpha=0.18, linewidth=0, label="TD 90% HDI")
-    ax.fill_between(ds_vg09["words_understood"], ds_vg09["hdi_lo"], ds_vg09["hdi_hi"],
-                    color=DS_COLOUR, alpha=0.18, linewidth=0, label="DS 90% HDI")
-    ax.plot(td["words_understood"], td["q_median"], color=TD_COLOUR, lw=2.5,
-            label="TD median q (VG06)")
-    ax.plot(ds_vg09["words_understood"], ds_vg09["q_median"], color=DS_COLOUR, lw=2.5,
-            label="DS median q (VG09)")
-    ax.plot(ds_vg07["words_understood"], ds_vg07["q_median"], color=DS_COLOUR,
-            lw=1.5, linestyle="--", alpha=0.7,
-            label="DS median q (VG07, no subject RE)")
-
-    for thresh in (0.5, 0.9):
-        ax.axhline(thresh, color=plot_styles.LINE_COLOUR, lw=0.6, linestyle="--")
-
-    ax.set_xlim(0, max(td["words_understood"].max(),
-                       ds_vg09["words_understood"].max()))
-    ax.set_ylim(0, 1)
-    ax.set_xlabel("Expected words understood")
-    ax.set_ylabel(r"Production ratio  q = $p_S$ / $p_U$")
-    ax.set_title("Production ratio against words understood — DS (VG09) vs TD (VG06)")
-    ax.legend(loc="lower right", frameon=True)
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood.png"))
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood.svg"))
-    plt.close(fig)
-
+def _q_vs_understood_crossings(series: list[tuple[str, pd.DataFrame]]) -> pd.DataFrame:
     rows = []
-    for pop, df in (("DS (VG09)", ds_vg09), ("DS (VG07)", ds_vg07), ("TD (VG06)", td)):
+    for pop, df in series:
         for thresh in (0.25, 0.5, 0.75, 0.90):
             rows.append({
                 "population": pop,
@@ -195,124 +85,93 @@ def ds_td_q_vs_understood() -> None:
                 "n_understood_at_hdi_hi": first_crossing(
                     df["words_understood"].to_numpy(), df["hdi_hi"].to_numpy(), thresh),
             })
-    pd.DataFrame(rows).to_csv(os.path.join(OUT_DIR, "ds_td_q_crossings.csv"),
-                              index=False)
+    return pd.DataFrame(rows)
+
+
+def ds_td_q_vs_understood() -> None:
+    """Headline matched-comprehension q overlay: DS (VG09) vs TD (VG06), VG07 dashed."""
+    ds_vg09 = _read("vg09", "production_rate_by_understood.csv")
+    ds_vg07 = _read("vg07", "production_rate_by_understood.csv")
+    td = _read("vg06", "production_rate_by_understood.csv")
+
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+    ax.fill_between(td["words_understood"], td["hdi_lo"], td["hdi_hi"],
+                    color=TD_COLOUR, alpha=0.18, linewidth=0, label="TD 90% HDI")
+    ax.fill_between(ds_vg09["words_understood"], ds_vg09["hdi_lo"], ds_vg09["hdi_hi"],
+                    color=DS_COLOUR, alpha=0.18, linewidth=0, label="DS 90% HDI")
+    ax.plot(td["words_understood"], td["q_median"], color=TD_COLOUR, lw=2.5,
+            label="TD median q (VG06)")
+    ax.plot(ds_vg09["words_understood"], ds_vg09["q_median"], color=DS_COLOUR, lw=2.5,
+            label="DS median q (VG09)")
+    ax.plot(ds_vg07["words_understood"], ds_vg07["q_median"], color=DS_COLOUR,
+            lw=1.5, linestyle="--", alpha=0.7, label="DS median q (VG07, no subject RE)")
+    for thresh in (0.5, 0.9):
+        ax.axhline(thresh, color=plot_styles.LINE_COLOUR, lw=0.6, linestyle="--")
+    ax.set_xlim(0, max(td["words_understood"].max(), ds_vg09["words_understood"].max()))
+    ax.set_ylim(0, 1)
+    ax.set_xlabel("Expected words understood")
+    ax.set_ylabel(r"Production ratio  q = $p_S$ / $p_U$")
+    ax.set_title("Production ratio against words understood — DS (VG09) vs TD (VG06)")
+    ax.legend(loc="lower right", frameon=True)
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood.png"))
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood.svg"))
+    plt.close(fig)
+
+    _q_vs_understood_crossings(
+        [("DS (VG09)", ds_vg09), ("DS (VG07)", ds_vg07), ("TD (VG06)", td)]
+    ).to_csv(os.path.join(OUT_DIR, "ds_td_q_crossings.csv"), index=False)
+
+
+def _merge_q_by_age(frames: list[tuple[str, pd.DataFrame]]) -> pd.DataFrame:
+    merged = None
+    for tag, df in frames:
+        cols = df[["age_months", "q_median", "q_hdi_lo", "q_hdi_hi"]].rename(
+            columns={"q_median": f"{tag}_median", "q_hdi_lo": f"{tag}_hdi_lo",
+                     "q_hdi_hi": f"{tag}_hdi_hi"})
+        merged = cols if merged is None else merged.merge(cols, on="age_months", how="outer")
+    return merged.sort_values("age_months")
 
 
 def vg07_vg09_vg10_q_by_age() -> None:
-    """Three-way overlay of q(age) for VG07, VG09 and VG10.
-
-    VG07 has no subject REs on q (the pre-redundancy baseline).
-    VG09 adds subject REs on U and q with an unanchored GP.
-    VG10 is VG09 with tighter q-anchor priors and the GP anchored
-    to zero at the reference age (see notes/202605131500-...).
-    """
-    vg07 = pd.read_csv(
-        os.path.join(MODELS_DIR, "VG07-age-understood-spoken-ds-re",
-                     "posterior_summary_q.csv")
-    )
-    vg09 = pd.read_csv(
-        os.path.join(MODELS_DIR, "VG09-age-understood-spoken-ds-re-subj-uq",
-                     "posterior_summary_q.csv")
-    )
-    vg10 = pd.read_csv(
-        os.path.join(
-            MODELS_DIR,
-            "VG10-age-understood-spoken-ds-re-subj-uq-anchored",
-            "posterior_summary_q.csv",
-        )
-    )
-
+    """Three-way overlay of q(age) for VG07, VG09 and VG10."""
     series = [
-        ("VG07 (no subject RE on q)", vg07, plot_styles.COLOUR_PURPLE),
-        ("VG09 (subj REs, GP unanchored)", vg09, plot_styles.COLOUR_BLUE),
-        ("VG10 (subj REs, GP anchored at 54mo)", vg10, plot_styles.COLOUR_GREEN),
+        ("VG07 (no subject RE on q)", _read("vg07", "posterior_summary_q.csv"), plot_styles.COLOUR_PURPLE),
+        ("VG09 (subj REs, GP unanchored)", _read("vg09", "posterior_summary_q.csv"), plot_styles.COLOUR_BLUE),
+        ("VG10 (subj REs, GP anchored at 54mo)", _read("vg10", "posterior_summary_q.csv"), plot_styles.COLOUR_GREEN),
     ]
-
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
     for label, df, colour in series:
-        ax.fill_between(
-            df["age_months"], df["q_hdi_lo"], df["q_hdi_hi"],
-            color=colour, alpha=0.15, linewidth=0,
-            label=f"{label} 90% HDI",
-        )
-        ax.plot(
-            df["age_months"], df["q_median"], color=colour, lw=2.5,
-            label=f"{label} median",
-        )
+        ax.fill_between(df["age_months"], df["q_hdi_lo"], df["q_hdi_hi"],
+                        color=colour, alpha=0.15, linewidth=0, label=f"{label} 90% HDI")
+        ax.plot(df["age_months"], df["q_median"], color=colour, lw=2.5, label=f"{label} median")
     ax.axhline(0.5, color=plot_styles.LINE_COLOUR, lw=0.6, linestyle="--")
     ax.axhline(0.9, color=plot_styles.LINE_COLOUR, lw=0.6, linestyle="--")
     ax.set_xlabel("Age (months)")
     ax.set_ylabel(r"Production ratio  q = $p_S$ / $p_U$")
     ax.set_ylim(0, 1)
-    ax.set_title(
-        "Production ratio q(age) — VG07 vs VG09 vs VG10 (DS, rep config)"
-    )
+    ax.set_title("Production ratio q(age) — VG07 vs VG09 vs VG10 (DS, rep config)")
     ax.legend(loc="lower right", frameon=True, fontsize="small")
     fig.savefig(os.path.join(OUT_DIR, "vg07_vg09_vg10_q_by_age.png"))
     fig.savefig(os.path.join(OUT_DIR, "vg07_vg09_vg10_q_by_age.svg"))
     plt.close(fig)
 
-    merged = vg07[["age_months", "q_median", "q_hdi_lo", "q_hdi_hi"]].rename(
-        columns={"q_median": "vg07_median",
-                 "q_hdi_lo": "vg07_hdi_lo",
-                 "q_hdi_hi": "vg07_hdi_hi"}
-    )
-    merged = merged.merge(
-        vg09[["age_months", "q_median", "q_hdi_lo", "q_hdi_hi"]].rename(
-            columns={"q_median": "vg09_median",
-                     "q_hdi_lo": "vg09_hdi_lo",
-                     "q_hdi_hi": "vg09_hdi_hi"}
-        ),
-        on="age_months",
-    )
-    merged = merged.merge(
-        vg10[["age_months", "q_median", "q_hdi_lo", "q_hdi_hi"]].rename(
-            columns={"q_median": "vg10_median",
-                     "q_hdi_lo": "vg10_hdi_lo",
-                     "q_hdi_hi": "vg10_hdi_hi"}
-        ),
-        on="age_months",
-    )
-    merged.to_csv(
-        os.path.join(OUT_DIR, "vg07_vg09_vg10_q_by_age.csv"),
-        index=False,
-    )
+    _merge_q_by_age([("vg07", series[0][1]), ("vg09", series[1][1]), ("vg10", series[2][1])]).to_csv(
+        os.path.join(OUT_DIR, "vg07_vg09_vg10_q_by_age.csv"), index=False)
 
 
 def ds_td_q_by_age_vg10() -> None:
-    """DS (VG10) vs TD (VG06) production-ratio overlay against age.
-
-    Visualises the chronological production lag: at any given age the
-    DS curve sits well below the TD curve, and reaches the same
-    production-ratio milestones years later.
-    """
-    ds = pd.read_csv(
-        os.path.join(
-            MODELS_DIR,
-            "VG10-age-understood-spoken-ds-re-subj-uq-anchored",
-            "posterior_summary_q.csv",
-        )
-    )
-    td = pd.read_csv(
-        os.path.join(MODELS_DIR, "VG06-age-understood-spoken-td",
-                     "posterior_summary_q.csv")
-    )
-
+    """DS (VG10) vs TD (VG06) production-ratio overlay against age."""
+    ds = _read("vg10", "posterior_summary_q.csv")
+    td = _read("vg06", "posterior_summary_q.csv")
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
     ax.fill_between(td["age_months"], td["q_hdi_lo"], td["q_hdi_hi"],
-                    color=TD_COLOUR, alpha=0.18, linewidth=0,
-                    label="TD 90% HDI")
+                    color=TD_COLOUR, alpha=0.18, linewidth=0, label="TD 90% HDI")
     ax.fill_between(ds["age_months"], ds["q_hdi_lo"], ds["q_hdi_hi"],
-                    color=DS_COLOUR, alpha=0.18, linewidth=0,
-                    label="DS 90% HDI")
-    ax.plot(td["age_months"], td["q_median"], color=TD_COLOUR, lw=2.5,
-            label="TD median q (VG06)")
-    ax.plot(ds["age_months"], ds["q_median"], color=DS_COLOUR, lw=2.5,
-            label="DS median q (VG10)")
+                    color=DS_COLOUR, alpha=0.18, linewidth=0, label="DS 90% HDI")
+    ax.plot(td["age_months"], td["q_median"], color=TD_COLOUR, lw=2.5, label="TD median q (VG06)")
+    ax.plot(ds["age_months"], ds["q_median"], color=DS_COLOUR, lw=2.5, label="DS median q (VG10)")
     for thresh in (0.5, 0.9):
-        ax.axhline(thresh, color=plot_styles.LINE_COLOUR, lw=0.6,
-                   linestyle="--")
+        ax.axhline(thresh, color=plot_styles.LINE_COLOUR, lw=0.6, linestyle="--")
     ax.set_xlim(min(ds["age_months"].min(), td["age_months"].min()),
                 max(ds["age_months"].max(), td["age_months"].max()))
     ax.set_ylim(0, 1)
@@ -324,68 +183,28 @@ def ds_td_q_by_age_vg10() -> None:
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_by_age_vg10.svg"))
     plt.close(fig)
 
-    merged = (
-        td[["age_months", "q_median", "q_hdi_lo", "q_hdi_hi"]]
-        .rename(columns={"q_median": "td_median",
-                         "q_hdi_lo": "td_hdi_lo",
-                         "q_hdi_hi": "td_hdi_hi"})
-        .merge(
-            ds[["age_months", "q_median", "q_hdi_lo", "q_hdi_hi"]].rename(
-                columns={"q_median": "ds_median",
-                         "q_hdi_lo": "ds_hdi_lo",
-                         "q_hdi_hi": "ds_hdi_hi"}
-            ),
-            on="age_months", how="outer",
-        )
-        .sort_values("age_months")
-    )
-    merged.to_csv(
-        os.path.join(OUT_DIR, "ds_td_q_by_age_vg10.csv"),
-        index=False,
-    )
+    _merge_q_by_age([("td", td), ("ds", ds)]).to_csv(
+        os.path.join(OUT_DIR, "ds_td_q_by_age_vg10.csv"), index=False)
 
 
 def ds_td_q_vs_understood_vg10() -> None:
-    """DS (VG10) vs TD (VG06) production-ratio against words understood.
-
-    Updated matched-comprehension overlay using VG10 as the headline
-    DS joint model. Preserves the original VG09-based figure for
-    backward compatibility.
-    """
-    ds = pd.read_csv(
-        os.path.join(
-            MODELS_DIR,
-            "VG10-age-understood-spoken-ds-re-subj-uq-anchored",
-            "production_rate_by_understood.csv",
-        )
-    )
-    td = pd.read_csv(
-        os.path.join(MODELS_DIR, "VG06-age-understood-spoken-td",
-                     "production_rate_by_understood.csv")
-    )
-
+    """DS (VG10) vs TD (VG06) production-ratio against words understood."""
+    ds = _read("vg10", "production_rate_by_understood.csv")
+    td = _read("vg06", "production_rate_by_understood.csv")
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
     ax.fill_between(td["words_understood"], td["hdi_lo"], td["hdi_hi"],
-                    color=TD_COLOUR, alpha=0.18, linewidth=0,
-                    label="TD 90% HDI")
+                    color=TD_COLOUR, alpha=0.18, linewidth=0, label="TD 90% HDI")
     ax.fill_between(ds["words_understood"], ds["hdi_lo"], ds["hdi_hi"],
-                    color=DS_COLOUR, alpha=0.18, linewidth=0,
-                    label="DS 90% HDI")
-    ax.plot(td["words_understood"], td["q_median"], color=TD_COLOUR, lw=2.5,
-            label="TD median q (VG06)")
-    ax.plot(ds["words_understood"], ds["q_median"], color=DS_COLOUR, lw=2.5,
-            label="DS median q (VG10)")
+                    color=DS_COLOUR, alpha=0.18, linewidth=0, label="DS 90% HDI")
+    ax.plot(td["words_understood"], td["q_median"], color=TD_COLOUR, lw=2.5, label="TD median q (VG06)")
+    ax.plot(ds["words_understood"], ds["q_median"], color=DS_COLOUR, lw=2.5, label="DS median q (VG10)")
     for thresh in (0.5, 0.9):
-        ax.axhline(thresh, color=plot_styles.LINE_COLOUR, lw=0.6,
-                   linestyle="--")
-    ax.set_xlim(0, max(td["words_understood"].max(),
-                       ds["words_understood"].max()))
+        ax.axhline(thresh, color=plot_styles.LINE_COLOUR, lw=0.6, linestyle="--")
+    ax.set_xlim(0, max(td["words_understood"].max(), ds["words_understood"].max()))
     ax.set_ylim(0, 1)
     ax.set_xlabel("Expected words understood")
     ax.set_ylabel(r"Production ratio  q = $p_S$ / $p_U$")
-    ax.set_title(
-        "Production ratio against words understood — DS (VG10) vs TD (VG06)"
-    )
+    ax.set_title("Production ratio against words understood — DS (VG10) vs TD (VG06)")
     ax.legend(loc="lower right", frameon=True)
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg10.png"))
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_vs_understood_vg10.svg"))
@@ -395,7 +214,6 @@ def ds_td_q_vs_understood_vg10() -> None:
 def main() -> None:
     plot_styles.set_matplotlib_default_style()
     os.makedirs(OUT_DIR, exist_ok=True)
-
     ds_td_spoken_by_age()
     ds_td_understood_by_age()
     vg05_vs_vg07()
@@ -403,7 +221,6 @@ def main() -> None:
     vg07_vg09_vg10_q_by_age()
     ds_td_q_by_age_vg10()
     ds_td_q_vs_understood_vg10()
-
     print(f"Comparisons written to: {OUT_DIR}")
 
 

--- a/scripts/time_to_milestone.py
+++ b/scripts/time_to_milestone.py
@@ -31,8 +31,9 @@ import os
 
 import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
-import numpy as np
 import pandas as pd
+
+from vocab_growth.comparison import invert_curve
 
 MODELS_DIR = "output/models"
 COMPARE_DIR = "output/comparisons"
@@ -54,44 +55,6 @@ BIVARIATE = {
     "VG09": ("VG09-age-understood-spoken-ds-re-subj-uq", "DS"),
     "VG10": ("VG10-age-understood-spoken-ds-re-subj-uq-anchored", "DS"),
 }
-
-
-def first_crossing(x: np.ndarray, y: np.ndarray, threshold: float) -> float | None:
-    """Smallest x at which monotone-ish y first reaches `threshold`."""
-    above = y >= threshold
-    if not above.any():
-        return None
-    if above.all():
-        return float(x[0])
-    i = int(np.argmax(above))
-    if i == 0:
-        return float(x[0])
-    x0, x1 = float(x[i - 1]), float(x[i])
-    y0, y1 = float(y[i - 1]), float(y[i])
-    if y1 == y0:
-        return x1
-    return x0 + (threshold - y0) * (x1 - x0) / (y1 - y0)
-
-
-def invert_curve(df: pd.DataFrame) -> pd.DataFrame:
-    """For each target, return the age at which the 5%, 50%, 95%
-    percentile child first reaches the target word count."""
-    age = df["age_months"].to_numpy(dtype=float)
-    y_lo = df["Y_hdi_lo"].to_numpy(dtype=float)
-    y_md = df["Y_median"].to_numpy(dtype=float)
-    y_hi = df["Y_hdi_hi"].to_numpy(dtype=float)
-
-    rows = []
-    for target in TARGETS:
-        rows.append(
-            {
-                "target_words": target,
-                "age_fast_child_p95": first_crossing(age, y_hi, target),
-                "age_typical_child_p50": first_crossing(age, y_md, target),
-                "age_slow_child_p5": first_crossing(age, y_lo, target),
-            }
-        )
-    return pd.DataFrame(rows)
 
 
 def plot_milestone(df: pd.DataFrame, title: str, out_base: str) -> None:
@@ -130,7 +93,7 @@ def process_univariate(short: str, label: str, outcome: str, pop: str,
                        merged_rows: list[dict]) -> None:
     model_dir = os.path.join(MODELS_DIR, label)
     summary = pd.read_csv(os.path.join(model_dir, "posterior_summary.csv"))
-    inv = invert_curve(summary)
+    inv = invert_curve(summary, TARGETS)
     inv.insert(0, "outcome", outcome)
     inv.insert(0, "population", pop)
     inv.insert(0, "model", short)
@@ -148,7 +111,7 @@ def process_bivariate(short: str, label: str, pop: str,
     model_dir = os.path.join(MODELS_DIR, label)
     for outcome, suffix in (("understood", "u"), ("spoken", "s")):
         summary = pd.read_csv(os.path.join(model_dir, f"posterior_summary_{suffix}.csv"))
-        inv = invert_curve(summary)
+        inv = invert_curve(summary, TARGETS)
         inv.insert(0, "outcome", outcome)
         inv.insert(0, "population", pop)
         inv.insert(0, "model", short)

--- a/src/vocab_growth/comparison.py
+++ b/src/vocab_growth/comparison.py
@@ -1,0 +1,365 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Shared utilities for comparing fitted vocabulary-growth models.
+
+This module consolidates the helpers that the ``scripts/compare_*`` and
+``scripts/time_to_milestone`` tools previously each re-implemented (five copies
+of ``first_crossing``, two trace loaders, ad-hoc HDI code). The comparison
+scripts are now thin CLI wrappers around the functions here.
+
+Everything is **model-agnostic** and **registry-parameterised**: a comparison
+target is a ``MODEL_REGISTRY`` key (e.g. ``"vg06"``, ``"vg10"``). Output
+directories, vocabulary-checklist sizes (``n_trials``) and populations are
+resolved from the model definition rather than hardcoded paths, so a *new*
+model pair -- for example a future TD model with study intercepts -- can be
+compared by adding it to the registry and passing its key. No script edits
+required.
+
+Two complementary lenses are supported:
+
+* **Age-aligned** -- trajectories / contrasts vs chronological age. Only valid
+  over the age range where *both* models have data (the TD models are fit to
+  8-30 months); callers must restrict to the overlap.
+* **Comprehension-matched** -- the production ratio ``q = E[S]/E[U]`` and
+  derived latencies as a function of *understood vocabulary*, which removes the
+  TD/DS timescale difference.
+
+The population-level trajectories (``p_u_plot``, ``p_s_plot``, ``q_plot`` over
+``X_plot``) read here are the GP+linear means with study/subject random effects
+excluded, and are emitted under the same names by every bivariate model
+(plain, study-RE and subject-RE), so this code is unchanged across them.
+"""
+
+from __future__ import annotations
+
+import os
+
+import arviz as az
+import numpy as np
+import pandas as pd
+
+from vocab_growth import environment as env
+from vocab_growth.models.definitions import MODEL_REGISTRY
+
+DEFAULT_MILESTONES = (25, 50, 100, 200, 400)
+DEFAULT_MIN_COVERAGE = 0.80
+
+
+# ----------------------------------------------------------------------------
+# Registry resolution
+# ----------------------------------------------------------------------------
+def model_dir(key: str) -> str:
+    """Output directory for a registry key, e.g. 'vg06' -> .../VG06-age-...-td."""
+    d = MODEL_REGISTRY[key]
+    return os.path.join(env.MODELS_OUTPUT_DIR, f"{d.model_id}-{d.config_name}")
+
+
+def trace_path(key: str) -> str:
+    return os.path.join(model_dir(key), "trace.nc")
+
+
+def n_trials(key: str) -> int:
+    return MODEL_REGISTRY[key].n_trials
+
+
+def population(key: str) -> str:
+    pop = MODEL_REGISTRY[key].population
+    return pop.value if hasattr(pop, "value") else str(pop)
+
+
+def model_label(key: str) -> str:
+    """Short display label, e.g. 'VG06 (TD)'."""
+    d = MODEL_REGISTRY[key]
+    return f"{d.model_id} ({population(key).upper()})"
+
+
+# ----------------------------------------------------------------------------
+# Trace loading
+# ----------------------------------------------------------------------------
+def _dataset(idata: az.InferenceData, group: str):
+    """Return a group as an xarray Dataset, robust to ArviZ DataTree backing."""
+    node = getattr(idata, group)
+    return node if hasattr(node, "data_vars") else node.to_dataset()
+
+
+def load_population_trajectory(
+    path: str, n_trials_: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ``(ages, U, S)`` for a fitted model's population-level trajectory.
+
+    ``U`` and ``S`` are ``(n_draw, n_age)`` word counts (proportion * n_trials)
+    over the plot grid; ``ages`` is sorted ascending in months. ``n_trials_``
+    must match the checklist size used at fit time (see definitions.py).
+    """
+    d = az.from_netcdf(path)
+    post = _dataset(d, "posterior")
+    cdata = _dataset(d, "constant_data")
+    p_u = post["p_u_plot"].values  # (chain, draw, n_age)
+    p_s = post["p_s_plot"].values
+    n_chain, n_draw, n_age = p_u.shape
+    p_u = p_u.reshape(n_chain * n_draw, n_age)
+    p_s = p_s.reshape(n_chain * n_draw, n_age)
+    ages = np.asarray(cdata["X_plot"].values, dtype=float)
+    order = np.argsort(ages)
+    return ages[order], (p_u * n_trials_)[:, order], (p_s * n_trials_)[:, order]
+
+
+def population_trajectory(key: str) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Registry-keyed convenience wrapper around :func:`load_population_trajectory`."""
+    return load_population_trajectory(trace_path(key), n_trials(key))
+
+
+# ----------------------------------------------------------------------------
+# Crossing / interpolation / HDI helpers
+# ----------------------------------------------------------------------------
+def first_crossing(x: np.ndarray, y: np.ndarray, threshold: float) -> float | None:
+    """Smallest x at which a monotone-ish 1-D curve y first reaches threshold.
+
+    Linear interpolation between grid points; ``None`` if never reached. Used
+    for summarising pre-computed median/HDI curves (CSV-based scripts).
+    """
+    above = y >= threshold
+    if not above.any():
+        return None
+    if above.all():
+        return float(x[0])
+    i = int(np.argmax(above))
+    if i == 0:
+        return float(x[0])
+    x0, x1 = float(x[i - 1]), float(x[i])
+    y0, y1 = float(y[i - 1]), float(y[i])
+    if y1 == y0:
+        return x1
+    return x0 + (threshold - y0) * (x1 - x0) / (y1 - y0)
+
+
+def first_crossing_age(Y: np.ndarray, ages: np.ndarray, N: float) -> np.ndarray:
+    """Per-draw first age where each row of Y (n_draw, n_age) reaches N.
+
+    Linear interpolation between adjacent grid points; NaN where never reached.
+    """
+    mask = Y >= N
+    any_above = mask.any(axis=1)
+    first_idx = mask.argmax(axis=1)
+    j = first_idx
+    j_prev = np.maximum(j - 1, 0)
+    y0 = np.take_along_axis(Y, j_prev[:, None], axis=1).squeeze(1)
+    y1 = np.take_along_axis(Y, j[:, None], axis=1).squeeze(1)
+    a0 = ages[j_prev]
+    a1 = ages[j]
+    with np.errstate(invalid="ignore", divide="ignore"):
+        denom = y1 - y0
+        interp = np.where(denom == 0, a1, a0 + (N - y0) * (a1 - a0) / denom)
+    crossing = np.where(j == 0, ages[0], interp)
+    return np.where(any_above, crossing, np.nan)
+
+
+def evaluate_at_ages(
+    Y: np.ndarray, ages: np.ndarray, target_ages: np.ndarray
+) -> np.ndarray:
+    """Per-row linear interpolation of Y (n_draw, n_age) at target_ages (n_draw,).
+
+    NaN where a target age is outside the grid.
+    """
+    n_draw, n_age = Y.shape
+    idx = np.searchsorted(ages, target_ages, side="right")
+    idx = np.clip(idx, 1, n_age - 1)
+    a_lo = ages[idx - 1]
+    a_hi = ages[idx]
+    Y_lo = np.take_along_axis(Y, (idx - 1)[:, None], axis=1).squeeze(1)
+    Y_hi = np.take_along_axis(Y, idx[:, None], axis=1).squeeze(1)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        t = (target_ages - a_lo) / (a_hi - a_lo)
+        out = Y_lo + t * (Y_hi - Y_lo)
+    out_of_range = (
+        (target_ages < ages[0]) | (target_ages > ages[-1]) | np.isnan(target_ages)
+    )
+    return np.where(out_of_range, np.nan, out)
+
+
+def hdi_from_samples(x: np.ndarray, prob: float) -> tuple[float, float]:
+    """Narrowest-interval HDI of a 1-D sample array, ignoring NaN."""
+    x = x[~np.isnan(x)]
+    if x.size == 0:
+        return np.nan, np.nan
+    xs = np.sort(x)
+    n = xs.size
+    k = int(np.floor(prob * n))
+    if k >= n:
+        return float(xs[0]), float(xs[-1])
+    widths = xs[k:] - xs[: n - k]
+    i = int(np.argmin(widths))
+    return float(xs[i]), float(xs[i + k])
+
+
+def summarise_per_N(samples: np.ndarray, grid: np.ndarray) -> pd.DataFrame:
+    """Median + 50%/90% HDI across draws (axis 0) per grid column, with coverage."""
+    rows = []
+    n_draw = samples.shape[0]
+    for i, N in enumerate(grid):
+        col = samples[:, i]
+        valid = ~np.isnan(col)
+        n_valid = int(valid.sum())
+        cov = n_valid / n_draw
+        if n_valid == 0:
+            rows.append(
+                {"N": N, "coverage": cov, "median": np.nan,
+                 "hdi50_lo": np.nan, "hdi50_hi": np.nan,
+                 "hdi90_lo": np.nan, "hdi90_hi": np.nan}
+            )
+            continue
+        l50, u50 = hdi_from_samples(col, 0.50)
+        l90, u90 = hdi_from_samples(col, 0.90)
+        rows.append(
+            {"N": N, "coverage": cov, "median": float(np.nanmedian(col)),
+             "hdi50_lo": l50, "hdi50_hi": u50, "hdi90_lo": l90, "hdi90_hi": u90}
+        )
+    return pd.DataFrame(rows)
+
+
+def prob_a_greater_b(
+    a: np.ndarray, b: np.ndarray, *, n_iter: int = 20000, rng=None
+) -> np.ndarray:
+    """Per-column MC estimate of P(a > b) treating columns as independent posteriors.
+
+    NaN-aware; NaN where either column is empty.
+    """
+    if rng is None:
+        rng = np.random.default_rng(0)
+    p = np.full(a.shape[1], np.nan)
+    for i in range(a.shape[1]):
+        a_i = a[~np.isnan(a[:, i]), i]
+        b_i = b[~np.isnan(b[:, i]), i]
+        if a_i.size == 0 or b_i.size == 0:
+            continue
+        a_s = rng.choice(a_i, size=n_iter, replace=True)
+        b_s = rng.choice(b_i, size=n_iter, replace=True)
+        p[i] = float(np.mean(a_s > b_s))
+    return p
+
+
+# ----------------------------------------------------------------------------
+# Analyses (per-draw, population-level)
+# ----------------------------------------------------------------------------
+def compute_latency(
+    ages: np.ndarray, U: np.ndarray, S: np.ndarray, N_grid: np.ndarray
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Learn-to-say latency. Returns (DA_summary, extra_summary) per N.
+
+    DA(N) = a_S(N) - a_U(N); extra(N) = U(a_S(N)) - N, per draw, then summarised.
+    """
+    n_draw = U.shape[0]
+    DA = np.full((n_draw, len(N_grid)), np.nan)
+    extra = np.full((n_draw, len(N_grid)), np.nan)
+    for i, N in enumerate(N_grid):
+        a_U = first_crossing_age(U, ages, N)
+        a_S = first_crossing_age(S, ages, N)
+        DA[:, i] = a_S - a_U
+        extra[:, i] = evaluate_at_ages(U, ages, a_S) - N
+    return summarise_per_N(DA, N_grid), summarise_per_N(extra, N_grid)
+
+
+def compute_q_at_U(
+    ages: np.ndarray, U: np.ndarray, S: np.ndarray, N_grid: np.ndarray
+) -> np.ndarray:
+    """Per-draw production ratio q at matched comprehension U=N: q = S(a_U(N)) / N."""
+    q = np.full((U.shape[0], len(N_grid)), np.nan)
+    for i, N in enumerate(N_grid):
+        a_U = first_crossing_age(U, ages, N)
+        with np.errstate(invalid="ignore"):
+            q[:, i] = evaluate_at_ages(S, ages, a_U) / N
+    return q
+
+
+def compute_q_at_age(
+    ages: np.ndarray, U: np.ndarray, S: np.ndarray, age_grid: np.ndarray
+) -> np.ndarray:
+    """Per-draw production ratio q at chronological age: q(a) = E[S(a)] / E[U(a)]."""
+    n_draw = U.shape[0]
+    q = np.full((n_draw, len(age_grid)), np.nan)
+    for j, a in enumerate(age_grid):
+        target = np.full(n_draw, a)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            q[:, j] = evaluate_at_ages(S, ages, target) / evaluate_at_ages(
+                U, ages, target
+            )
+    return q
+
+
+def invert_curve(
+    df: pd.DataFrame, targets=DEFAULT_MILESTONES
+) -> pd.DataFrame:
+    """Age at which the 5%/50%/95% percentile child first reaches each target.
+
+    Inverts the pre-computed posterior-predictive percentile columns
+    (``Y_hdi_lo``/``Y_median``/``Y_hdi_hi``) of a ``posterior_summary*`` frame.
+    """
+    age = df["age_months"].to_numpy(dtype=float)
+    y_lo = df["Y_hdi_lo"].to_numpy(dtype=float)
+    y_md = df["Y_median"].to_numpy(dtype=float)
+    y_hi = df["Y_hdi_hi"].to_numpy(dtype=float)
+    rows = []
+    for target in targets:
+        rows.append(
+            {
+                "target_words": target,
+                "age_fast_child_p95": first_crossing(age, y_hi, target),
+                "age_typical_child_p50": first_crossing(age, y_md, target),
+                "age_slow_child_p5": first_crossing(age, y_lo, target),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+# ----------------------------------------------------------------------------
+# Plot helpers
+# ----------------------------------------------------------------------------
+def overlay_age_curves(title, series, out_base, *, ylabel="Expected words"):
+    """Overlay Ey_median + Ey_hdi bands from posterior_summary-shaped frames.
+
+    ``series`` is a list of ``(label, dataframe, colour)``; each frame needs
+    ``age_months``, ``Ey_median``, ``Ey_hdi_lo``, ``Ey_hdi_hi``.
+    """
+    import dse_research_utils.plot.styles as plot_styles
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+    for label, df, colour in series:
+        ax.fill_between(
+            df["age_months"], df["Ey_hdi_lo"], df["Ey_hdi_hi"],
+            color=colour, alpha=0.18, linewidth=0, label=f"{label} 90% HDI",
+        )
+        ax.plot(
+            df["age_months"], df["Ey_median"], color=colour, lw=2.5,
+            label=f"{label} median",
+        )
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.set_ylim(bottom=0)
+    ax.legend(loc="upper left", frameon=True)
+    fig.savefig(out_base + ".png")
+    fig.savefig(out_base + ".svg")
+    plt.close(fig)
+
+
+def plot_summary_band(
+    ax, df: pd.DataFrame, x_col: str, label: str, colour: str,
+    *, min_coverage: float = DEFAULT_MIN_COVERAGE, show_50: bool = True,
+) -> None:
+    """Plot a median line with 90% (and optionally 50%) HDI bands from a
+    :func:`summarise_per_N`-shaped frame, dropping low-coverage grid points."""
+    df_ok = df[df["coverage"] >= min_coverage] if "coverage" in df else df
+    if df_ok.empty:
+        return
+    ax.fill_between(
+        df_ok[x_col], df_ok["hdi90_lo"], df_ok["hdi90_hi"],
+        color=colour, alpha=0.15, linewidth=0, label=f"{label} 90% HDI",
+    )
+    if show_50:
+        ax.fill_between(
+            df_ok[x_col], df_ok["hdi50_lo"], df_ok["hdi50_hi"],
+            color=colour, alpha=0.30, linewidth=0, label=f"{label} 50% HDI",
+        )
+    ax.plot(df_ok[x_col], df_ok["median"], color=colour, lw=2.5, label=f"{label} median")

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import numpy as np
+import pandas as pd
+
+from vocab_growth import comparison
+
+
+# ---- registry resolution ----
+def test_registry_resolution():
+    assert comparison.model_dir("vg06").replace("\\", "/").endswith(
+        "output/models/VG06-age-understood-spoken-td"
+    )
+    assert comparison.n_trials("vg06") == 800
+    assert comparison.n_trials("vg10") == 800
+    assert comparison.population("vg06") == "td"
+    assert comparison.population("vg10") == "ds"
+    assert comparison.model_label("vg06") == "VG06 (TD)"
+    assert comparison.model_label("vg10") == "VG10 (DS)"
+    assert comparison.trace_path("vg10").replace("\\", "/").endswith("trace.nc")
+
+
+# ---- first_crossing (scalar, CSV curves) ----
+def test_first_crossing_linear_interpolation():
+    x = np.array([0.0, 1.0, 2.0, 3.0])
+    y = np.array([0.0, 10.0, 20.0, 30.0])
+    assert comparison.first_crossing(x, y, 15.0) == 1.5
+
+
+def test_first_crossing_never_reached_is_none():
+    x = np.array([0.0, 1.0, 2.0])
+    y = np.array([0.0, 1.0, 2.0])
+    assert comparison.first_crossing(x, y, 99.0) is None
+
+
+def test_first_crossing_already_above_returns_first_x():
+    x = np.array([5.0, 6.0, 7.0])
+    y = np.array([50.0, 60.0, 70.0])
+    assert comparison.first_crossing(x, y, 10.0) == 5.0
+
+
+# ---- per-draw crossing / interpolation ----
+def test_first_crossing_age_recovers_shift():
+    ages = np.linspace(0.0, 100.0, 1001)
+    U = np.stack([ages, ages + 0.5, ages - 0.3])
+    S = U - 5.0
+    for n in (10.0, 50.0, 90.0):
+        da = comparison.first_crossing_age(S, ages, n) - comparison.first_crossing_age(U, ages, n)
+        assert np.allclose(da, 5.0, atol=1e-2)
+
+
+def test_evaluate_at_ages_interp_and_out_of_range():
+    ages = np.array([0.0, 10.0, 20.0])
+    Y = np.array([[0.0, 100.0, 200.0]])
+    assert np.isclose(comparison.evaluate_at_ages(Y, ages, np.array([5.0]))[0], 50.0)
+    assert np.isnan(comparison.evaluate_at_ages(Y, ages, np.array([25.0]))[0])
+
+
+# ---- HDI / summary ----
+def test_hdi_from_samples_uniform_grid():
+    x = np.linspace(0.0, 1.0, 1001)
+    lo, hi = comparison.hdi_from_samples(x, 0.5)
+    assert np.isclose(hi - lo, 0.5, atol=1e-2)
+    assert lo >= 0.0 and hi <= 1.0
+
+
+def test_summarise_per_N_coverage_and_columns():
+    samples = np.tile(np.array([1.0, 2.0, 3.0]), (100, 1))
+    samples[:50, 1] = np.nan  # half-missing middle column
+    df = comparison.summarise_per_N(samples, np.array([10.0, 20.0, 30.0]))
+    assert list(df["coverage"]) == [1.0, 0.5, 1.0]
+    assert {"median", "hdi50_lo", "hdi90_hi"}.issubset(df.columns)
+
+
+# ---- analyses ----
+def test_compute_latency_shifted_linear():
+    ages = np.linspace(0.0, 100.0, 1001)
+    U = np.stack([ages, ages + 0.2])
+    S = U - 5.0
+    da_df, extra_df = comparison.compute_latency(ages, U, S, np.array([10.0, 50.0]))
+    assert np.allclose(da_df["median"], 5.0, atol=1e-2)
+    assert np.allclose(extra_df["median"], 5.0, atol=1e-2)
+
+
+def test_compute_q_at_U_constant_ratio():
+    ages = np.linspace(0.0, 100.0, 1001)
+    U = np.stack([ages * 8.0, ages * 8.0])  # 0..800
+    S = 0.3 * U
+    q = comparison.compute_q_at_U(ages, U, S, np.array([100.0, 400.0]))
+    assert np.allclose(q[~np.isnan(q)], 0.3, atol=1e-6)
+
+
+def test_invert_curve_linear():
+    df = pd.DataFrame(
+        {
+            "age_months": [0.0, 10.0, 20.0, 30.0],
+            "Y_hdi_lo": [0.0, 50.0, 100.0, 150.0],
+            "Y_median": [0.0, 100.0, 200.0, 300.0],
+            "Y_hdi_hi": [0.0, 200.0, 400.0, 600.0],
+        }
+    )
+    inv = comparison.invert_curve(df, targets=[100])
+    row = inv.iloc[0]
+    assert row["target_words"] == 100
+    assert np.isclose(row["age_typical_child_p50"], 10.0)  # median hits 100 at age 10
+    assert np.isclose(row["age_fast_child_p95"], 5.0)      # fast hits 100 at age 5
+    assert np.isclose(row["age_slow_child_p5"], 20.0)      # slow hits 100 at age 20


### PR DESCRIPTION
## Summary

The `scripts/compare_*` and `time_to_milestone` tools had each re-implemented the same logic — **five copies of `first_crossing`**, two trace loaders, ad-hoc HDI/interpolation — and **hardcoded the compared models by output-directory path**. Adding a new model pair (e.g. a future TD model with study intercepts) meant editing every script.

This introduces `src/vocab_growth/comparison.py` as the single, model-agnostic home for the shared helpers, and turns the scripts into thin CLI wrappers around it. **Comparison targets are now `MODEL_REGISTRY` keys** (`"vg06"`, `"vg10"`, …); output dirs, `n_trials` and population are resolved from each model's definition.

> A future TD-with-study-intercepts model plugs in by adding one registry entry and re-fitting — `comparison.compare`/the scripts need no edits, because every bivariate model (plain, study-RE, subject-RE) emits the same `p_u_plot`/`p_s_plot`/`q_plot` population trajectories that the module reads.

## Module (`vocab_growth.comparison`)

Behaviour is preserved **verbatim** from the validated `compare_ds_td_latency.py` / `compare_ds_td_q_overlap.py` implementations (the ones `verify_ds_td_latency.py` checks):

- **Registry resolution:** `model_dir`, `trace_path`, `n_trials`, `population`, `model_label`, `population_trajectory`
- **Trace loading:** `load_population_trajectory` (robust to the ArviZ 1.x DataTree backing)
- **Helpers:** `first_crossing`, `first_crossing_age`, `evaluate_at_ages`, `hdi_from_samples`, `summarise_per_N`, `prob_a_greater_b`, `invert_curve`
- **Analyses:** `compute_latency`, `compute_q_at_U`, `compute_q_at_age`
- **Plots:** `overlay_age_curves`, `plot_summary_band`

## Scripts (net −560 lines)

Refactored to import from the module: `compare_models`, `compare_ds_td_latency`, `compare_ds_td_q_overlap`, `compare_ds_td_q_vs_understood`, `compare_ds_td_trajectories`, `time_to_milestone`. `compare_ds_td.py` (already documented as superseded by `compare_models.py`) becomes a thin deprecation shim. **All output filenames and locations are unchanged.**

## Verification

- `verify_ds_td_latency.py` still imports its names from `compare_ds_td_latency` (re-exported) and **passes** unchanged.
- All 8 comparison scripts run to completion and regenerate their outputs.
- `ruff check` clean; `pytest` green — adds `tests/test_comparison.py` (11 synthetic + registry unit tests covering crossings, interpolation, HDI, latency, q-at-comprehension, curve inversion, and registry resolution).

## Note

Pairs with #41: the joint-model output tables this consolidates over are only produced once the `az.hdi` fix in #41 lets VG05–VG10 finish their reporting stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)