### PR TITLE
data: use understood_imputed for uk_01 WG rows in vocab_combined

### DIFF
--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -227,7 +227,7 @@ con.execute(
            vuk1.subject_id,
            vuk1.sex,
            vuk1.age,
-           vuk1.understood,
+           CASE WHEN vuk1.survey = 'WG' THEN vuk1.understood_imputed ELSE NULL END as understood,
            vuk1.spoken,
            vuk1.signed,
            vuk1.produced,


### PR DESCRIPTION
## Summary

- Updates the `uk_01` UNION block in `vocab_combined` to use `understood_imputed` instead of `understood` for WG rows
- WS rows retain `NULL` for understood (WS form does not assess comprehension)
- Recovers 41 previously-excluded WG rows: uk_01 WG rows with non-null `understood` goes from **29 → 70**

## What understood_imputed actually is

**This is not recovered comprehension data.** For the 41 WG rows where `understood` is `NULL` (set during data cleaning in `uk_01_edg.py` because the understood count was 0 but production was > 0 — treated as a recording error), `understood_imputed` is:

```python
df["understood_imputed"] = df["understood"].fillna(df[["spoken", "signed"]].max(axis=1))
```

So comprehension for those 41 rows is **imputed as `max(spoken, signed)`** — a production-floor proxy. The reasoning: you can't produce a word without understanding it, so production is a lower bound on comprehension. This is the same logic as the `GREATEST(says, understands)` pattern already used for ie_01.

**Implication**: On the WG form, true comprehension typically runs well above production. The imputed value is a floor, not an estimate of true comprehension. For the 41 recovered rows, we know the child understands *at least* as many words as they produce, but the actual comprehension score may be substantially higher.

## Verification

- uk_01 WG rows: 70 total, 70 with non-null `understood` ✓
- uk_01 WS rows: 149 total, 0 with non-null `understood` ✓
- Spot-check: imputed rows have `understood = max(spoken, signed)` ✓
- Spot-check: original rows (29) have `understood = understood_imputed = orig understood` ✓

This PR recovers 41 WG rows by substituting `max(spoken, signed)` as a comprehension floor, not actual comprehension scores.

The `uk_01_edg.md` documentation in `research-data-analysis` has been updated separately to record this decision.

## Test plan

- [ ] Frank reviews and confirms production-as-floor is acceptable for the 41 imputed rows
- [ ] Re-run `python scripts/prepare_data.py` and confirm counts match above
- [ ] Re-fit any affected models after merge