### PR TITLE
VG14: intercept-only signed mean (free the prior-dominated level)

### DIFF
--- a/docs/models/vg14/index.qmd
+++ b/docs/models/vg14/index.qmd
@@ -87,15 +87,13 @@ For full details and discussion, please refer to the technical report.
 
 ### Signed ratio
 
-The empirical signed fraction of understood words is a **hump** — near zero below ~24 months, rising to a peak in the preschool years, then receding as words move into speech — not a monotone trend. The signed-ratio mean trend is therefore pinned approximately **flat** (tight, equal low-fraction anchor priors, so the logit-linear trend cannot co-opt the real old-age fade into a monotone decline), and the GP is given a **looser amplitude** (`eta_sign`) and a **shorter lengthscale** than the spoken ratio so it can carry the rise-then-fall shape itself.
+The empirical signed fraction of understood words is a **hump** — near zero below ~24 months, rising to a peak in the preschool years, then receding as words move into speech — not a monotone trend. The signed-ratio mean trend is **intercept-only** (no age slope): this structurally prevents a free slope from extrapolating the ratio below the data floor (< ~18 months), so the level no longer needs a tight prior. A single weakly-informative intercept (`intercept_sign`, logit scale) lets the data set the signed level and old-age tail, while the GP — given a **looser amplitude** (`eta_sign`) and a **shorter lengthscale** than the spoken ratio — carries the rise-then-fall shape.
 
 ![Lengthscale prior `ell_unit_sign_dist`](ell_unit_sign_dist.svg){#fig-ell-sign .lightbox fig-align="left"}
 
 ![Amplitude prior `eta_sign_dist`](eta_sign_dist.svg){#fig-eta-sign .lightbox fig-align="left"}
 
-![Flat-anchor prior (24 months) `p_slope_low_sign_dist`](p_slope_low_sign_dist.svg){#fig-slope-low-sign .lightbox fig-align="left"}
-
-![Flat-anchor prior (84 months) `p_slope_hi_sign_dist` — tight and equal to the 24-month anchor, pinning the signed mean trend flat](p_slope_hi_sign_dist.svg){#fig-slope-hi-sign .lightbox fig-align="left"}
+![Signed-ratio mean intercept prior `intercept_sign_dist` (logit scale, intercept-only mean)](intercept_sign_dist.svg){#fig-intercept-sign .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- understood
 

--- a/notes/202606151700-vg14-signed-ratio-shape-and-p-any-bias.md
+++ b/notes/202606151700-vg14-signed-ratio-shape-and-p-any-bias.md
@@ -154,8 +154,9 @@ prose describes the result as a hump (signing rises then yields to speech), not
 
 Re-fitted at `--config rep` (6 chains × 6000 draws) after the changes above.
 Diagnostics are clean: **0 divergences / 36 000**, max r̂ = 1.001, min ESS ≈ 6.5k.
-Signed-block posteriors: `eta_sign` 1.15 (the loosened GP is used), `ell_sign`
-≈ 10 mo, anchors pinned flat at 0.16 / 0.12 (the tight prior held).
+(The signed mean here used the tight flat-anchor parameterisation; it is
+**superseded by §6's intercept-only refit** — the r(a) shape, peak and crossover
+below are unchanged, only the signed-mean parameterisation differs.)
 
 `r(a)` is now a **hump**, not a monotone decline:
 
@@ -186,3 +187,49 @@ independence over-states the union by **3.7 pp** within `uk_02` (0.608 vs observ
 
 Key figures: `signed_rate.svg` (hump, extrapolation shaded < 18 / > 54 mo),
 `sign_speech_crossover.svg`, `p_any_validation.svg`.
+
+## 6. Signed mean was prior-dominated → intercept-only refit (current)
+
+The flat-anchor signed mean (§1) did its job — it killed the original spurious
+"~58% signed at 12 mo" slope-extrapolation — but it was **too strict**: the two
+anchor priors (`Beta(15,90) ≈ 0.143 ± 0.034`) were prior-dominated (posterior sd
+≈ prior sd, ~0.16/0.12 — the data wasn't moving them), so the signed **level**
+was set by the prior, not the data. By contrast the understood/spoken anchors all
+moved a lot and shrank, confirming the strictness was isolated to the signed mean.
+
+**Fix:** make the signed mean **intercept-only** (drop the age slope entirely —
+that was the actual failure mode) and replace the two tight anchors with one
+weakly-informative intercept, `intercept_sign ~ Normal(logit(0.15), 0.75)` on the
+logit scale. The slope can no longer extrapolate, so a wide level prior is safe.
+The signed GP (`eta_sign`, `ell_unit_sign`) is unchanged. Understood/spoken,
+kappa, sampler and `include_uk06=True` are untouched.
+
+**Result (rep, uk_06 included, intercept-only):** clean (0 divergences / 36 000,
+r̂ ≤ 1.001, min ESS ≈ 7.6k).
+
+| quantity                   | flat-anchor                  | intercept-only                 |
+| -------------------------- | ---------------------------- | ------------------------------ |
+| signed level prior sd      | ~0.034 (probability)         | 0.75 (logit)                   |
+| `intercept_sign` posterior | (pinned) 0.16 / 0.12 anchors | mean −1.84 ≈ 0.14, **sd 0.44** |
+| `eta_sign`                 | 1.15                         | 1.06                           |
+| r peak                     | 0.46 @ ~30 mo                | 0.47 @ ~30 mo                  |
+| crossover                  | ~39 mo                       | ~39 mo                         |
+| r(90) tail                 | 0.043                        | 0.043                          |
+
+The intercept posterior sd (0.44) is now **meaningfully below its prior sd
+(0.75)** — the data is speaking, where before it wasn't. `eta_sign` dropped
+slightly (the free level carries some of what the GP was lifting) and is not
+pinned. **Substantively the curve is unchanged**: the freed level lands at ~0.14
+(≈ the old pinned level), and — contrary to the hypothesis that uk_06's heavy
+older signers would lift the tail — the old-age tail stays low (r(90) ≈ 0.04).
+The aggregate 60–115 mo marginal is dominated by uk_01's many near-zero older
+signers, which outweigh uk_06's 11 heavy ones, so the data genuinely supports a
+low old-age population tail. The change is therefore a **methodological
+correction** (level now data-informed, honest wider uncertainty), not a new
+substantive result.
+
+**Peak still does not relocate** and is not expected to: looser priors give
+honest wider uncertainty, not a later peak. The late window is essentially one
+study and VG14 has no study random effects, so the peak age remains
+study-confounded. The real peak-identifiability fix is **study random
+intercepts (VG15)**, not prior tuning.

--- a/src/vocab_growth/models/common_trivariate.py
+++ b/src/vocab_growth/models/common_trivariate.py
@@ -110,9 +110,8 @@ class TrivariateModelConfiguration(BaseModelConfiguration):
     ell_unit_q_dist: Continuous
     eta_q_dist: Continuous
 
-    # Signed ratio (r) priors
-    p_slope_low_sign_dist: Continuous
-    p_slope_hi_sign_dist: Continuous
+    # Signed ratio (r) priors — intercept-only mean (no age slope)
+    intercept_sign_dist: Continuous
     ell_unit_sign_dist: Continuous
     eta_sign_dist: Continuous
 
@@ -360,15 +359,12 @@ def configure_trivariate_priors(
     eta_sign_dist = pz.HalfNormal(sigma=definition.eta_sign_sigma)
     _plot_and_print_dist(context, eta_sign_dist, "eta_sign_dist")
 
-    p_slope_low_sign_dist = pz.Beta(
-        alpha=definition.p_slope_low_sign_alpha, beta=definition.p_slope_low_sign_beta
+    # Intercept-only signed mean (no age slope): a single weakly-informative
+    # intercept on the logit scale lets the data set the signed level / tail.
+    intercept_sign_dist = pz.Normal(
+        mu=definition.intercept_sign_mu, sigma=definition.intercept_sign_sigma
     )
-    _plot_and_print_dist(context, p_slope_low_sign_dist, "p_slope_low_sign_dist")
-
-    p_slope_hi_sign_dist = pz.Beta(
-        alpha=definition.p_slope_hi_sign_alpha, beta=definition.p_slope_hi_sign_beta
-    )
-    _plot_and_print_dist(context, p_slope_hi_sign_dist, "p_slope_hi_sign_dist")
+    _plot_and_print_dist(context, intercept_sign_dist, "intercept_sign_dist")
 
     # --- Kappa priors — understood ---
     heading("Kappa priors — understood", style="bold cyan")
@@ -426,9 +422,8 @@ def configure_trivariate_priors(
         p_slope_hi_q_dist=p_slope_hi_q_dist,
         ell_unit_q_dist=ell_unit_q_dist,
         eta_q_dist=eta_q_dist,
-        # Signed rate
-        p_slope_low_sign_dist=p_slope_low_sign_dist,
-        p_slope_hi_sign_dist=p_slope_hi_sign_dist,
+        # Signed rate (intercept-only mean)
+        intercept_sign_dist=intercept_sign_dist,
         ell_unit_sign_dist=ell_unit_sign_dist,
         eta_sign_dist=eta_sign_dist,
         # Kappa — understood
@@ -669,19 +664,12 @@ def build_model(context: TrivariateContext):
         # Signed ratio: g_sign(a) -> r(a) = sigmoid(g_sign(a))
         # ============================================================
 
-        p_slope_low_sign = config.p_slope_low_sign_dist.to_pymc("p_slope_low_sign")
-        p_slope_hi_sign = config.p_slope_hi_sign_dist.to_pymc("p_slope_hi_sign")
-
-        slope_sign = pm.Deterministic(
-            "slope_sign",
-            (pymc_utils.logit(p_slope_hi_sign) - pymc_utils.logit(p_slope_low_sign))
-            / (slope_age_b_z - slope_age_a_z),
-        )
-        intercept_sign = pm.Deterministic(
-            "intercept_sign",
-            pymc_utils.logit(p_slope_low_sign) - slope_sign * slope_age_a_z,
-        )
-        mean_trend_sign = intercept_sign + slope_sign * X_all_z_data[:, 0]
+        # Intercept-only mean (no age slope): structurally prevents a free slope
+        # from extrapolating the signed ratio below the data floor (< ~18 mo),
+        # while a wide intercept prior lets the data set the level. The GP carries
+        # the age-varying (rise-then-fall) shape.
+        intercept_sign = config.intercept_sign_dist.to_pymc("intercept_sign")
+        mean_trend_sign = intercept_sign
 
         # GP for signed rate
         ell_unit_sign = config.ell_unit_sign_dist.to_pymc("ell_unit_sign")

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -261,17 +261,20 @@ class TrivariateModelDefinition:
     p_slope_hi_q_alpha: float = 2.0
     p_slope_hi_q_beta: float = 1.2
 
-    # -- Signed ratio (r) slope priors --
+    # -- Signed ratio (r) mean prior (intercept-only) --
     # The empirical signed/understood ratio is a *hump* (near zero < 24 mo, peak
-    # ~0.5 around 48-54 mo, receding after), not a monotone trend. The two
-    # anchors share a TIGHT, equal low-fraction prior so the logit-linear mean
-    # trend is pinned ~flat (it cannot co-opt the real old-age fade into a
-    # monotone decline that then extrapolates upward below 24 mo); the loosened
-    # signed GP (eta_sign, below) is left to carry the entire rise-then-fall.
-    p_slope_low_sign_alpha: float = 15.0
-    p_slope_low_sign_beta: float = 90.0
-    p_slope_hi_sign_alpha: float = 15.0
-    p_slope_hi_sign_beta: float = 90.0
+    # in the preschool years, receding after), not a monotone trend. The signed
+    # mean trend is INTERCEPT-ONLY (no age slope) — this structurally removes the
+    # original "free slope tilts down and extrapolates to a spurious ~58% signed
+    # at 12 mo" failure mode, so the level no longer needs a tight prior. A single
+    # weakly-informative intercept (logit scale) lets the data set the signed
+    # level and old-age tail; the GP (eta_sign, below) carries the rise-then-fall.
+    intercept_sign_mu: float = math.log(0.15 / 0.85)
+    """Normal mu for the signed-ratio intercept (logit scale, ~0.15)."""
+    intercept_sign_sigma: float = 0.75
+    """Normal sigma for the signed-ratio intercept (logit scale). Wide enough to
+    span a broad signed level once combined with the GP; calibrated against the
+    prior-predictive r(a) band (broad, not piling at 0 or 1)."""
 
     # -- Shared GP / amplitude priors --
     ell_unit_u_alpha: float = 3.0
@@ -634,8 +637,8 @@ VG14 = TrivariateModelDefinition(
     p_slope_hi_u_alpha=1.1,
     p_slope_hi_u_beta=1.1,
     # Spoken ratio q: bivariate defaults.
-    # Signed ratio r: tight flat low-fraction anchors + loosened GP (eta_sign=1.0)
-    #   so the GP carries the empirical rise-then-fall hump (see dataclass).
+    # Signed ratio r: intercept-only mean (data-set level) + loosened GP
+    #   (eta_sign=1.0) carrying the rise-then-fall hump (see dataclass).
     # uk_06 signed included by default (include_uk06=True); kappa_sign default.
 )
 


### PR DESCRIPTION
## VG14 — free the prior-dominated signed mean (intercept-only)

Refinement on top of the **slope-based VG14 merged to `main` in #52**. **Stacked below #53** (VG15 builds on this branch).

### What & why
The signed mean-trend previously carried a logit-linear **age slope** anchored at two reference ages. With signing data this sparse, the slope's anchor priors (`Beta(15,90)`) **dominated the posterior** and produced an artefactual extrapolation in `r(a)`. This PR drops the slope and makes the signed mean **intercept-only** — `intercept_sign ~ Normal(logit(0.15), 0.75)` — letting the HSGP deviation carry the rise-then-fall hump. Understood and spoken blocks are unchanged. (The same fix is applied in VG15's engine in #53.)

### Diagnostics (`--config rep`, 6×6000)
- 0 divergences / 36k draws; R-hat ≈ 1.001; healthy ESS.
- `intercept_sign` posterior sd **0.44 vs prior 0.75** → now data-informed, no longer prior-pinned.

### Review status
- #52 (slope-based VG14) was **approved by @frankbuckley** and squash-merged to `main`.
- Copilot's 3 items on #52 are addressed: the `uk_06` comments use the maintainer's neutral wording (no "by default" / "comprehension-adjacent" inconsistency) and the report reads "more approximate than **when** …".

### Verification
`ruff check src/ scripts/` ✓ · `npm run format:check` ✓ · `npm run spellcheck` ✓ · `rep` fit + render ✓
