### PR TITLE
build(env): pin matplotlib <3.11 (arviz-plots 1.1.0 incompatibility)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
       - ipython>=9.14.1
       - ipywidgets>=8.1.8
       - jupytext
-      - matplotlib>=3.10.9
+      - matplotlib>=3.10.9,<3.11
       - notebook>=7.5.7
       - orjson>=3.11.9
       - pytest>=9.0.3


### PR DESCRIPTION
## Summary

Pin `matplotlib` to `<3.11` in `environment.yml` so the conda env builds into a working state.

## Why

`matplotlib 3.11.0` removed the `matplotlib.style.core` submodule. `arviz-plots 1.1.0` (pulled in transitively via `nutpie → arviz`) still calls `matplotlib.style.core.USER_LIBRARY_PATHS` / `reload_library()` at import, so a fresh env raises:

```
AttributeError: module 'matplotlib.style' has no attribute 'core'
```

…which breaks the entire `nutpie → arviz → pymc` import chain — **no model can be fit**. The existing floor (`>=3.10.9`) had no upper bound, so `conda env update` pulled 3.11.

`3.10.9` (the current floor) is fully compatible, so this is a no-op for already-working installs and only prevents the 3.11 break.

## Scope

One line in `environment.yml`. Revert the upper bound once `arviz-plots` ships a 3.11-compatible release.

Companion to #50 (full reporting fits for VG11/VG12/VG13), where this fix is listed as a required environment prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
