### PR TITLE
Add VG15 — joint sign/speech model (within-understood association ψ + study REs)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -61,7 +61,7 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 ```
 
-- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, or `all`.
+- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
@@ -88,22 +88,23 @@ Each model is a self-contained module in `src/vocab_growth/models/model_vgNN.py`
 
 The models differ in which outcome, population, and structure they target:
 
-| Model | Outcome                                    | Population           | Notes                                                                                                                                              |
-| ----- | ------------------------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| VG01  | Words spoken                               | Down syndrome        |                                                                                                                                                    |
-| VG02  | Words understood                           | Down syndrome        |                                                                                                                                                    |
-| VG03  | Words spoken                               | Typically developing |                                                                                                                                                    |
-| VG04  | Words understood                           | Typically developing |                                                                                                                                                    |
-| VG05  | Words understood + spoken (joint)          | Down syndrome        |                                                                                                                                                    |
-| VG06  | Words understood + spoken (joint)          | Typically developing |                                                                                                                                                    |
-| VG07  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts                                                                                                                            |
-| VG08  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts + subject random intercepts on understood                                                                                  |
-| VG09  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio                                                          |
-| VG10  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age |
-| VG11  | Words spoken                               | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                     |
-| VG12  | Words understood                           | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                     |
-| VG13  | Words understood + spoken (joint)          | Typically developing | Ages 8–18 months only; dataset-level study random intercepts + GP anchor at 13 months                                                              |
-| VG14  | Words understood + spoken + signed (joint) | Down syndrome        | Adds signing as a third production ratio `r(a)`; `p_Sign = p_U · r`; total expressive `p_any` derived assuming sign/speech independence given age  |
+| Model | Outcome                                               | Population           | Notes                                                                                                                                                                                                        |
+| ----- | ----------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| VG01  | Words spoken                                          | Down syndrome        |                                                                                                                                                                                                              |
+| VG02  | Words understood                                      | Down syndrome        |                                                                                                                                                                                                              |
+| VG03  | Words spoken                                          | Typically developing |                                                                                                                                                                                                              |
+| VG04  | Words understood                                      | Typically developing |                                                                                                                                                                                                              |
+| VG05  | Words understood + spoken (joint)                     | Down syndrome        |                                                                                                                                                                                                              |
+| VG06  | Words understood + spoken (joint)                     | Typically developing |                                                                                                                                                                                                              |
+| VG07  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts                                                                                                                                                                                      |
+| VG08  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts + subject random intercepts on understood                                                                                                                                            |
+| VG09  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio                                                                                                                    |
+| VG10  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age                                                           |
+| VG11  | Words spoken                                          | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                                                                               |
+| VG12  | Words understood                                      | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                                                                               |
+| VG13  | Words understood + spoken (joint)                     | Typically developing | Ages 8–18 months only; dataset-level study random intercepts + GP anchor at 13 months                                                                                                                        |
+| VG14  | Words understood + spoken + signed (joint)            | Down syndrome        | Adds signing as a third production ratio `r(a)`; `p_Sign = p_U · r`; total expressive `p_any` derived assuming sign/speech independence given age                                                            |
+| VG15  | Words understood + spoken + signed (joint, four-cell) | Down syndrome        | Within-understood sign-speech association `psi` (Plackett copula, identified from the uk_02 four-cell cross-tab) + study random intercepts; data-identified `p_any` replaces VG14's independence upper bound |
 
 ### Shared utilities (`dse_research_utils`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 ```
 
-- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, or `all`.
+- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
@@ -88,22 +88,23 @@ Each model is a self-contained module in `src/vocab_growth/models/model_vgNN.py`
 
 The models differ in which outcome, population, and structure they target:
 
-| Model | Outcome                                    | Population           | Notes                                                                                                                                              |
-| ----- | ------------------------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| VG01  | Words spoken                               | Down syndrome        |                                                                                                                                                    |
-| VG02  | Words understood                           | Down syndrome        |                                                                                                                                                    |
-| VG03  | Words spoken                               | Typically developing |                                                                                                                                                    |
-| VG04  | Words understood                           | Typically developing |                                                                                                                                                    |
-| VG05  | Words understood + spoken (joint)          | Down syndrome        |                                                                                                                                                    |
-| VG06  | Words understood + spoken (joint)          | Typically developing |                                                                                                                                                    |
-| VG07  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts                                                                                                                            |
-| VG08  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts + subject random intercepts on understood                                                                                  |
-| VG09  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio                                                          |
-| VG10  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age |
-| VG11  | Words spoken                               | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                     |
-| VG12  | Words understood                           | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                     |
-| VG13  | Words understood + spoken (joint)          | Typically developing | Ages 8–18 months only; dataset-level study random intercepts + GP anchor at 13 months                                                              |
-| VG14  | Words understood + spoken + signed (joint) | Down syndrome        | Adds signing as a third production ratio `r(a)`; `p_Sign = p_U · r`; total expressive `p_any` derived assuming sign/speech independence given age  |
+| Model | Outcome                                               | Population           | Notes                                                                                                                                                                                                        |
+| ----- | ----------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| VG01  | Words spoken                                          | Down syndrome        |                                                                                                                                                                                                              |
+| VG02  | Words understood                                      | Down syndrome        |                                                                                                                                                                                                              |
+| VG03  | Words spoken                                          | Typically developing |                                                                                                                                                                                                              |
+| VG04  | Words understood                                      | Typically developing |                                                                                                                                                                                                              |
+| VG05  | Words understood + spoken (joint)                     | Down syndrome        |                                                                                                                                                                                                              |
+| VG06  | Words understood + spoken (joint)                     | Typically developing |                                                                                                                                                                                                              |
+| VG07  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts                                                                                                                                                                                      |
+| VG08  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts + subject random intercepts on understood                                                                                                                                            |
+| VG09  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio                                                                                                                    |
+| VG10  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age                                                           |
+| VG11  | Words spoken                                          | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                                                                               |
+| VG12  | Words understood                                      | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                                                                               |
+| VG13  | Words understood + spoken (joint)                     | Typically developing | Ages 8–18 months only; dataset-level study random intercepts + GP anchor at 13 months                                                                                                                        |
+| VG14  | Words understood + spoken + signed (joint)            | Down syndrome        | Adds signing as a third production ratio `r(a)`; `p_Sign = p_U · r`; total expressive `p_any` derived assuming sign/speech independence given age                                                            |
+| VG15  | Words understood + spoken + signed (joint, four-cell) | Down syndrome        | Within-understood sign-speech association `psi` (Plackett copula, identified from the uk_02 four-cell cross-tab) + study random intercepts; data-identified `p_any` replaces VG14's independence upper bound |
 
 ### Shared utilities (`dse_research_utils`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
 ```
 
-- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, or `all`.
+- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg06`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
@@ -88,22 +88,23 @@ Each model is a self-contained module in `src/vocab_growth/models/model_vgNN.py`
 
 The models differ in which outcome, population, and structure they target:
 
-| Model | Outcome                                    | Population           | Notes                                                                                                                                              |
-| ----- | ------------------------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| VG01  | Words spoken                               | Down syndrome        |                                                                                                                                                    |
-| VG02  | Words understood                           | Down syndrome        |                                                                                                                                                    |
-| VG03  | Words spoken                               | Typically developing |                                                                                                                                                    |
-| VG04  | Words understood                           | Typically developing |                                                                                                                                                    |
-| VG05  | Words understood + spoken (joint)          | Down syndrome        |                                                                                                                                                    |
-| VG06  | Words understood + spoken (joint)          | Typically developing |                                                                                                                                                    |
-| VG07  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts                                                                                                                            |
-| VG08  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts + subject random intercepts on understood                                                                                  |
-| VG09  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio                                                          |
-| VG10  | Words understood + spoken (joint)          | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age |
-| VG11  | Words spoken                               | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                     |
-| VG12  | Words understood                           | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                     |
-| VG13  | Words understood + spoken (joint)          | Typically developing | Ages 8–18 months only; dataset-level study random intercepts + GP anchor at 13 months                                                              |
-| VG14  | Words understood + spoken + signed (joint) | Down syndrome        | Adds signing as a third production ratio `r(a)`; `p_Sign = p_U · r`; total expressive `p_any` derived assuming sign/speech independence given age  |
+| Model | Outcome                                               | Population           | Notes                                                                                                                                                                                                        |
+| ----- | ----------------------------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| VG01  | Words spoken                                          | Down syndrome        |                                                                                                                                                                                                              |
+| VG02  | Words understood                                      | Down syndrome        |                                                                                                                                                                                                              |
+| VG03  | Words spoken                                          | Typically developing |                                                                                                                                                                                                              |
+| VG04  | Words understood                                      | Typically developing |                                                                                                                                                                                                              |
+| VG05  | Words understood + spoken (joint)                     | Down syndrome        |                                                                                                                                                                                                              |
+| VG06  | Words understood + spoken (joint)                     | Typically developing |                                                                                                                                                                                                              |
+| VG07  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts                                                                                                                                                                                      |
+| VG08  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts + subject random intercepts on understood                                                                                                                                            |
+| VG09  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio                                                                                                                    |
+| VG10  | Words understood + spoken (joint)                     | Down syndrome        | Study random intercepts + subject random intercepts on understood and on production ratio + tighter q-anchor priors + GP anchored at reference age                                                           |
+| VG11  | Words spoken                                          | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                                                                               |
+| VG12  | Words understood                                      | Typically developing | Dataset-level study random intercepts + GP anchor at 19 months                                                                                                                                               |
+| VG13  | Words understood + spoken (joint)                     | Typically developing | Ages 8–18 months only; dataset-level study random intercepts + GP anchor at 13 months                                                                                                                        |
+| VG14  | Words understood + spoken + signed (joint)            | Down syndrome        | Adds signing as a third production ratio `r(a)`; `p_Sign = p_U · r`; total expressive `p_any` derived assuming sign/speech independence given age                                                            |
+| VG15  | Words understood + spoken + signed (joint, four-cell) | Down syndrome        | Within-understood sign-speech association `psi` (Plackett copula, identified from the uk_02 four-cell cross-tab) + study random intercepts; data-identified `p_any` replaces VG14's independence upper bound |
 
 ### Shared utilities (`dse_research_utils`)
 

--- a/docs/models/vg14/index.qmd
+++ b/docs/models/vg14/index.qmd
@@ -87,15 +87,13 @@ For full details and discussion, please refer to the technical report.
 
 ### Signed ratio
 
-The empirical signed fraction of understood words is a **hump** — near zero below ~24 months, rising to a peak in the preschool years, then receding as words move into speech — not a monotone trend. The signed-ratio mean trend is therefore pinned approximately **flat** (tight, equal low-fraction anchor priors, so the logit-linear trend cannot co-opt the real old-age fade into a monotone decline), and the GP is given a **looser amplitude** (`eta_sign`) and a **shorter lengthscale** than the spoken ratio so it can carry the rise-then-fall shape itself.
+The empirical signed fraction of understood words is a **hump** — near zero below ~24 months, rising to a peak in the preschool years, then receding as words move into speech — not a monotone trend. The signed-ratio mean trend is **intercept-only** (no age slope): this structurally prevents a free slope from extrapolating the ratio below the data floor (< ~18 months), so the level no longer needs a tight prior. A single weakly-informative intercept (`intercept_sign`, logit scale) lets the data set the signed level and old-age tail, while the GP — given a **looser amplitude** (`eta_sign`) and a **shorter lengthscale** than the spoken ratio — carries the rise-then-fall shape.
 
 ![Lengthscale prior `ell_unit_sign_dist`](ell_unit_sign_dist.svg){#fig-ell-sign .lightbox fig-align="left"}
 
 ![Amplitude prior `eta_sign_dist`](eta_sign_dist.svg){#fig-eta-sign .lightbox fig-align="left"}
 
-![Flat-anchor prior (24 months) `p_slope_low_sign_dist`](p_slope_low_sign_dist.svg){#fig-slope-low-sign .lightbox fig-align="left"}
-
-![Flat-anchor prior (84 months) `p_slope_hi_sign_dist` — tight and equal to the 24-month anchor, pinning the signed mean trend flat](p_slope_hi_sign_dist.svg){#fig-slope-hi-sign .lightbox fig-align="left"}
+![Signed-ratio mean intercept prior `intercept_sign_dist` (logit scale, intercept-only mean)](intercept_sign_dist.svg){#fig-intercept-sign .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- understood
 

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -19,7 +19,7 @@ format:
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
+If the model was not fitted in "reporting" mode, the results will be more approximate than when additional sampling has been performed.
 :::
 
 This model (issue #49, Option 3) estimates the **within-understood association** between signing and speaking — the overlap that VG14 assumed away — and adds **study random intercepts**, replacing VG14's independence-based `p_any` upper bound with a _data-identified_ total expressive vocabulary.

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -1,0 +1,151 @@
+---
+title: "Model VG15: Joint sign/speech model with within-understood association - children with Down syndrome"
+
+date: last-modified
+date-format: "YYYY-MM-DD HH:mm:ss Z"
+
+format:
+  html:
+    code-fold: true
+    theme: cosmo
+    number-sections: true
+    toc: true
+    toc-depth: 2
+    code-links:
+      - repo
+---
+
+::: {.callout-warning title="Warning: Preliminary model output"}
+
+This model output is preliminary and likely to change as the model evolves and further data are received.
+
+If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
+:::
+
+This model (issue #49, Option 3) estimates the **within-understood association** between signing and speaking — the overlap that VG14 assumed away — and adds **study random intercepts**, replacing VG14's independence-based `p_any` upper bound with a _data-identified_ total expressive vocabulary.
+
+```{python}
+import matplotlib.pyplot as plt
+import pandas as pd
+```
+
+## Statistical model
+
+For each understood word, a child may sign it, speak it, both, or neither. We model the within-understood marginals and their association jointly, out of 800 checklist words:
+
+$$
+p_U(a) = \text{sigmoid}(f_U(a)), \quad r(a) = P(\text{sign}\mid\text{understood}) = \text{sigmoid}(g(a)), \quad q(a) = P(\text{speak}\mid\text{understood}) = \text{sigmoid}(h(a)),
+$$
+
+each a linear trend plus an HSGP on the logit scale (the signed ratio reuses VG14's hump-capable spec). A single scalar **Plackett odds ratio** $\psi$ links sign and speech within understood words:
+
+$$
+\pi_\text{both} = C(r, q; \psi), \quad \pi_\text{sign-only} = r - \pi_\text{both}, \quad \pi_\text{speak-only} = q - \pi_\text{both}, \quad \pi_\text{neither} = 1 - r - q + \pi_\text{both}.
+$$
+
+$\psi = 1$ is independence ($\pi_\text{both} = r\,q$, the VG14 assumption); $\psi > 1$ is positive association (a word is signed and spoken together more often than independence predicts). The **data-identified total expressive vocabulary** is
+
+$$
+p_\text{any}(a) = p_U(a)\,\bigl(r(a) + q(a) - \pi_\text{both}(a)\bigr),
+$$
+
+which sits _below_ VG14's independence upper bound $p_U(1-(1-r)(1-q))$ whenever $\psi>1$.
+
+**Study random intercepts** ($\delta_u, \delta_q, \delta_\text{sign} \sim \text{Normal}(0,\tau)$ per study, the VG07–VG10 pattern) sit on $f_U$, $g$, $h$ at the observation level, so the reported age curves (population level) are separated from study composition — which made VG14's signed peak unidentifiable.
+
+### Likelihoods
+
+- **understood** (all DS studies): $\text{BetaBinomial}(800, p_U, \kappa_U)$.
+- **spoken / signed marginals** (uk_01/04/05/06 + uk_02 marginal-only rows): $\text{BetaBinomial}(800, p_U q, \kappa_S)$ and $\text{BetaBinomial}(800, p_U r, \kappa_\text{sign})$.
+- **uk_02 four cells** (the only cross-tab source): $\text{DirichletMultinomial}(\text{total}, \text{conc}\cdot[\pi_\text{neither}, \pi_\text{sign-only}, \pi_\text{speak-only}, \pi_\text{both}])$. **This is what identifies $\psi$.**
+
+::: {.callout-important title="psi rests almost entirely on uk_02 — descriptive / exploratory"}
+
+The association $\psi$ is identified by the ~60 uk_02 rows with the four-cell cross-tab (19–56 months). It is a **single scalar** (the data do not support an age-varying association at this sample size) and is **descriptive/exploratory**. The four-cell composition outside ~19–56 months, and $p_\text{any}$ there, lean on the marginal trajectories plus scalar-$\psi$ extrapolation. uk_06 contributes marginal signed/spoken counts only (no cross-tab).
+
+:::
+
+![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
+
+## Priors
+
+### Trajectories (understood / spoken-ratio / signed-ratio)
+
+![`p_slope_low_u_dist`](p_slope_low_u_dist.svg){.lightbox fig-align="left" width=380}
+![`eta_u_dist`](eta_u_dist.svg){.lightbox fig-align="left" width=380}
+![`p_slope_low_sign_dist`](p_slope_low_sign_dist.svg){.lightbox fig-align="left" width=380}
+![`eta_sign_dist`](eta_sign_dist.svg){.lightbox fig-align="left" width=380}
+
+### Association and concentration
+
+![Plackett log odds-ratio prior `log_psi_dist`](log_psi_dist.svg){#fig-log-psi .lightbox fig-align="left" width=380}
+![Dirichlet-Multinomial log-concentration prior `log_conc_dist`](log_conc_dist.svg){#fig-log-conc .lightbox fig-align="left" width=380}
+
+## Prior predictive checks
+
+![Prior r(a) = P(sign | understood)](prior_samples_r.svg){#fig-prior-r .lightbox fig-align="left"}
+
+![Prior q(a) = P(speak | understood)](prior_samples_q.svg){#fig-prior-q .lightbox fig-align="left"}
+
+## Data
+
+```{python}
+descriptive_stats = pd.read_csv("descriptive_statistics.csv", index_col=0)
+descriptive_stats
+```
+
+## Diagnostics
+
+```{python}
+diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
+diagnostics
+```
+
+![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}
+
+![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
+
+## Association psi
+
+The posterior of the sign-speech odds ratio $\psi$, with the independence reference $\psi = 1$.
+
+![Association psi posterior](psi_posterior.svg){#fig-psi .lightbox fig-align="left"}
+
+```{python}
+summary_psi = pd.read_csv("posterior_summary_psi.csv")
+summary_psi
+```
+
+## Within-understood composition
+
+The four mutually-exclusive states of an understood word (sign-only, sign+speech, speak-only, neither) as fractions of understood vocabulary over age — words migrating from sign into speech.
+
+![Four-cell composition trajectory](four_cell_composition.svg){#fig-composition .lightbox fig-align="left"}
+
+## Total expressive vocabulary (data-identified)
+
+The data-identified $p_\text{any}$ against VG14's independence upper bound. With $\psi > 1$ the identified total sits below the bound (the gap is the association VG14 ignored).
+
+![Data-identified p_any vs independence bound](p_any_identified_vs_bound.svg){#fig-p-any .lightbox fig-align="left"}
+
+```{python}
+summary_p_any = pd.read_csv("posterior_summary_p_any.csv")
+summary_p_any
+```
+
+## Signed vs spoken ratio (study REs marginalised)
+
+The population sign and speak ratios with study composition absorbed by the random intercepts. Compare the signed peak/recede with VG14, where it was study-confounded.
+
+![Signed vs spoken ratio](signed_vs_spoken_rate.svg){#fig-rates .lightbox fig-align="left"}
+
+```{python}
+summary_r = pd.read_csv("posterior_summary_r.csv")
+summary_r
+```
+
+## uk_02 four-cell posterior predictive check
+
+Observed vs predicted totals for the four within-understood cells (uk_02), checking the Dirichlet-Multinomial fit that identifies $\psi$.
+
+![uk_02 four-cell PPC](uk02_cell_ppc.svg){#fig-ppc .lightbox fig-align="left"}

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -37,7 +37,7 @@ $$
 p_U(a) = \text{sigmoid}(f_U(a)), \quad r(a) = P(\text{sign}\mid\text{understood}) = \text{sigmoid}(g(a)), \quad q(a) = P(\text{speak}\mid\text{understood}) = \text{sigmoid}(h(a)),
 $$
 
-each a linear trend plus an HSGP on the logit scale (the signed ratio reuses VG14's hump-capable spec). A single scalar **Plackett odds ratio** $\psi$ links sign and speech within understood words:
+$f_U$ and $h$ are a linear trend plus an HSGP on the logit scale; the signed mean $g$ is **intercept-only** plus an HSGP (matching VG14 — a free age slope would extrapolate the signed ratio below the data floor, so the GP alone carries the rise-then-fall hump). A single scalar **Plackett odds ratio** $\psi$ links sign and speech within understood words:
 
 $$
 \pi_\text{both} = C(r, q; \psi), \quad \pi_\text{sign-only} = r - \pi_\text{both}, \quad \pi_\text{speak-only} = q - \pi_\text{both}, \quad \pi_\text{neither} = 1 - r - q + \pi_\text{both}.
@@ -73,7 +73,7 @@ The association $\psi$ is identified by the ~60 uk_02 rows with the four-cell cr
 
 ![`p_slope_low_u_dist`](p_slope_low_u_dist.svg){.lightbox fig-align="left" width=380}
 ![`eta_u_dist`](eta_u_dist.svg){.lightbox fig-align="left" width=380}
-![`p_slope_low_sign_dist`](p_slope_low_sign_dist.svg){.lightbox fig-align="left" width=380}
+![`intercept_sign_dist` (signed mean is intercept-only)](intercept_sign_dist.svg){.lightbox fig-align="left" width=380}
 ![`eta_sign_dist`](eta_sign_dist.svg){.lightbox fig-align="left" width=380}
 
 ### Association and concentration

--- a/notes/202606151700-vg14-signed-ratio-shape-and-p-any-bias.md
+++ b/notes/202606151700-vg14-signed-ratio-shape-and-p-any-bias.md
@@ -154,8 +154,9 @@ prose describes the result as a hump (signing rises then yields to speech), not
 
 Re-fitted at `--config rep` (6 chains × 6000 draws) after the changes above.
 Diagnostics are clean: **0 divergences / 36 000**, max r̂ = 1.001, min ESS ≈ 6.5k.
-Signed-block posteriors: `eta_sign` 1.15 (the loosened GP is used), `ell_sign`
-≈ 10 mo, anchors pinned flat at 0.16 / 0.12 (the tight prior held).
+(The signed mean here used the tight flat-anchor parameterisation; it is
+**superseded by §6's intercept-only refit** — the r(a) shape, peak and crossover
+below are unchanged, only the signed-mean parameterisation differs.)
 
 `r(a)` is now a **hump**, not a monotone decline:
 
@@ -186,3 +187,49 @@ independence over-states the union by **3.7 pp** within `uk_02` (0.608 vs observ
 
 Key figures: `signed_rate.svg` (hump, extrapolation shaded < 18 / > 54 mo),
 `sign_speech_crossover.svg`, `p_any_validation.svg`.
+
+## 6. Signed mean was prior-dominated → intercept-only refit (current)
+
+The flat-anchor signed mean (§1) did its job — it killed the original spurious
+"~58% signed at 12 mo" slope-extrapolation — but it was **too strict**: the two
+anchor priors (`Beta(15,90) ≈ 0.143 ± 0.034`) were prior-dominated (posterior sd
+≈ prior sd, ~0.16/0.12 — the data wasn't moving them), so the signed **level**
+was set by the prior, not the data. By contrast the understood/spoken anchors all
+moved a lot and shrank, confirming the strictness was isolated to the signed mean.
+
+**Fix:** make the signed mean **intercept-only** (drop the age slope entirely —
+that was the actual failure mode) and replace the two tight anchors with one
+weakly-informative intercept, `intercept_sign ~ Normal(logit(0.15), 0.75)` on the
+logit scale. The slope can no longer extrapolate, so a wide level prior is safe.
+The signed GP (`eta_sign`, `ell_unit_sign`) is unchanged. Understood/spoken,
+kappa, sampler and `include_uk06=True` are untouched.
+
+**Result (rep, uk_06 included, intercept-only):** clean (0 divergences / 36 000,
+r̂ ≤ 1.001, min ESS ≈ 7.6k).
+
+| quantity                   | flat-anchor                  | intercept-only                 |
+| -------------------------- | ---------------------------- | ------------------------------ |
+| signed level prior sd      | ~0.034 (probability)         | 0.75 (logit)                   |
+| `intercept_sign` posterior | (pinned) 0.16 / 0.12 anchors | mean −1.84 ≈ 0.14, **sd 0.44** |
+| `eta_sign`                 | 1.15                         | 1.06                           |
+| r peak                     | 0.46 @ ~30 mo                | 0.47 @ ~30 mo                  |
+| crossover                  | ~39 mo                       | ~39 mo                         |
+| r(90) tail                 | 0.043                        | 0.043                          |
+
+The intercept posterior sd (0.44) is now **meaningfully below its prior sd
+(0.75)** — the data is speaking, where before it wasn't. `eta_sign` dropped
+slightly (the free level carries some of what the GP was lifting) and is not
+pinned. **Substantively the curve is unchanged**: the freed level lands at ~0.14
+(≈ the old pinned level), and — contrary to the hypothesis that uk_06's heavy
+older signers would lift the tail — the old-age tail stays low (r(90) ≈ 0.04).
+The aggregate 60–115 mo marginal is dominated by uk_01's many near-zero older
+signers, which outweigh uk_06's 11 heavy ones, so the data genuinely supports a
+low old-age population tail. The change is therefore a **methodological
+correction** (level now data-informed, honest wider uncertainty), not a new
+substantive result.
+
+**Peak still does not relocate** and is not expected to: looser priors give
+honest wider uncertainty, not a later peak. The late window is essentially one
+study and VG14 has no study random effects, so the peak age remains
+study-confounded. The real peak-identifiability fix is **study random
+intercepts (VG15)**, not prior tuning.

--- a/notes/202606151900-vg15-joint-signspeech.md
+++ b/notes/202606151900-vg15-joint-signspeech.md
@@ -43,9 +43,10 @@ marginal signed only (no cross-tab).
 
 ## 3. Model + priors
 
-- `p_U`, `r = P(sign|understood)`, `q = P(speak|understood)`: linear trend + HSGP
-  on logit scale; signed ratio reuses VG14's hump-capable spec (flat-pinned mean,
-  loose+short GP). Priors seeded from VG14.
+- `p_U`, `r = P(sign|understood)`, `q = P(speak|understood)`: HSGP on the logit
+  scale. `p_U`/`q` have a linear trend; the signed mean `r` is **intercept-only**
+  (no age slope, matching VG14 — see §6), with a loose+short GP carrying the hump.
+  Priors seeded from VG14.
 - `psi`: `log psi ~ Normal(0.3, 0.5)` — weakly positive (uk_02 shows both 0.18 >
   r·q 0.14) but spanning independence `psi = 1`.
 - Dirichlet-Multinomial concentration: `log conc ~ Normal(3.0, 1.0)`.
@@ -65,7 +66,10 @@ marginal signed only (no cross-tab).
 
 Fitted at `--config rep` (6 chains × 6000 draws). **Clean: 0 divergences /
 36 000, max r̂ = 1.001, min ESS ≈ 5.3k** (dev had 2/1000 divergences; they clear
-at `target_accept = 0.95`).
+at `target_accept = 0.95`). _(This section is the flat-anchor signed-mean fit; the
+current model is the intercept-only refit in §6 — ψ, the four-cell composition and
+`p_any` are substantively the same; only the signed-mean parameterisation
+differs.)_
 
 **Association.** `psi` median **1.78**, 90% HDI **[1.21, 2.44]**, **P(psi > 1) =
 0.997** — a clear positive within-understood sign-speech association. Words a
@@ -102,3 +106,37 @@ the preschool years.
 
 Key figures: `psi_posterior.svg`, `four_cell_composition.svg`,
 `p_any_identified_vs_bound.svg`, `signed_vs_spoken_rate.svg`, `uk02_cell_ppc.svg`.
+
+## 6. Signed marginal mean was prior-dominated → intercept-only refit (current)
+
+VG15 inherited VG14's tight `Beta(15,90)` signed anchors, and — exactly as in
+VG14 — they were **prior-dominated**: posterior sd ≈ prior sd (`p_slope_low_sign`
+0.169 ± 0.036, `p_slope_hi_sign` 0.129 ± 0.030, both ≈ the 0.034 prior sd), so
+the signed grand-mean **level** was set by the prior, not the data, while the
+spoken anchors were data-informed. Applied the same fix as VG14 (PR #52
+`da5750a`): the signed marginal mean is now **intercept-only** (drop the age
+slope — the actual extrapolation failure mode) with one weakly-informative
+intercept `intercept_sign ~ Normal(logit(0.15), 0.75)`. The **study random
+intercepts are untouched** (`tau_sign` is the largest RE in the model, ~0.95);
+with the REs handling between-study level, freeing the grand-mean intercept is
+even more clearly correct.
+
+**Result (rep, intercept-only):** clean — **2 / 36 000 divergences** (0.006%, a
+documented near-zero rate), max r̂ = 1.001, min ESS ≈ 6.1k.
+
+| quantity                   | flat-anchor                  | intercept-only                 |
+| -------------------------- | ---------------------------- | ------------------------------ |
+| `intercept_sign` posterior | (pinned) 0.17 / 0.13 anchors | mean −1.59 ≈ 0.17, **sd 0.48** |
+| `eta_sign`                 | ~1.0                         | 0.81                           |
+| `tau_sign` (study RE)      | ~0.95                        | 0.95 (unchanged)               |
+| ψ median [90% HDI]         | 1.82 [1.26, 2.51]            | 1.78 [1.19, 2.42]              |
+| P(ψ > 1)                   | 0.997                        | 0.997                          |
+
+The intercept posterior sd (0.48) is now meaningfully below its prior sd (0.75) —
+the data is speaking. `eta_sign` dropped (the free intercept carries level the GP
+was lifting) and is not pinned. **ψ, the four-cell composition and the
+data-identified `p_any` (still below the independence bound) are substantively
+unchanged** — this is a level/uncertainty correction, not a re-estimation of the
+association. The peak does **not** relocate; as throughout, study REs (not prior
+tuning) are the lever for the signed level/peak. The signed specs of VG14
+(trivariate) and VG15 (joint) are now consistently intercept-only.

--- a/notes/202606151900-vg15-joint-signspeech.md
+++ b/notes/202606151900-vg15-joint-signspeech.md
@@ -1,0 +1,104 @@
+# VG15: joint sign/speech model (issue #49, Option 3)
+
+Status: 2026-06-15, build + first fit. Author: Ethan (with Claude Code). Numbers
+from `output/models/VG15-age-joint-signspeech-ds/` and the source data in
+`data/`.
+
+## 1. What VG15 is (and why)
+
+VG14 modelled signing and speaking as two production ratios hanging off the
+understood trajectory, but assumed they were **conditionally independent given
+age**, so its total expressive vocabulary `p_any` was only an independence
+**upper bound**, and its signed peak age was **study-confounded** (no study
+random effects). VG15 fixes both:
+
+1. A scalar **Plackett association** `psi` linking sign and speech _within_
+   understood words, identified from uk_02's four-cell cross-tab. This yields a
+   **data-identified** `p_any = p_U·(r + q − pi_both)` instead of an upper bound,
+   plus the four-cell composition trajectory (sign-only → both → speak-only).
+2. **Study random intercepts** on `f_U`, `g` (sign), `h` (speak) — the VG07-VG10
+   pattern — so the reported (population) age curves are separated from study
+   composition.
+
+Built in a new isolated engine `common_joint_modality.py` (does not import or
+modify the bivariate / trivariate engines; VG01-VG14 untouched). Same
+`*_all`-as-plain-tensors memory discipline as VG14. r/q/p_U prior specs are
+seeded from the (uk_06-included) VG14 fit.
+
+## 2. Data
+
+DS only. Non-uk_02 studies contribute marginal understood/spoken/signed (from the
+merged view). uk_02 is taken from its raw CSV and split:
+
+- **Four-cell rows** (margins reconcile: `signed = signed_only + signed_spoken`,
+  `spoken = spoken_only + signed_spoken`, positive cell-sum): ~62 rows, 19–56 mo.
+  These feed the **Dirichlet-Multinomial** and identify `psi`. (The issue quoted
+  ~56; the margin-reconciling set used here is a few rows larger — it does not
+  change the science. Cell means as fractions of understood: neither ~0.43,
+  sign-only ~0.31, speak-only ~0.12, both ~0.18.)
+- **Marginal-only rows** (no cross-tab): ordinary marginal signed/spoken/understood.
+
+uk_06 signed counts are **included** (inherits the VG14 decision); they contribute
+marginal signed only (no cross-tab).
+
+## 3. Model + priors
+
+- `p_U`, `r = P(sign|understood)`, `q = P(speak|understood)`: linear trend + HSGP
+  on logit scale; signed ratio reuses VG14's hump-capable spec (flat-pinned mean,
+  loose+short GP). Priors seeded from VG14.
+- `psi`: `log psi ~ Normal(0.3, 0.5)` — weakly positive (uk_02 shows both 0.18 >
+  r·q 0.14) but spanning independence `psi = 1`.
+- Dirichlet-Multinomial concentration: `log conc ~ Normal(3.0, 1.0)`.
+- Study random intercepts: `tau_{u,q,sign} ~ HalfNormal(0.5)`, non-centred.
+- Likelihoods: understood / spoken / signed Beta-Binomial marginals +
+  uk_02 four-cell Dirichlet-Multinomial.
+
+## 4. Caveats (state up front)
+
+- `psi` is a **single scalar** resting almost entirely on ~62 uk_02 rows
+  (19–56 mo) — descriptive/exploratory; no age-varying association at this n.
+- Composition and `p_any` outside ~19–56 mo lean on the marginal trajectories +
+  scalar-`psi` extrapolation.
+- uk_06 contributes marginals only.
+
+## 5. Fitted result (rep)
+
+Fitted at `--config rep` (6 chains × 6000 draws). **Clean: 0 divergences /
+36 000, max r̂ = 1.001, min ESS ≈ 5.3k** (dev had 2/1000 divergences; they clear
+at `target_accept = 0.95`).
+
+**Association.** `psi` median **1.78**, 90% HDI **[1.21, 2.44]**, **P(psi > 1) =
+0.997** — a clear positive within-understood sign-speech association. Words a
+child understands are signed-and-spoken together more often than independence
+predicts, consistent with signing bridging into speech word-by-word.
+
+**Data-identified `p_any` vs the VG14 independence bound** (expected words):
+
+| Age (mo) | identified p_any | independence bound |
+| -------: | ---------------: | -----------------: |
+|       24 |               42 |                 44 |
+|       36 |              107 |                112 |
+|       48 |              191 |                199 |
+|       60 |              259 |                265 |
+
+The identified total sits a few words **below** the independence bound at every
+age — the positive association means the union is smaller than independence
+implies, so VG14's `p_any` was indeed a (mild) over-estimate. The gap is modest
+here because the model's in-window `r` is also lower than VG14's (see below).
+
+**Four-cell composition** (fractions of understood, study REs marginalised) shows
+the migration directly: sign-only 0.25 → 0.19 → 0.10 and speak-only 0.09 → 0.17 →
+0.35 across 24 → 36 → 48 mo, with sign+speech peaking mid (0.07 → 0.12 → 0.18).
+
+**Does adding study REs sharpen the signed peak?** No — it **flattens** it. The
+population signed ratio `r(a)` peaks at ~0.36 around 30 mo (vs VG14's ~0.46), is
+broad and flat across 18–60 mo, and crosses `q(a)` at ~37 mo. Once study
+composition is absorbed by the random intercepts, the apparent age-peak in
+signing is _lower and less pronounced_ — confirming the VG14 finding that the
+signed peak was partly study-driven, not a sharp developmental feature. The
+robust story is unchanged: signing rises from near-zero in infancy to a
+substantial fraction of understood words by age 2–3 and hands off to speech in
+the preschool years.
+
+Key figures: `psi_posterior.svg`, `four_cell_composition.svg`,
+`p_any_identified_vs_bound.svg`, `signed_vs_spoken_rate.svg`, `uk02_cell_ppc.svg`.

--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -28,6 +28,7 @@ from vocab_growth.models import (
     model_vg12,
     model_vg13,
     model_vg14,
+    model_vg15,
 )
 from vocab_growth.reporting import (
     console,
@@ -84,6 +85,7 @@ if __name__ == "__main__":
         "vg12": model_vg12,
         "vg13": model_vg13,
         "vg14": model_vg14,
+        "vg15": model_vg15,
     }
 
     if args.model == "all":

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -1,0 +1,1005 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Shared dataclasses and pipeline functions for the joint sign/speech modality
+model (VG15): issue #49 Option 3.
+
+VG15 extends the trivariate VG14 with two things VG14 assumed away:
+
+1.  A within-understood sign-speech ASSOCIATION (a single scalar Plackett odds
+    ratio ``psi``), identified from the uk_02 four-cell cross-tabulation
+    (sign-only / sign+speech / speech-only / understood-only). This replaces
+    VG14's independence-based ``p_any`` upper bound with a *data-identified*
+    total expressive vocabulary.
+2.  STUDY random intercepts on each latent trajectory (the VG07-VG10 pattern),
+    so the age curve is separated from study composition (which made VG14's
+    signed peak unidentifiable).
+
+Latent scale (all out of N = 800 checklist words):
+
+    p_U(a)  = sigmoid(f_U(a))                 # proportion understood
+    r(a)    = sigmoid(g(a))                   # P(sign  | understood)
+    q(a)    = sigmoid(h(a))                   # P(speak | understood)
+
+    pi_both     = Plackett(r, q; psi)         # P(sign & speak | understood)
+    pi_signonly = r - pi_both
+    pi_speakonly= q - pi_both
+    pi_neither  = 1 - r - q + pi_both
+    p_any(a)    = p_U(a) * (r + q - pi_both)   # total expressive (data-identified)
+
+Likelihoods:
+    - understood ~ BetaBinomial(800, p_U)              (all DS studies)
+    - spoken     ~ BetaBinomial(800, p_U * q)          (marginal-only rows)
+    - signed     ~ BetaBinomial(800, p_U * r)          (uk_01/04/05/06 + uk_02 marginal-only)
+    - uk_02 four cells ~ DirichletMultinomial(total, conc * [pi_*])  (identifies psi)
+
+This is a self-contained module (like common_trivariate.py); it does not import
+from or modify the bivariate / trivariate engines. The full-grid intermediates
+are kept as plain tensors (only obs/plot/query slices are stored), following the
+VG14 memory discipline.
+"""
+
+import os
+import shutil
+import time
+from dataclasses import dataclass
+
+import arviz as az
+import dse_research_utils.environment.info as env_info
+import dse_research_utils.math.constants as math_constants
+import dse_research_utils.metadata.packages as package_metadata
+import dse_research_utils.plot.styles as plot_styles
+import dse_research_utils.statistics.descriptive as descriptive_stats
+import dse_research_utils.statistics.models.data as model_data
+import dse_research_utils.statistics.models.pymc_utils as pymc_utils
+import dse_research_utils.statistics.models.reporting as reporting
+import dse_research_utils.statistics.models.sampling as sampling
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import preliz as pz
+import pymc as pm
+from preliz.distributions.distributions import Continuous
+
+import vocab_growth.data_utils as vocab_data_utils
+import vocab_growth.environment as local_env
+import vocab_growth.reporting as vg_reporting
+from vocab_growth.models.common import (
+    PACKAGE_LIST,
+    BaseModelConfiguration,
+    ModelFitContext,
+    _plot_and_print_dist,
+    _report_diagnostic_warnings,
+    get_hsgp_hyperparams,
+    report,
+)
+from vocab_growth.models.definitions import JointModelDefinition
+from vocab_growth.models.diagnostics_utils import capped_plot_var_names
+from vocab_growth.plotting import _save_csv
+from vocab_growth.reporting import (
+    config_table,
+    console,
+    dataframe_table,
+    heading,
+    key_value_table,
+    pipeline_summary,
+    run_banner,
+    section,
+)
+
+EPSILON = math_constants.EPSILON
+
+# uk_02 is the only source with the four-cell sign/speech cross-tabulation.
+UK02_STUDY_ID = "uk_02"
+
+# Order of the four mutually-exclusive within-understood cells.
+CELL_NAMES = ["neither", "sign_only", "speak_only", "both"]
+
+
+# ============================================================
+# Dataclasses
+# ============================================================
+
+
+@dataclass
+class JointModelConfiguration(BaseModelConfiguration):
+    """Configuration for the joint sign/speech modality model (VG15)."""
+
+    # Understood (U) trajectory priors
+    p_slope_low_u_dist: Continuous
+    p_slope_hi_u_dist: Continuous
+    ell_unit_u_dist: Continuous
+    eta_u_dist: Continuous
+
+    # Speak-given-understood ratio (q) priors
+    p_slope_low_q_dist: Continuous
+    p_slope_hi_q_dist: Continuous
+    ell_unit_q_dist: Continuous
+    eta_q_dist: Continuous
+
+    # Sign-given-understood ratio (r) priors
+    p_slope_low_sign_dist: Continuous
+    p_slope_hi_sign_dist: Continuous
+    ell_unit_sign_dist: Continuous
+    eta_sign_dist: Continuous
+
+    # Kappa priors (age-varying dispersion) — understood / spoken / signed
+    kappa_min_u_dist: Continuous
+    a_kappa_u_dist: Continuous
+    b_kappa_mag_u_dist: Continuous
+    kappa_min_s_dist: Continuous
+    a_kappa_s_dist: Continuous
+    b_kappa_mag_s_dist: Continuous
+    kappa_min_sign_dist: Continuous
+    a_kappa_sign_dist: Continuous
+    b_kappa_mag_sign_dist: Continuous
+
+    # Association (Plackett log odds-ratio) and Dirichlet-Multinomial concentration
+    log_psi_dist: Continuous
+    log_conc_dist: Continuous
+
+    # Study random-intercept scales
+    tau_u_sigma: float
+    tau_q_sigma: float
+    tau_sign_sigma: float
+
+
+@dataclass
+class JointModelSamples:
+    """Posterior and predictive samples from the joint model (population level)."""
+
+    X_plot: np.ndarray
+    X_query: np.ndarray
+
+    # Population trajectories (no study effect), plot grid
+    p_u_plot: np.ndarray
+    q_plot: np.ndarray
+    r_plot: np.ndarray
+    pi_both_plot: np.ndarray
+    p_any_plot: np.ndarray
+    p_any_indep_plot: np.ndarray
+    # Four-cell composition (fractions of understood), plot grid
+    pi_neither_plot: np.ndarray
+    pi_sign_only_plot: np.ndarray
+    pi_speak_only_plot: np.ndarray
+
+    # Query grid
+    p_u_query: np.ndarray
+    q_query: np.ndarray
+    r_query: np.ndarray
+    p_any_query: np.ndarray
+    p_any_indep_query: np.ndarray
+
+    # Association scalar
+    psi: np.ndarray  # shape (n_samples,)
+
+    # uk_02 four-cell posterior predictive (counts) and observed
+    cell_obs: np.ndarray  # (n_cells_obs, 4) observed
+    cell_pred: np.ndarray  # (n_cells_obs, 4, n_samples) predicted
+    cell_ages: np.ndarray  # (n_cells_obs,)
+
+
+JointContext = ModelFitContext[JointModelConfiguration, JointModelSamples]
+
+
+# ============================================================
+# Data preparation
+# ============================================================
+
+
+def _load_uk02_four_cell():
+    """Load uk_02 rows, split into four-cell (cross-tab) and marginal-only rows.
+
+    Returns (four_cell_df, marginal_df). The four-cell rows are those whose four
+    cells reconcile with the signed/spoken margins and sum to a positive total
+    (cell-sum within a few words of comprehension); they identify psi. The rest
+    are marginal-only uk_02 rows (no cross-tab).
+    """
+    path = os.path.join(local_env.DATA_DIR, "vocab_data_uk_02.csv")
+    raw = pd.read_csv(path)
+    cells = ["understood_only", "signed_only", "spoken_only", "signed_spoken"]
+    raw["cell_total"] = raw[cells].sum(axis=1)
+    reconciles = (
+        (raw["signed"] == raw["signed_only"] + raw["signed_spoken"])
+        & (raw["spoken"] == raw["spoken_only"] + raw["signed_spoken"])
+        & (raw["cell_total"] > 0)
+    )
+    four = raw[reconciles].copy()
+    marg = raw[~reconciles].copy()
+    return four, marg
+
+
+def prepare_joint_data(
+    context: JointContext,
+    definition: JointModelDefinition,
+):
+    """Load and prepare data for the joint model.
+
+    Non-uk_02 DS studies contribute understood/spoken/signed marginals (from the
+    merged view). uk_02 is taken from its raw CSV and split into four-cell rows
+    (Dirichlet-Multinomial) and marginal-only rows (marginal likelihoods).
+    """
+    merged = vocab_data_utils.load_data(
+        population=definition.population,
+        columns=["study", "age", "understood", "spoken", "signed"],
+    )
+    other = merged[merged["study"] != UK02_STUDY_ID].copy()
+
+    four, marg = _load_uk02_four_cell()
+    include_uk06 = definition.include_uk06
+
+    # uk_02 four-cell rows: understood for the U likelihood; cells for the DM;
+    # marginal spoken/signed set NaN (subsumed by the DM, avoids double counting).
+    four_df = pd.DataFrame(
+        {
+            "study": UK02_STUDY_ID,
+            "age": four["age"].to_numpy(dtype=float),
+            "understood": four["comprehension"].to_numpy(dtype=float),
+            "spoken": np.nan,
+            "signed": np.nan,
+            "understood_only": four["understood_only"].to_numpy(dtype=float),
+            "signed_only": four["signed_only"].to_numpy(dtype=float),
+            "spoken_only": four["spoken_only"].to_numpy(dtype=float),
+            "signed_spoken": four["signed_spoken"].to_numpy(dtype=float),
+            "cell_total": four["cell_total"].to_numpy(dtype=float),
+        }
+    )
+
+    # uk_02 marginal-only rows: ordinary marginals.
+    marg_df = pd.DataFrame(
+        {
+            "study": UK02_STUDY_ID,
+            "age": marg["age"].to_numpy(dtype=float),
+            "understood": marg["comprehension"].to_numpy(dtype=float),
+            "spoken": marg["spoken"].to_numpy(dtype=float),
+            "signed": marg["signed"].to_numpy(dtype=float),
+        }
+    )
+
+    analysis_df = pd.concat([other, marg_df, four_df], ignore_index=True)
+    analysis_df = analysis_df.dropna(subset=["age"]).reset_index(drop=True)
+
+    # Drop uk_06 signed unless included (its understood/spoken stay).
+    if not include_uk06:
+        m = (analysis_df["study"] == "uk_06") & analysis_df["signed"].notna()
+        analysis_df.loc[m, "signed"] = np.nan
+
+    # Integer study codes (sorted for stability).
+    unique_studies = sorted(analysis_df["study"].unique())
+    study_map = {s: i for i, s in enumerate(unique_studies)}
+    analysis_df["study_code"] = analysis_df["study"].map(study_map).astype(int)
+
+    n = len(analysis_df)
+    n_u = int(analysis_df["understood"].notna().sum())
+    n_s = int(analysis_df["spoken"].notna().sum())
+    n_sign = int(analysis_df["signed"].notna().sum())
+    n_cells = int(analysis_df["signed_spoken"].notna().sum())
+
+    key_value_table(
+        "Observation counts",
+        [
+            ("Total observations", n),
+            ("Studies", f"{len(unique_studies)} ({', '.join(unique_studies)})"),
+            ("Understood observed", n_u),
+            ("Spoken observed (marginal)", n_s),
+            ("Signed observed (marginal)", n_sign),
+            ("uk_02 four-cell rows (DM)", n_cells),
+            ("include_uk06", include_uk06),
+        ],
+    )
+
+    desc = descriptive_stats.describe_all(
+        analysis_df[["age", "understood", "spoken", "signed"]], alpha=0.05
+    )
+    dataframe_table(desc, title="Descriptive statistics")
+
+    X_obs = np.asarray(analysis_df["age"], dtype=float).reshape(-1, 1)
+    y_u_valid = analysis_df.loc[analysis_df["understood"].notna(), "understood"]
+    y_obs_placeholder = np.zeros(n, dtype=int)
+    y_obs_placeholder[analysis_df["understood"].notna().values] = y_u_valid.values.astype(
+        int
+    )
+    bmd = model_data.BinomialModelData(
+        X_obs=X_obs, y_obs=y_obs_placeholder, n_trials=definition.n_trials
+    )
+
+    context.set_model_data(bmd, analysis_df)
+    context.dataframes["descriptive_stats"] = desc
+    desc.to_csv(
+        os.path.join(context.reporting.output_dir, "descriptive_statistics.csv"),
+        index=True,
+    )
+
+
+# ============================================================
+# Prior configuration
+# ============================================================
+
+
+def configure_joint_priors(context: JointContext, definition: JointModelDefinition):
+    """Configure priors from the joint model definition."""
+
+    def beta(a, b, name):
+        d = pz.Beta(alpha=a, beta=b)
+        _plot_and_print_dist(context, d, name)
+        return d
+
+    def halfnormal(sigma, name):
+        d = pz.HalfNormal(sigma=sigma)
+        _plot_and_print_dist(context, d, name)
+        return d
+
+    heading("Understood trajectory priors", style="bold cyan")
+    ell_unit_u_dist = beta(definition.ell_unit_u_alpha, definition.ell_unit_u_beta, "ell_unit_u_dist")
+    eta_u_dist = halfnormal(definition.eta_u_sigma, "eta_u_dist")
+    p_slope_low_u_dist = beta(definition.p_slope_low_u_alpha, definition.p_slope_low_u_beta, "p_slope_low_u_dist")
+    p_slope_hi_u_dist = beta(definition.p_slope_hi_u_alpha, definition.p_slope_hi_u_beta, "p_slope_hi_u_dist")
+
+    heading("Speak-given-understood (q) priors", style="bold cyan")
+    ell_unit_q_dist = beta(definition.ell_unit_q_alpha, definition.ell_unit_q_beta, "ell_unit_q_dist")
+    eta_q_dist = halfnormal(definition.eta_q_sigma, "eta_q_dist")
+    p_slope_low_q_dist = beta(definition.p_slope_low_q_alpha, definition.p_slope_low_q_beta, "p_slope_low_q_dist")
+    p_slope_hi_q_dist = beta(definition.p_slope_hi_q_alpha, definition.p_slope_hi_q_beta, "p_slope_hi_q_dist")
+
+    heading("Sign-given-understood (r) priors", style="bold cyan")
+    ell_unit_sign_dist = beta(definition.ell_unit_sign_alpha, definition.ell_unit_sign_beta, "ell_unit_sign_dist")
+    eta_sign_dist = halfnormal(definition.eta_sign_sigma, "eta_sign_dist")
+    p_slope_low_sign_dist = beta(definition.p_slope_low_sign_alpha, definition.p_slope_low_sign_beta, "p_slope_low_sign_dist")
+    p_slope_hi_sign_dist = beta(definition.p_slope_hi_sign_alpha, definition.p_slope_hi_sign_beta, "p_slope_hi_sign_dist")
+
+    def kappa_block(kp, suffix):
+        heading(f"Kappa priors — {suffix}", style="bold cyan")
+        kmin = pz.LogNormal(mu=kp.kappa_min_mu, sigma=kp.kappa_min_sigma)
+        _plot_and_print_dist(context, kmin, f"kappa_min_{suffix}_dist")
+        a = pz.Normal(mu=kp.a_kappa_mu, sigma=kp.a_kappa_sigma)
+        _plot_and_print_dist(context, a, f"a_kappa_{suffix}_dist")
+        b = pz.HalfNormal(sigma=kp.b_kappa_mag_sigma)
+        _plot_and_print_dist(context, b, f"b_kappa_mag_{suffix}_dist")
+        return kmin, a, b
+
+    kappa_min_u_dist, a_kappa_u_dist, b_kappa_mag_u_dist = kappa_block(definition.kappa_u, "u")
+    kappa_min_s_dist, a_kappa_s_dist, b_kappa_mag_s_dist = kappa_block(definition.kappa_s, "s")
+    kappa_min_sign_dist, a_kappa_sign_dist, b_kappa_mag_sign_dist = kappa_block(definition.kappa_sign, "sign")
+
+    heading("Association (psi) and Dirichlet-Multinomial concentration", style="bold cyan")
+    log_psi_dist = pz.Normal(mu=definition.log_psi_mu, sigma=definition.log_psi_sigma)
+    _plot_and_print_dist(context, log_psi_dist, "log_psi_dist")
+    log_conc_dist = pz.Normal(mu=definition.log_conc_mu, sigma=definition.log_conc_sigma)
+    _plot_and_print_dist(context, log_conc_dist, "log_conc_dist")
+
+    config = JointModelConfiguration(
+        slope_anchors=definition.slope_anchors,
+        ell_months_range=definition.ell_months_range,
+        n_plot=definition.n_plot,
+        ages_query=definition.ages_query,
+        p_slope_low_u_dist=p_slope_low_u_dist,
+        p_slope_hi_u_dist=p_slope_hi_u_dist,
+        ell_unit_u_dist=ell_unit_u_dist,
+        eta_u_dist=eta_u_dist,
+        p_slope_low_q_dist=p_slope_low_q_dist,
+        p_slope_hi_q_dist=p_slope_hi_q_dist,
+        ell_unit_q_dist=ell_unit_q_dist,
+        eta_q_dist=eta_q_dist,
+        p_slope_low_sign_dist=p_slope_low_sign_dist,
+        p_slope_hi_sign_dist=p_slope_hi_sign_dist,
+        ell_unit_sign_dist=ell_unit_sign_dist,
+        eta_sign_dist=eta_sign_dist,
+        kappa_min_u_dist=kappa_min_u_dist,
+        a_kappa_u_dist=a_kappa_u_dist,
+        b_kappa_mag_u_dist=b_kappa_mag_u_dist,
+        kappa_min_s_dist=kappa_min_s_dist,
+        a_kappa_s_dist=a_kappa_s_dist,
+        b_kappa_mag_s_dist=b_kappa_mag_s_dist,
+        kappa_min_sign_dist=kappa_min_sign_dist,
+        a_kappa_sign_dist=a_kappa_sign_dist,
+        b_kappa_mag_sign_dist=b_kappa_mag_sign_dist,
+        log_psi_dist=log_psi_dist,
+        log_conc_dist=log_conc_dist,
+        tau_u_sigma=definition.tau_u_sigma,
+        tau_q_sigma=definition.tau_q_sigma,
+        tau_sign_sigma=definition.tau_sign_sigma,
+    )
+    context.set_model_config(config)
+
+
+# ============================================================
+# Plackett association helper (PyTensor)
+# ============================================================
+
+
+def _plackett_pi_both(r, q, psi):
+    """P(both | understood) under a Plackett copula with odds ratio psi.
+
+    Closed-form root, falling back to independence at psi == 1, then clipped to
+    the Frechet bounds [max(0, r+q-1), min(r, q)].
+    """
+    S = 1.0 + (r + q) * (psi - 1.0)
+    disc = pm.math.sqrt(pm.math.maximum(S * S - 4.0 * psi * (psi - 1.0) * r * q, 0.0))
+    denom = 2.0 * (psi - 1.0)
+    pi_root = (S - disc) / denom
+    pi_both = pm.math.switch(abs(psi - 1.0) < 1e-6, r * q, pi_root)
+    lo = pm.math.maximum(0.0, r + q - 1.0)
+    hi = pm.math.minimum(r, q)
+    return pm.math.clip(pi_both, lo, hi)
+
+
+# ============================================================
+# Model building
+# ============================================================
+
+
+def build_model(context: JointContext):
+    """Build the joint sign/speech PyMC model with study random intercepts."""
+    config = context.model_config
+    df = context.analysis_df
+    n_trials = context.model_data.n_trials
+
+    has_u = df["understood"].notna().values
+    has_s = df["spoken"].notna().values
+    has_sign = df["signed"].notna().values
+    has_cells = df["signed_spoken"].notna().values
+
+    idx_u = np.where(has_u)[0]
+    idx_s = np.where(has_s)[0]
+    idx_sign = np.where(has_sign)[0]
+    idx_cells = np.where(has_cells)[0]
+
+    y_u = np.asarray(df.loc[has_u, "understood"], dtype=int)
+    y_s = np.asarray(df.loc[has_s, "spoken"], dtype=int)
+    y_sign = np.asarray(df.loc[has_sign, "signed"], dtype=int)
+
+    cell_counts = np.asarray(
+        df.loc[has_cells, ["understood_only", "signed_only", "spoken_only", "signed_spoken"]],
+        dtype=int,
+    )
+    cell_total = np.asarray(df.loc[has_cells, "cell_total"], dtype=int)
+
+    # Validate
+    for arr, nm in [(y_u, "understood"), (y_s, "spoken"), (y_sign, "signed")]:
+        if arr.size and (arr.min() < 0 or arr.max() > n_trials):
+            raise ValueError(f"{nm} outside [0, n_trials].")
+    if cell_counts.size and (cell_counts.min() < 0):
+        raise ValueError("negative four-cell count.")
+
+    study_codes = np.asarray(df["study_code"], dtype=int)
+    n_studies = int(study_codes.max()) + 1
+
+    X_obs = np.asarray(df["age"], dtype=float).reshape(-1, 1)
+    n = len(X_obs)
+    X_mean = float(np.mean(X_obs))
+    X_std = float(np.std(X_obs, ddof=1))
+
+    X_obs_z = (X_obs - X_mean) / X_std
+    X_plot = np.linspace(X_obs.min(), X_obs.max(), config.n_plot).reshape(-1, 1)
+    X_plot_z = (X_plot - X_mean) / X_std
+    X_query = np.array(config.ages_query).reshape(-1, 1)
+    X_query_z = (X_query - X_mean) / X_std
+    X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z])
+    n_plot = X_plot_z.shape[0]
+    n_query = X_query_z.shape[0]
+    n_all = X_all_z.shape[0]
+
+    ell_low_z = float(config.ell_months_range[0]) / X_std
+    ell_high_z = float(config.ell_months_range[1]) / X_std
+    L, M = get_hsgp_hyperparams(X_obs_z, (ell_low_z, ell_high_z))
+
+    sa = float(config.slope_anchors[0])
+    sb = float(config.slope_anchors[1])
+    sa_z = (sa - X_mean) / X_std
+    sb_z = (sb - X_mean) / X_std
+
+    key_value_table(
+        "Build configuration",
+        [
+            ("Total observations", n),
+            ("Studies", n_studies),
+            ("Understood / spoken / signed / cells", f"{len(idx_u)} / {len(idx_s)} / {len(idx_sign)} / {len(idx_cells)}"),
+            ("n_trials", n_trials),
+            ("Age mean / std", (round(X_mean, 1), round(X_std, 1))),
+            ("HSGP m / L", (M, L)),
+        ],
+    )
+
+    i_obs0, i_obs1 = 0, n
+    i_plot0, i_plot1 = n, n + n_plot
+    i_query0, i_query1 = n + n_plot, n + n_plot + n_query
+
+    coords = {
+        "all_id": np.arange(n_all),
+        "obs_id": np.arange(n),
+        "obs_u_id": np.arange(len(idx_u)),
+        "obs_s_id": np.arange(len(idx_s)),
+        "obs_sign_id": np.arange(len(idx_sign)),
+        "obs_cells_id": np.arange(len(idx_cells)),
+        "plot_id": np.arange(n_plot),
+        "query_id": np.arange(n_query),
+        "study_id": np.arange(n_studies),
+        "cell_id": CELL_NAMES,
+        "x_dim": np.arange(1),
+    }
+
+    def trend_and_gp(cfg_low, cfg_hi, cfg_ell, cfg_eta, suffix, X_all_z_data):
+        """Build a logit-linear trend + HSGP deviation; return the full-grid latent."""
+        p_lo = cfg_low.to_pymc(f"p_slope_low_{suffix}")
+        p_hi = cfg_hi.to_pymc(f"p_slope_hi_{suffix}")
+        slope = pm.Deterministic(
+            f"slope_{suffix}",
+            (pymc_utils.logit(p_hi) - pymc_utils.logit(p_lo)) / (sb_z - sa_z),
+        )
+        intercept = pm.Deterministic(
+            f"intercept_{suffix}", pymc_utils.logit(p_lo) - slope * sa_z
+        )
+        mean_trend = intercept + slope * X_all_z_data[:, 0]
+        ell_unit = cfg_ell.to_pymc(f"ell_unit_{suffix}")
+        ell = pm.Deterministic(
+            f"ell_{suffix}", ell_low_z + (ell_high_z - ell_low_z) * ell_unit
+        )
+        eta = cfg_eta.to_pymc(f"eta_{suffix}")
+        cov = pm.gp.cov.ExpQuad(1, ls=ell)
+        hsgp = pm.gp.HSGP(cov_func=cov, m=M, L=L)
+        g_unit = hsgp.prior(f"g_unit_{suffix}", X=X_all_z_data, dims="all_id")
+        return mean_trend + eta * g_unit  # plain tensor (n_all,)
+
+    with pm.Model(coords=coords) as model_pm:
+        X_all_z_data = pm.Data("X_all_z", X_all_z, dims=("all_id", "x_dim"))
+        _ = pm.Data("X_plot", X_plot.flatten(), dims=("plot_id",))
+        _ = pm.Data("X_query", X_query.flatten(), dims=("query_id",))
+        study_obs = pm.Data("study_obs", study_codes, dims=("obs_id",))
+
+        # Latent full-grid trajectories (plain tensors).
+        f_u_all = trend_and_gp(
+            config.p_slope_low_u_dist, config.p_slope_hi_u_dist,
+            config.ell_unit_u_dist, config.eta_u_dist, "u", X_all_z_data
+        )
+        h_all = trend_and_gp(
+            config.p_slope_low_q_dist, config.p_slope_hi_q_dist,
+            config.ell_unit_q_dist, config.eta_q_dist, "q", X_all_z_data
+        )
+        g_all = trend_and_gp(
+            config.p_slope_low_sign_dist, config.p_slope_hi_sign_dist,
+            config.ell_unit_sign_dist, config.eta_sign_dist, "sign", X_all_z_data
+        )
+
+        # Study random intercepts (non-centred), applied at obs level only.
+        tau_u = pm.HalfNormal("tau_u", sigma=config.tau_u_sigma)
+        tau_q = pm.HalfNormal("tau_q", sigma=config.tau_q_sigma)
+        tau_sign = pm.HalfNormal("tau_sign", sigma=config.tau_sign_sigma)
+        delta_u = pm.Deterministic(
+            "delta_u", tau_u * pm.Normal("z_u", 0.0, 1.0, dims="study_id"), dims="study_id"
+        )
+        delta_q = pm.Deterministic(
+            "delta_q", tau_q * pm.Normal("z_q", 0.0, 1.0, dims="study_id"), dims="study_id"
+        )
+        delta_sign = pm.Deterministic(
+            "delta_sign", tau_sign * pm.Normal("z_sign", 0.0, 1.0, dims="study_id"), dims="study_id"
+        )
+
+        # Standardised observed ages (used by the age-varying kappa functions).
+        z_obs = pm.Deterministic("z_obs", X_all_z_data[i_obs0:i_obs1, 0], dims="obs_id")
+
+        # --- obs-level latents WITH study shift ---
+        f_u_obs = f_u_all[i_obs0:i_obs1] + delta_u[study_obs]
+        h_obs = h_all[i_obs0:i_obs1] + delta_q[study_obs]
+        g_obs = g_all[i_obs0:i_obs1] + delta_sign[study_obs]
+        p_u_obs = pm.math.sigmoid(f_u_obs)
+        q_obs = pm.math.sigmoid(h_obs)
+        r_obs = pm.math.sigmoid(g_obs)
+
+        # --- population-level latents (no study shift), plot + query ---
+        p_u_plot = pm.Deterministic("p_u_plot", pm.math.sigmoid(f_u_all[i_plot0:i_plot1]), dims="plot_id")
+        q_plot = pm.Deterministic("q_plot", pm.math.sigmoid(h_all[i_plot0:i_plot1]), dims="plot_id")
+        r_plot = pm.Deterministic("r_plot", pm.math.sigmoid(g_all[i_plot0:i_plot1]), dims="plot_id")
+        p_u_query = pm.Deterministic("p_u_query", pm.math.sigmoid(f_u_all[i_query0:i_query1]), dims="query_id")
+        q_query = pm.Deterministic("q_query", pm.math.sigmoid(h_all[i_query0:i_query1]), dims="query_id")
+        r_query = pm.Deterministic("r_query", pm.math.sigmoid(g_all[i_query0:i_query1]), dims="query_id")
+
+        # --- association ---
+        log_psi = config.log_psi_dist.to_pymc("log_psi")
+        psi = pm.Deterministic("psi", pm.math.exp(log_psi))
+        log_conc = config.log_conc_dist.to_pymc("log_conc")
+        conc = pm.Deterministic("conc", pm.math.exp(log_conc))
+
+        # --- kappa functions ---
+        def kappa_fn(kmin_d, a_d, bmag_d, suffix):
+            kmin = kmin_d.to_pymc(f"kappa_min_{suffix}")
+            a = a_d.to_pymc(f"a_kappa_{suffix}")
+            bmag = bmag_d.to_pymc(f"b_kappa_mag_{suffix}")
+            b = pm.Deterministic(f"b_kappa_{suffix}", -bmag)
+            return lambda z: kmin + pm.math.exp(a + b * z)
+
+        kappa_u_of_z = kappa_fn(config.kappa_min_u_dist, config.a_kappa_u_dist, config.b_kappa_mag_u_dist, "u")
+        kappa_s_of_z = kappa_fn(config.kappa_min_s_dist, config.a_kappa_s_dist, config.b_kappa_mag_s_dist, "s")
+        kappa_sign_of_z = kappa_fn(config.kappa_min_sign_dist, config.a_kappa_sign_dist, config.b_kappa_mag_sign_dist, "sign")
+
+        kappa_u_obs = kappa_u_of_z(z_obs)
+        kappa_s_obs = kappa_s_of_z(z_obs)
+        kappa_sign_obs = kappa_sign_of_z(z_obs)
+
+        # ============================================================
+        # Likelihoods
+        # ============================================================
+        # Understood (all studies)
+        p_u_sel = pm.math.clip(p_u_obs[idx_u], EPSILON, 1 - EPSILON)
+        k_u = kappa_u_obs[idx_u]
+        pm.BetaBinomial("y_u_obs", n=n_trials, alpha=p_u_sel * k_u, beta=(1 - p_u_sel) * k_u,
+                        observed=y_u, dims="obs_u_id")
+
+        # Spoken marginal (p_U * q)
+        p_s_sel = pm.math.clip((p_u_obs * q_obs)[idx_s], EPSILON, 1 - EPSILON)
+        k_s = kappa_s_obs[idx_s]
+        pm.BetaBinomial("y_s_obs", n=n_trials, alpha=p_s_sel * k_s, beta=(1 - p_s_sel) * k_s,
+                        observed=y_s, dims="obs_s_id")
+
+        # Signed marginal (p_U * r)
+        p_sign_sel = pm.math.clip((p_u_obs * r_obs)[idx_sign], EPSILON, 1 - EPSILON)
+        k_sign = kappa_sign_obs[idx_sign]
+        pm.BetaBinomial("y_sign_obs", n=n_trials, alpha=p_sign_sel * k_sign, beta=(1 - p_sign_sel) * k_sign,
+                        observed=y_sign, dims="obs_sign_id")
+
+        # uk_02 four cells (Dirichlet-Multinomial), within-understood composition
+        r_c = pm.math.clip(r_obs[idx_cells], EPSILON, 1 - EPSILON)
+        q_c = pm.math.clip(q_obs[idx_cells], EPSILON, 1 - EPSILON)
+        pi_both_c = _plackett_pi_both(r_c, q_c, psi)
+        pi_sign_c = pm.math.maximum(r_c - pi_both_c, EPSILON)
+        pi_speak_c = pm.math.maximum(q_c - pi_both_c, EPSILON)
+        pi_neither_c = pm.math.maximum(1 - r_c - q_c + pi_both_c, EPSILON)
+        pi_both_c = pm.math.maximum(pi_both_c, EPSILON)
+        pi_stack = pm.math.stack([pi_neither_c, pi_sign_c, pi_speak_c, pi_both_c], axis=1)
+        pi_stack = pi_stack / pi_stack.sum(axis=1, keepdims=True)
+        pm.DirichletMultinomial(
+            "cells_obs", n=cell_total, a=conc * pi_stack, observed=cell_counts,
+            dims=("obs_cells_id", "cell_id"),
+        )
+
+        # ============================================================
+        # Reporting deterministics (population, plot/query): four-cell + p_any
+        # ============================================================
+        for grid, rg, qg, pug in [("plot", r_plot, q_plot, p_u_plot), ("query", r_query, q_query, p_u_query)]:
+            pi_both = _plackett_pi_both(rg, qg, psi)
+            pm.Deterministic(f"pi_both_{grid}", pi_both, dims=f"{grid}_id")
+            pm.Deterministic(f"pi_sign_only_{grid}", pm.math.maximum(rg - pi_both, 0.0), dims=f"{grid}_id")
+            pm.Deterministic(f"pi_speak_only_{grid}", pm.math.maximum(qg - pi_both, 0.0), dims=f"{grid}_id")
+            pm.Deterministic(f"pi_neither_{grid}", pm.math.maximum(1 - rg - qg + pi_both, 0.0), dims=f"{grid}_id")
+            # data-identified union and independence union (out of understood)
+            pm.Deterministic(f"p_any_{grid}", pug * (rg + qg - pi_both), dims=f"{grid}_id")
+            pm.Deterministic(f"p_any_indep_{grid}", pug * (1 - (1 - rg) * (1 - qg)), dims=f"{grid}_id")
+
+        # kappa for plot grid (reporting)
+        pm.Deterministic("kappa_sign_obs", kappa_sign_obs, dims="obs_id")
+
+    pymc_utils.report_model_summary(model_pm)
+    variables = pymc_utils.get_variables_dict(model_pm)
+    try:
+        digraph = pymc_utils.model_to_graphviz(model_pm)
+        digraph.render(
+            filename=os.path.join(context.reporting.output_dir, "gp_model_graph"),
+            format="svg", cleanup=True,
+        )
+    except Exception as exc:  # graphviz 'dot' not on PATH — non-fatal
+        console.print(f"[yellow]Skipped model graph: {exc}[/yellow]")
+
+    context.set_model(model_pm, variables)
+
+
+# ============================================================
+# Pipeline
+# ============================================================
+
+
+def prior_predictive_checks(context: JointContext):
+    """Light prior predictive check: r(a), q(a), psi spans independence."""
+    with context.model:
+        prior = pm.sample_prior_predictive(
+            draws=500, random_seed=context.sampling.random_seed,
+            compile_kwargs=dict(mode="FAST_COMPILE"),
+        )
+    context.set_prior_samples(prior)
+    for var, ylab, fname in [("r_plot", "r(a) = P(sign | understood)", "prior_samples_r"),
+                             ("q_plot", "q(a) = P(speak | understood)", "prior_samples_q")]:
+        s = prior.prior[var].stack(sample=("chain", "draw")).transpose("plot_id", "sample")
+        fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+        Xp = prior.constant_data["X_plot"].values
+        for i in range(min(400, s.shape[1])):
+            ax.plot(Xp, s.values[:, i], alpha=0.02)
+        ax.set_xlabel("Age (months)")
+        ax.set_ylabel(ylab)
+        ax.set_ylim(0, 1)
+        fig.savefig(os.path.join(context.reporting.output_dir, f"{fname}.png"), dpi=300)
+        fig.savefig(os.path.join(context.reporting.output_dir, f"{fname}.svg"))
+        plt.close(fig)
+
+
+def sample(context: JointContext):
+    config_table("Sampling configuration", context.sampling)
+    with context.model:
+        trace = pm.sample(
+            context.sampling.draws, tune=context.sampling.tune,
+            chains=context.sampling.chains, cores=context.sampling.cores,
+            target_accept=context.sampling.target_accept,
+            nuts_sampler="nutpie", return_inferencedata=True,
+            random_seed=context.sampling.random_seed,
+        )
+    context.set_trace(trace)
+
+
+def diagnostics(context: JointContext):
+    var_names = [v.name for v in context.model.unobserved_RVs if v.size.eval() <= 2]
+    diag = az.summary(context.trace, var_names=var_names, round_to=4,
+                      ci_prob=context.reporting.hdi, ci_kind="hdi")
+    diag.to_csv(os.path.join(context.reporting.output_dir, "diagnostics.csv"), index=True)
+    dataframe_table(diag, title="Posterior diagnostics")
+    _report_diagnostic_warnings(diag)
+    tv = capped_plot_var_names(context.trace, var_names + ["psi", "conc"])
+    az.plot_trace(context.trace, var_names=tv)
+    plt.savefig(os.path.join(context.reporting.output_dir, "trace_plot.png"), dpi=300)
+    plt.close()
+    az.plot_energy(context.trace, figure_kwargs={"figsize": plot_styles.FIGSIZE_SM})
+    plt.savefig(os.path.join(context.reporting.output_dir, "energy_plot.png"), dpi=300)
+    plt.close()
+
+
+def _extract(trace, name, dim):
+    return np.array(trace.posterior[name].stack(sample=("chain", "draw")).transpose(dim, "sample").values)
+
+
+def sample_posterior_predictive(context: JointContext, definition=None):
+    """Posterior predictive for the uk_02 four cells (for the cell PPC)."""
+    with context.model:
+        trace = pm.sample_posterior_predictive(
+            context.trace, var_names=["cells_obs"], extend_inferencedata=True,
+            random_seed=context.sampling.random_seed,
+        )
+    context.set_trace(trace)
+    trace.to_netcdf(os.path.join(context.reporting.output_dir, "trace.nc"))
+
+    # Observed uk_02 four-cell counts / ages (recomputed from analysis_df).
+    df = context.analysis_df
+    has_cells = df["signed_spoken"].notna().values
+    cell_counts = np.asarray(
+        df.loc[has_cells, ["understood_only", "signed_only", "spoken_only", "signed_spoken"]],
+        dtype=int,
+    )
+    cell_ages = np.asarray(df.loc[has_cells, "age"], dtype=float)
+
+    samples = JointModelSamples(
+        X_plot=np.array(trace.constant_data["X_plot"].values),
+        X_query=np.array(trace.constant_data["X_query"].values),
+        p_u_plot=_extract(trace, "p_u_plot", "plot_id"),
+        q_plot=_extract(trace, "q_plot", "plot_id"),
+        r_plot=_extract(trace, "r_plot", "plot_id"),
+        pi_both_plot=_extract(trace, "pi_both_plot", "plot_id"),
+        p_any_plot=_extract(trace, "p_any_plot", "plot_id"),
+        p_any_indep_plot=_extract(trace, "p_any_indep_plot", "plot_id"),
+        pi_neither_plot=_extract(trace, "pi_neither_plot", "plot_id"),
+        pi_sign_only_plot=_extract(trace, "pi_sign_only_plot", "plot_id"),
+        pi_speak_only_plot=_extract(trace, "pi_speak_only_plot", "plot_id"),
+        p_u_query=_extract(trace, "p_u_query", "query_id"),
+        q_query=_extract(trace, "q_query", "query_id"),
+        r_query=_extract(trace, "r_query", "query_id"),
+        p_any_query=_extract(trace, "p_any_query", "query_id"),
+        p_any_indep_query=_extract(trace, "p_any_indep_query", "query_id"),
+        psi=np.array(trace.posterior["psi"].stack(sample=("chain", "draw")).values),
+        cell_obs=cell_counts,
+        cell_pred=np.array(
+            trace.posterior_predictive["cells_obs"]
+            .stack(sample=("chain", "draw"))
+            .transpose("obs_cells_id", "cell_id", "sample")
+            .values
+        ),
+        cell_ages=cell_ages,
+    )
+    context.set_model_samples(samples)
+
+
+def posterior_summary(context: JointContext):
+    s = context.model_samples
+    n_trials = context.model_data.n_trials
+    hdi = context.reporting.hdi
+    od = context.reporting.output_dir
+
+    def ratio_summary(X, draws, prefix):
+        med = np.median(draws, axis=1)
+        h = az.hdi(draws, prob=hdi)
+        d = pd.DataFrame({"age_months": X, f"{prefix}_median": med,
+                          f"{prefix}_hdi_lo": h[:, 0], f"{prefix}_hdi_hi": h[:, 1]})
+        d.to_csv(os.path.join(od, f"posterior_summary_{prefix}.csv"), index=False)
+        return d
+
+    ratio_summary(s.X_query, s.r_query, "r")
+    ratio_summary(s.X_query, s.q_query, "q")
+
+    # Data-identified p_any vs independence (expected counts)
+    Ey = s.p_any_query * n_trials
+    Ey_i = s.p_any_indep_query * n_trials
+    pany = pd.DataFrame({
+        "age_months": s.X_query,
+        "p_any_median": np.median(s.p_any_query, axis=1),
+        "p_any_hdi_lo": az.hdi(s.p_any_query, prob=hdi)[:, 0],
+        "p_any_hdi_hi": az.hdi(s.p_any_query, prob=hdi)[:, 1],
+        "Ey_any_median": np.median(Ey, axis=1),
+        "p_any_indep_median": np.median(s.p_any_indep_query, axis=1),
+        "Ey_any_indep_median": np.median(Ey_i, axis=1),
+    })
+    pany.to_csv(os.path.join(od, "posterior_summary_p_any.csv"), index=False)
+    dataframe_table(pany.round(3), title="Total expressive p_any (identified vs independence)", show_index=False)
+
+    # psi summary
+    psi = s.psi
+    psi_df = pd.DataFrame({
+        "psi_median": [float(np.median(psi))],
+        "psi_hdi_lo": [float(az.hdi(psi, prob=hdi)[0])],
+        "psi_hdi_hi": [float(az.hdi(psi, prob=hdi)[1])],
+        "P_psi_gt_1": [float((psi > 1).mean())],
+    })
+    psi_df.to_csv(os.path.join(od, "posterior_summary_psi.csv"), index=False)
+    key_value_table("Association psi", [
+        ("psi median", round(float(np.median(psi)), 3)),
+        ("psi 90% HDI", (round(float(az.hdi(psi, prob=hdi)[0]), 3), round(float(az.hdi(psi, prob=hdi)[1]), 3))),
+        ("P(psi > 1)", round(float((psi > 1).mean()), 3)),
+    ])
+
+
+# ============================================================
+# Plots
+# ============================================================
+
+
+def _run_joint_plots(context: JointContext):
+    s = context.model_samples
+    n_trials = context.model_data.n_trials
+    od = context.reporting.output_dir
+    hdi = context.reporting.hdi
+    X = s.X_plot
+
+    # 1) Data-identified p_any vs independence upper bound (expected counts)
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+    id_med = np.median(s.p_any_plot, axis=1) * n_trials
+    id_hdi = az.hdi(s.p_any_plot, prob=hdi) * n_trials
+    ind_med = np.median(s.p_any_indep_plot, axis=1) * n_trials
+    ax.fill_between(X, id_hdi[:, 0], id_hdi[:, 1], alpha=0.20, color="C0")
+    ax.plot(X, id_med, lw=3, color="C0", label="Data-identified p_any (median)")
+    ax.plot(X, ind_med, lw=2.5, ls="--", color="C3", label="Independence upper bound (r·q)")
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel("Expected words produced (any modality)")
+    ax.set_ylim(0, n_trials + 50)
+    ax.legend(loc="upper left", frameon=True)
+    ax.set_title("Total expressive vocabulary: identified vs independence bound")
+    fig.savefig(os.path.join(od, "p_any_identified_vs_bound.png"), dpi=300)
+    fig.savefig(os.path.join(od, "p_any_identified_vs_bound.svg"))
+    _save_csv(pd.DataFrame({"age_months": X, "identified_median": id_med,
+                            "identified_hdi_lo": id_hdi[:, 0], "identified_hdi_hi": id_hdi[:, 1],
+                            "independence_median": ind_med}), od, "p_any_identified_vs_bound")
+    context.plots["p_any_identified_vs_bound"] = fig
+    plt.close(fig)
+
+    # 2) Four-cell composition trajectory (fractions of understood)
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+    comp = {
+        "neither": (np.median(s.pi_neither_plot, axis=1), "C7"),
+        "sign-only": (np.median(s.pi_sign_only_plot, axis=1), "C2"),
+        "sign+speech": (np.median(s.pi_both_plot, axis=1), "C4"),
+        "speak-only": (np.median(s.pi_speak_only_plot, axis=1), "C1"),
+    }
+    for lab, (med, c) in comp.items():
+        ax.plot(X, med, lw=2.5, color=c, label=lab)
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel("Fraction of understood words")
+    ax.set_ylim(0, 1)
+    ax.legend(loc="upper right", frameon=True)
+    ax.set_title("Within-understood composition (sign-only → both → speak-only)")
+    fig.savefig(os.path.join(od, "four_cell_composition.png"), dpi=300)
+    fig.savefig(os.path.join(od, "four_cell_composition.svg"))
+    _save_csv(pd.DataFrame({"age_months": X, **{k: v[0] for k, v in comp.items()}}), od, "four_cell_composition")
+    context.plots["four_cell_composition"] = fig
+    plt.close(fig)
+
+    # 3) psi posterior
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_MD)
+    ax.hist(s.psi, bins=60, color="C4", alpha=0.8)
+    ax.axvline(1.0, ls=":", color="grey", label="independence (psi=1)")
+    ax.axvline(float(np.median(s.psi)), ls="-", color="C0", label=f"median {np.median(s.psi):.2f}")
+    ax.set_xlabel("psi (sign-speech odds ratio)")
+    ax.set_ylabel("posterior draws")
+    ax.legend(frameon=True)
+    ax.set_title(f"Association psi — P(psi>1) = {(s.psi > 1).mean():.2f}")
+    fig.savefig(os.path.join(od, "psi_posterior.png"), dpi=300)
+    fig.savefig(os.path.join(od, "psi_posterior.svg"))
+    context.plots["psi_posterior"] = fig
+    plt.close(fig)
+
+    # 4) signed rate r(a) (study REs absorb composition)
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+    r_med = np.median(s.r_plot, axis=1)
+    r_hdi = az.hdi(s.r_plot, prob=hdi)
+    q_med = np.median(s.q_plot, axis=1)
+    ax.fill_between(X, r_hdi[:, 0], r_hdi[:, 1], alpha=0.18, color="C2")
+    ax.plot(X, r_med, lw=3, color="C2", label="r(a) signed")
+    ax.plot(X, q_med, lw=3, color="C1", label="q(a) spoken")
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel("Fraction of understood words")
+    ax.set_ylim(0, 1)
+    ax.legend(loc="upper left", frameon=True)
+    ax.set_title("Signed vs spoken ratio (population, study REs marginalised)")
+    fig.savefig(os.path.join(od, "signed_vs_spoken_rate.png"), dpi=300)
+    fig.savefig(os.path.join(od, "signed_vs_spoken_rate.svg"))
+    context.plots["signed_vs_spoken_rate"] = fig
+    plt.close(fig)
+
+    # 5) uk_02 four-cell PPC (observed vs predicted cell totals)
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_MD)
+    obs_tot = s.cell_obs.sum(axis=0)  # (4,)
+    pred_tot = s.cell_pred.sum(axis=0)  # (4, n_samples)
+    pred_med = np.median(pred_tot, axis=1)
+    lo, hi = 100 * (1 - hdi) / 2, 100 * (1 + hdi) / 2
+    pred_lo = np.percentile(pred_tot, lo, axis=1)
+    pred_hi = np.percentile(pred_tot, hi, axis=1)
+    yerr = np.vstack([pred_med - pred_lo, pred_hi - pred_med])
+    xpos = np.arange(4)
+    ax.bar(xpos - 0.18, obs_tot, width=0.36, color="C0", label="observed")
+    ax.bar(xpos + 0.18, pred_med, width=0.36, color="C3", alpha=0.7, label="predicted (median)",
+           yerr=yerr, capsize=4)
+    ax.set_xticks(xpos)
+    ax.set_xticklabels(CELL_NAMES)
+    ax.set_ylabel("Total cell count (uk_02)")
+    ax.legend(frameon=True)
+    ax.set_title("uk_02 four-cell posterior predictive check")
+    fig.savefig(os.path.join(od, "uk02_cell_ppc.png"), dpi=300)
+    fig.savefig(os.path.join(od, "uk02_cell_ppc.svg"))
+    context.plots["uk02_cell_ppc"] = fig
+    plt.close(fig)
+
+
+# ============================================================
+# Fit orchestration
+# ============================================================
+
+
+def fit_joint_model(config: str, definition: JointModelDefinition) -> JointContext:
+    """Shared fit pipeline for the joint sign/speech model (VG15)."""
+    run_banner(definition.banner, subtitle=f"sampling config: {config}")
+    env_info.report_environment_info()
+    console.print()
+    package_metadata.report_package_versions(PACKAGE_LIST)
+
+    context: JointContext = ModelFitContext(
+        reporting=reporting.ReportingConfiguration(
+            model_name=definition.model_id,
+            config_name=definition.config_name,
+            output_root_dir=local_env.OUTPUT_DIR,
+            hdi=0.90,
+        ),
+        sampling=sampling.get_sampling_configuration(config),
+    )
+    if os.path.exists(context.reporting.output_dir):
+        shutil.rmtree(context.reporting.output_dir)
+    os.makedirs(context.reporting.output_dir, exist_ok=True)
+
+    timings = context.timings
+    run_started = time.perf_counter()
+    with section("Prepare data", timings=timings):
+        prepare_joint_data(context, definition)
+    with section("Priors and hyperparameters", timings=timings):
+        configure_joint_priors(context, definition)
+    with section("Model definition and initialisation", timings=timings):
+        build_model(context)
+    with section("Prior predictive checks", timings=timings):
+        prior_predictive_checks(context)
+    with section("Posterior sampling", timings=timings):
+        sample(context)
+    with section("Diagnostics", timings=timings):
+        diagnostics(context)
+    with section("Posterior predictions", timings=timings):
+        sample_posterior_predictive(context, definition)
+    with section("Posterior summary", timings=timings):
+        posterior_summary(context)
+    with section("Plots", timings=timings):
+        _run_joint_plots(context)
+    with section("Report", timings=timings):
+        report(context)
+
+    pipeline_summary(f"Pipeline summary — {context.reporting.model_label}", timings)
+    console.print(
+        f"[dim]Total wall time: {vg_reporting.format_duration(time.perf_counter() - run_started)}[/dim]"
+    )
+    return context

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -118,9 +118,8 @@ class JointModelConfiguration(BaseModelConfiguration):
     ell_unit_q_dist: Continuous
     eta_q_dist: Continuous
 
-    # Sign-given-understood ratio (r) priors
-    p_slope_low_sign_dist: Continuous
-    p_slope_hi_sign_dist: Continuous
+    # Sign-given-understood ratio (r) priors — intercept-only mean (no age slope)
+    intercept_sign_dist: Continuous
     ell_unit_sign_dist: Continuous
     eta_sign_dist: Continuous
 
@@ -345,8 +344,12 @@ def configure_joint_priors(context: JointContext, definition: JointModelDefiniti
     heading("Sign-given-understood (r) priors", style="bold cyan")
     ell_unit_sign_dist = beta(definition.ell_unit_sign_alpha, definition.ell_unit_sign_beta, "ell_unit_sign_dist")
     eta_sign_dist = halfnormal(definition.eta_sign_sigma, "eta_sign_dist")
-    p_slope_low_sign_dist = beta(definition.p_slope_low_sign_alpha, definition.p_slope_low_sign_beta, "p_slope_low_sign_dist")
-    p_slope_hi_sign_dist = beta(definition.p_slope_hi_sign_alpha, definition.p_slope_hi_sign_beta, "p_slope_hi_sign_dist")
+    # Intercept-only signed mean (no age slope): one weakly-informative intercept
+    # on the logit scale; the study REs carry between-study level, the GP the hump.
+    intercept_sign_dist = pz.Normal(
+        mu=definition.intercept_sign_mu, sigma=definition.intercept_sign_sigma
+    )
+    _plot_and_print_dist(context, intercept_sign_dist, "intercept_sign_dist")
 
     def kappa_block(kp, suffix):
         heading(f"Kappa priors — {suffix}", style="bold cyan")
@@ -381,8 +384,7 @@ def configure_joint_priors(context: JointContext, definition: JointModelDefiniti
         p_slope_hi_q_dist=p_slope_hi_q_dist,
         ell_unit_q_dist=ell_unit_q_dist,
         eta_q_dist=eta_q_dist,
-        p_slope_low_sign_dist=p_slope_low_sign_dist,
-        p_slope_hi_sign_dist=p_slope_hi_sign_dist,
+        intercept_sign_dist=intercept_sign_dist,
         ell_unit_sign_dist=ell_unit_sign_dist,
         eta_sign_dist=eta_sign_dist,
         kappa_min_u_dist=kappa_min_u_dist,
@@ -541,6 +543,25 @@ def build_model(context: JointContext):
         g_unit = hsgp.prior(f"g_unit_{suffix}", X=X_all_z_data, dims="all_id")
         return mean_trend + eta * g_unit  # plain tensor (n_all,)
 
+    def intercept_and_gp(cfg_intercept, cfg_ell, cfg_eta, suffix, X_all_z_data):
+        """Intercept-only mean (no age slope) + HSGP deviation; full-grid latent.
+
+        Used for the signed ratio: a free age slope would extrapolate the ratio
+        below the data floor (< ~18 mo), so the mean is intercept-only and the GP
+        carries the age-varying (rise-then-fall) shape. The study random
+        intercept is added at observation level by the caller.
+        """
+        intercept = cfg_intercept.to_pymc(f"intercept_{suffix}")
+        ell_unit = cfg_ell.to_pymc(f"ell_unit_{suffix}")
+        ell = pm.Deterministic(
+            f"ell_{suffix}", ell_low_z + (ell_high_z - ell_low_z) * ell_unit
+        )
+        eta = cfg_eta.to_pymc(f"eta_{suffix}")
+        cov = pm.gp.cov.ExpQuad(1, ls=ell)
+        hsgp = pm.gp.HSGP(cov_func=cov, m=M, L=L)
+        g_unit = hsgp.prior(f"g_unit_{suffix}", X=X_all_z_data, dims="all_id")
+        return intercept + eta * g_unit  # plain tensor (n_all,)
+
     with pm.Model(coords=coords) as model_pm:
         X_all_z_data = pm.Data("X_all_z", X_all_z, dims=("all_id", "x_dim"))
         _ = pm.Data("X_plot", X_plot.flatten(), dims=("plot_id",))
@@ -556,8 +577,10 @@ def build_model(context: JointContext):
             config.p_slope_low_q_dist, config.p_slope_hi_q_dist,
             config.ell_unit_q_dist, config.eta_q_dist, "q", X_all_z_data
         )
-        g_all = trend_and_gp(
-            config.p_slope_low_sign_dist, config.p_slope_hi_sign_dist,
+        # Signed marginal: intercept-only mean (no age slope) + GP hump; the
+        # study random intercept delta_sign is added at obs level below.
+        g_all = intercept_and_gp(
+            config.intercept_sign_dist,
             config.ell_unit_sign_dist, config.eta_sign_dist, "sign", X_all_z_data
         )
 

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -190,10 +190,11 @@ JointContext = ModelFitContext[JointModelConfiguration, JointModelSamples]
 def _load_uk02_four_cell():
     """Load uk_02 rows, split into four-cell (cross-tab) and marginal-only rows.
 
-    Returns (four_cell_df, marginal_df). The four-cell rows are those whose four
-    cells reconcile with the signed/spoken margins and sum to a positive total
-    (cell-sum within a few words of comprehension); they identify psi. The rest
-    are marginal-only uk_02 rows (no cross-tab).
+    Returns (four_cell_df, marginal_df). The four-cell rows are those whose
+    signed and spoken margins reconcile with the cross-tab cells
+    (signed == signed_only + signed_spoken, spoken == spoken_only + signed_spoken)
+    and whose four cells sum to a positive total; they identify psi. The rest
+    are marginal-only uk_02 rows (no usable cross-tab).
     """
     path = os.path.join(local_env.DATA_DIR, "vocab_data_uk_02.csv")
     raw = pd.read_csv(path)
@@ -461,8 +462,13 @@ def build_model(context: JointContext):
     for arr, nm in [(y_u, "understood"), (y_s, "spoken"), (y_sign, "signed")]:
         if arr.size and (arr.min() < 0 or arr.max() > n_trials):
             raise ValueError(f"{nm} outside [0, n_trials].")
-    if cell_counts.size and (cell_counts.min() < 0):
-        raise ValueError("negative four-cell count.")
+    if cell_counts.size:
+        if cell_counts.min() < 0:
+            raise ValueError("negative four-cell count.")
+        if not np.array_equal(cell_counts.sum(axis=1), cell_total):
+            raise ValueError("four-cell counts do not sum to cell_total.")
+        if cell_total.max() > n_trials:
+            raise ValueError(f"four-cell total exceeds n_trials ({n_trials}).")
 
     study_codes = np.asarray(df["study_code"], dtype=int)
     n_studies = int(study_codes.max()) + 1
@@ -882,7 +888,8 @@ def _run_joint_plots(context: JointContext):
     ind_med = np.median(s.p_any_indep_plot, axis=1) * n_trials
     ax.fill_between(X, id_hdi[:, 0], id_hdi[:, 1], alpha=0.20, color="C0")
     ax.plot(X, id_med, lw=3, color="C0", label="Data-identified p_any (median)")
-    ax.plot(X, ind_med, lw=2.5, ls="--", color="C3", label="Independence upper bound (r·q)")
+    ax.plot(X, ind_med, lw=2.5, ls="--", color="C3",
+            label="Independence upper bound (p_U·(1-(1-r)(1-q)))")
     ax.set_xlabel("Age (months)")
     ax.set_ylabel("Expected words produced (any modality)")
     ax.set_ylim(0, n_trials + 50)

--- a/src/vocab_growth/models/common_trivariate.py
+++ b/src/vocab_growth/models/common_trivariate.py
@@ -110,9 +110,8 @@ class TrivariateModelConfiguration(BaseModelConfiguration):
     ell_unit_q_dist: Continuous
     eta_q_dist: Continuous
 
-    # Signed ratio (r) priors
-    p_slope_low_sign_dist: Continuous
-    p_slope_hi_sign_dist: Continuous
+    # Signed ratio (r) priors — intercept-only mean (no age slope)
+    intercept_sign_dist: Continuous
     ell_unit_sign_dist: Continuous
     eta_sign_dist: Continuous
 
@@ -360,15 +359,12 @@ def configure_trivariate_priors(
     eta_sign_dist = pz.HalfNormal(sigma=definition.eta_sign_sigma)
     _plot_and_print_dist(context, eta_sign_dist, "eta_sign_dist")
 
-    p_slope_low_sign_dist = pz.Beta(
-        alpha=definition.p_slope_low_sign_alpha, beta=definition.p_slope_low_sign_beta
+    # Intercept-only signed mean (no age slope): a single weakly-informative
+    # intercept on the logit scale lets the data set the signed level / tail.
+    intercept_sign_dist = pz.Normal(
+        mu=definition.intercept_sign_mu, sigma=definition.intercept_sign_sigma
     )
-    _plot_and_print_dist(context, p_slope_low_sign_dist, "p_slope_low_sign_dist")
-
-    p_slope_hi_sign_dist = pz.Beta(
-        alpha=definition.p_slope_hi_sign_alpha, beta=definition.p_slope_hi_sign_beta
-    )
-    _plot_and_print_dist(context, p_slope_hi_sign_dist, "p_slope_hi_sign_dist")
+    _plot_and_print_dist(context, intercept_sign_dist, "intercept_sign_dist")
 
     # --- Kappa priors — understood ---
     heading("Kappa priors — understood", style="bold cyan")
@@ -426,9 +422,8 @@ def configure_trivariate_priors(
         p_slope_hi_q_dist=p_slope_hi_q_dist,
         ell_unit_q_dist=ell_unit_q_dist,
         eta_q_dist=eta_q_dist,
-        # Signed rate
-        p_slope_low_sign_dist=p_slope_low_sign_dist,
-        p_slope_hi_sign_dist=p_slope_hi_sign_dist,
+        # Signed rate (intercept-only mean)
+        intercept_sign_dist=intercept_sign_dist,
         ell_unit_sign_dist=ell_unit_sign_dist,
         eta_sign_dist=eta_sign_dist,
         # Kappa — understood
@@ -669,19 +664,12 @@ def build_model(context: TrivariateContext):
         # Signed ratio: g_sign(a) -> r(a) = sigmoid(g_sign(a))
         # ============================================================
 
-        p_slope_low_sign = config.p_slope_low_sign_dist.to_pymc("p_slope_low_sign")
-        p_slope_hi_sign = config.p_slope_hi_sign_dist.to_pymc("p_slope_hi_sign")
-
-        slope_sign = pm.Deterministic(
-            "slope_sign",
-            (pymc_utils.logit(p_slope_hi_sign) - pymc_utils.logit(p_slope_low_sign))
-            / (slope_age_b_z - slope_age_a_z),
-        )
-        intercept_sign = pm.Deterministic(
-            "intercept_sign",
-            pymc_utils.logit(p_slope_low_sign) - slope_sign * slope_age_a_z,
-        )
-        mean_trend_sign = intercept_sign + slope_sign * X_all_z_data[:, 0]
+        # Intercept-only mean (no age slope): structurally prevents a free slope
+        # from extrapolating the signed ratio below the data floor (< ~18 mo),
+        # while a wide intercept prior lets the data set the level. The GP carries
+        # the age-varying (rise-then-fall) shape.
+        intercept_sign = config.intercept_sign_dist.to_pymc("intercept_sign")
+        mean_trend_sign = intercept_sign
 
         # GP for signed rate
         ell_unit_sign = config.ell_unit_sign_dist.to_pymc("ell_unit_sign")

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -355,11 +355,15 @@ class JointModelDefinition:
     p_slope_hi_q_alpha: float = 2.0
     p_slope_hi_q_beta: float = 1.2
 
-    # -- Sign-given-understood (r) slope priors (VG14 hump-capable spec) --
-    p_slope_low_sign_alpha: float = 15.0
-    p_slope_low_sign_beta: float = 90.0
-    p_slope_hi_sign_alpha: float = 15.0
-    p_slope_hi_sign_beta: float = 90.0
+    # -- Sign-given-understood (r) mean prior (intercept-only, matching VG14) --
+    # The signed mean is intercept-only (no age slope): a free slope would
+    # extrapolate below the data floor (< ~18 mo). A single weakly-informative
+    # intercept lets the data set the grand-mean level; the study REs carry
+    # between-study level differences and the GP carries the rise-then-fall hump.
+    intercept_sign_mu: float = math.log(0.15 / 0.85)
+    """Normal mu for the signed-ratio intercept (logit scale, ~0.15)."""
+    intercept_sign_sigma: float = 0.75
+    """Normal sigma for the signed-ratio intercept (logit scale)."""
 
     # -- Shared GP / amplitude priors (sign GP looser + shorter, per VG14) --
     ell_unit_u_alpha: float = 3.0

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -36,6 +36,7 @@ class ModelType(Enum):
     UNIVARIATE = "univariate"
     BIVARIATE = "bivariate"
     TRIVARIATE = "trivariate"
+    JOINT = "joint"
 
 
 # ============================================================
@@ -316,6 +317,87 @@ class TrivariateModelDefinition:
     @property
     def model_type(self) -> ModelType:
         return ModelType.TRIVARIATE
+
+
+# ============================================================
+# Joint sign/speech model definition (VG15, issue #49 Option 3)
+# ============================================================
+
+
+@dataclass
+class JointModelDefinition:
+    """Complete definition for the joint sign/speech model (VG15).
+
+    Extends the trivariate structure (understood + within-understood sign/speak
+    ratios r, q) with a scalar Plackett association `psi` (identified from the
+    uk_02 four-cell cross-tab) and study random intercepts on each latent
+    trajectory. The r/q/p_U prior specs are seeded from the (uk_06-included)
+    VG14 fit (same hump-capable signed-ratio spec).
+    """
+
+    model_id: str
+    config_name: str
+    banner: str
+    population: Population
+    n_trials: int
+    slope_anchors: tuple[float, float]
+    ages_query: list[int]
+
+    # -- Understood (U) slope priors (seeded from VG05/VG14) --
+    p_slope_low_u_alpha: float = 1.0
+    p_slope_low_u_beta: float = 10.0
+    p_slope_hi_u_alpha: float = 1.1
+    p_slope_hi_u_beta: float = 1.1
+
+    # -- Speak-given-understood (q) slope priors (bivariate defaults) --
+    p_slope_low_q_alpha: float = 1.0
+    p_slope_low_q_beta: float = 1.5
+    p_slope_hi_q_alpha: float = 2.0
+    p_slope_hi_q_beta: float = 1.2
+
+    # -- Sign-given-understood (r) slope priors (VG14 hump-capable spec) --
+    p_slope_low_sign_alpha: float = 15.0
+    p_slope_low_sign_beta: float = 90.0
+    p_slope_hi_sign_alpha: float = 15.0
+    p_slope_hi_sign_beta: float = 90.0
+
+    # -- Shared GP / amplitude priors (sign GP looser + shorter, per VG14) --
+    ell_unit_u_alpha: float = 3.0
+    ell_unit_u_beta: float = 3.0
+    eta_u_sigma: float = 0.4
+    ell_unit_q_alpha: float = 3.0
+    ell_unit_q_beta: float = 3.0
+    eta_q_sigma: float = 0.4
+    ell_unit_sign_alpha: float = 2.0
+    ell_unit_sign_beta: float = 5.0
+    eta_sign_sigma: float = 1.0
+    ell_months_range: tuple[int, int] = (6, 18)
+    n_plot: int = 500
+    kappa_u: KappaPriorParams = field(default_factory=KappaPriorParams)
+    kappa_s: KappaPriorParams = field(default_factory=KappaPriorParams)
+    kappa_sign: KappaPriorParams = field(default_factory=KappaPriorParams)
+
+    # -- Association (Plackett log odds-ratio) --
+    log_psi_mu: float = 0.3
+    """Normal mu for log psi. Weakly positive (uk_02 shows both > r·q) but spans
+    independence (psi = 1)."""
+    log_psi_sigma: float = 0.5
+
+    # -- Dirichlet-Multinomial concentration (log scale) --
+    log_conc_mu: float = 3.0
+    log_conc_sigma: float = 1.0
+
+    # -- Study random-intercept scales (VG07-VG10 pattern) --
+    tau_u_sigma: float = 0.5
+    tau_q_sigma: float = 0.5
+    tau_sign_sigma: float = 0.5
+
+    # -- Signed data inclusion (inherits VG14's decision) --
+    include_uk06: bool = True
+
+    @property
+    def model_type(self) -> ModelType:
+        return ModelType.JOINT
 
 
 # ============================================================
@@ -642,8 +724,28 @@ VG14 = TrivariateModelDefinition(
     # uk_06 signed included by default (include_uk06=True); kappa_sign default.
 )
 
+VG15 = JointModelDefinition(
+    model_id="VG15",
+    config_name="age-joint-signspeech-ds",
+    banner=(
+        "Fitting Model VG15: Joint sign/speech model with within-understood"
+        " association (psi) and study random intercepts - Down syndrome"
+    ),
+    population=Population.DOWN_SYNDROME,
+    n_trials=800,
+    slope_anchors=(24, 84),
+    ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
+    # r/q/p_U priors seeded from the (uk_06-included) VG14 fit (see dataclass
+    # defaults); psi ~ logNormal(0.3, 0.5) (weakly positive, spans independence);
+    # study random intercepts on f_U/g/h (tau_*=0.5).
+)
+
 MODEL_REGISTRY: dict[
-    str, UnivariateModelDefinition | BivariateModelDefinition | TrivariateModelDefinition
+    str,
+    UnivariateModelDefinition
+    | BivariateModelDefinition
+    | TrivariateModelDefinition
+    | JointModelDefinition,
 ] = {
     "vg01": VG01,
     "vg02": VG02,
@@ -659,4 +761,5 @@ MODEL_REGISTRY: dict[
     "vg12": VG12,
     "vg13": VG13,
     "vg14": VG14,
+    "vg15": VG15,
 }

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -261,17 +261,20 @@ class TrivariateModelDefinition:
     p_slope_hi_q_alpha: float = 2.0
     p_slope_hi_q_beta: float = 1.2
 
-    # -- Signed ratio (r) slope priors --
+    # -- Signed ratio (r) mean prior (intercept-only) --
     # The empirical signed/understood ratio is a *hump* (near zero < 24 mo, peak
-    # ~0.5 around 48-54 mo, receding after), not a monotone trend. The two
-    # anchors share a TIGHT, equal low-fraction prior so the logit-linear mean
-    # trend is pinned ~flat (it cannot co-opt the real old-age fade into a
-    # monotone decline that then extrapolates upward below 24 mo); the loosened
-    # signed GP (eta_sign, below) is left to carry the entire rise-then-fall.
-    p_slope_low_sign_alpha: float = 15.0
-    p_slope_low_sign_beta: float = 90.0
-    p_slope_hi_sign_alpha: float = 15.0
-    p_slope_hi_sign_beta: float = 90.0
+    # in the preschool years, receding after), not a monotone trend. The signed
+    # mean trend is INTERCEPT-ONLY (no age slope) — this structurally removes the
+    # original "free slope tilts down and extrapolates to a spurious ~58% signed
+    # at 12 mo" failure mode, so the level no longer needs a tight prior. A single
+    # weakly-informative intercept (logit scale) lets the data set the signed
+    # level and old-age tail; the GP (eta_sign, below) carries the rise-then-fall.
+    intercept_sign_mu: float = math.log(0.15 / 0.85)
+    """Normal mu for the signed-ratio intercept (logit scale, ~0.15)."""
+    intercept_sign_sigma: float = 0.75
+    """Normal sigma for the signed-ratio intercept (logit scale). Wide enough to
+    span a broad signed level once combined with the GP; calibrated against the
+    prior-predictive r(a) band (broad, not piling at 0 or 1)."""
 
     # -- Shared GP / amplitude priors --
     ell_unit_u_alpha: float = 3.0
@@ -634,8 +637,8 @@ VG14 = TrivariateModelDefinition(
     p_slope_hi_u_alpha=1.1,
     p_slope_hi_u_beta=1.1,
     # Spoken ratio q: bivariate defaults.
-    # Signed ratio r: tight flat low-fraction anchors + loosened GP (eta_sign=1.0)
-    #   so the GP carries the empirical rise-then-fall hump (see dataclass).
+    # Signed ratio r: intercept-only mean (data-set level) + loosened GP
+    #   (eta_sign=1.0) carrying the rise-then-fall hump (see dataclass).
     # uk_06 signed included by default (include_uk06=True); kappa_sign default.
 )
 

--- a/src/vocab_growth/models/model_vg15.py
+++ b/src/vocab_growth/models/model_vg15.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Model VG15: Joint sign/speech model (issue #49 Option 3) - children with Down
+syndrome.
+
+Estimates the within-understood sign-speech association (a scalar Plackett odds
+ratio, identified from the uk_02 four-cell cross-tab) and adds study random
+intercepts, replacing VG14's independence-based p_any upper bound with a
+data-identified total expressive vocabulary. See ``common_joint_modality`` for
+the engine.
+"""
+
+from vocab_growth.models.common_joint_modality import (
+    JointContext,
+    fit_joint_model,
+)
+from vocab_growth.models.definitions import VG15
+
+
+def fit(config: str) -> JointContext:
+    return fit_joint_model(config, VG15)


### PR DESCRIPTION
## VG15 — joint sign/speech model (within-understood association ψ + study REs)

Implements **Option 3 of #49**. **Stacked on #54** (VG14 intercept-only) — review/merge #54 first; this PR's diff is VG15-only.

### Model (isolated engine `common_joint_modality.py`)
- Within-understood **sign–speech association ψ** via a Plackett copula, identified from the uk_02 four-cell cross-tab (Dirichlet-Multinomial on the four cells).
- **Data-identified** `p_any = p_U·(r + q − π_both)` replaces VG14's independence upper bound.
- **Study random intercepts** (VG07–VG10 pattern) on understood / spoken-ratio / signed-ratio.
- Signed marginal mean is **intercept-only** (same fix as #54).

### Findings (`--config rep`, 6×6000)
- 2 divergences / 36k draws (near-zero); R-hat ≈ 1.001.
- **ψ = 1.78, 95% HDI [1.19, 2.42], P(ψ>1) = 0.997** — within understood words, signing and speaking co-occur *more* than chance.
- `intercept_sign` posterior sd 0.48 (data-informed).

### Copilot review — all 4 items addressed
1. `_load_uk02_four_cell` docstring now describes the **actual** four-cell filter (signed/spoken margins reconcile + positive total), not "within a few words of comprehension".
2. `build_model` now **validates** the four cells sum to `cell_total` and `cell_total ≤ n_trials` (fail-fast on invalid Dirichlet-Multinomial input), beyond the prior non-negativity check.
3. p_any plot legend corrected from "(r·q)" to the true union form **p_U·(1−(1−r)(1−q))**.
4. Report grammar "than where" → "than **when**".

### Verification
`ruff check` ✓ · new four-cell invariants pass on real uk_02 data (62 rows, max total 639 ≤ 800) · `format:check` ✓ · `spellcheck` ✓ · `rep` fit + render ✓
