### PR TITLE
DS/TD comparative analysis: contrast tooling, report, disk preflight

### DIFF
--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -91,8 +91,8 @@ _style_diagnostics(diagnostics)
 ### Understood trajectory
 
 ```{python}
-posterior_summary = pd.read_csv("posterior_summary.csv", index_col=0)
-posterior_summary
+posterior_summary_u = pd.read_csv("posterior_summary_u.csv", index_col=0)
+posterior_summary_u
 ```
 
 ### Joint trajectory

--- a/scripts/compare_ds_td.py
+++ b/scripts/compare_ds_td.py
@@ -17,12 +17,15 @@ import os
 import dse_research_utils.plot.styles as plot_styles
 from compare_models import OUT_DIR, ds_td_q_vs_understood
 
+from vocab_growth import environment as env
+
 
 def _main() -> None:
     print(
         "[deprecated] compare_ds_td.py is superseded by compare_models.py; "
         "delegating to compare_models.ds_td_q_vs_understood().",
     )
+    env.preflight_disk(2.0, OUT_DIR, label="DS/TD q-vs-understood outputs")
     plot_styles.set_matplotlib_default_style()
     os.makedirs(OUT_DIR, exist_ok=True)
     ds_td_q_vs_understood()

--- a/scripts/compare_ds_td_latency.py
+++ b/scripts/compare_ds_td_latency.py
@@ -3,7 +3,7 @@
 """
 Reframe the comprehension-production gap as a learn-to-say latency.
 
-For each population (DS via VG10, TD via VG06) and each target vocabulary
+For each population (DS via VG10, TD via VG13) and each target vocabulary
 count N:
 
 - a_U(N) = first age at which the latent expected U(a) reaches N
@@ -50,7 +50,9 @@ from vocab_growth.comparison import (  # noqa: F401
 )
 
 DS_KEY = "vg10"
-TD_KEY = "vg06"
+# Repointed off the deleted non-RE VG06 trace to the RE TD joint (VG13, 8-18 mo).
+# Note: superseded by compare_ds_td_re.py; requires a fitted VG13 trace.
+TD_KEY = "vg13"
 
 DS_DIR = comparison.model_dir(DS_KEY)
 TD_DIR = comparison.model_dir(TD_KEY)
@@ -96,7 +98,7 @@ def main() -> None:
 
     ax = axes[0]
     comparison.plot_summary_band(ax, da_ds, "N", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
-    comparison.plot_summary_band(ax, da_td, "N", "TD (VG06)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
+    comparison.plot_summary_band(ax, da_td, "N", "TD (VG13)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
     ax.set_xlabel("Vocabulary count N (words)")
     ax.set_ylabel(r"$\Delta A(N) = a_S(N) - a_U(N)$  (months)")
     ax.set_title("Age lag between understanding and saying N words")
@@ -106,7 +108,7 @@ def main() -> None:
 
     ax = axes[1]
     comparison.plot_summary_band(ax, extra_ds, "N", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
-    comparison.plot_summary_band(ax, extra_td, "N", "TD (VG06)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
+    comparison.plot_summary_band(ax, extra_td, "N", "TD (VG13)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
     ax.set_xlabel("Spoken count N (words)")
     ax.set_ylabel("Extra words understood when first saying N  (= U(a_S(N)) - N)")
     ax.set_title("Vocabulary lag at production-matched points")
@@ -115,7 +117,7 @@ def main() -> None:
     ax.grid(True, which="both", alpha=0.3)
 
     fig.suptitle(
-        "Modeling the gap as a learn-to-say latency — DS (VG10) vs TD (VG06)",
+        "Modeling the gap as a learn-to-say latency — DS (VG10) vs TD (VG13)",
         fontsize=12,
     )
     fig.tight_layout()

--- a/scripts/compare_ds_td_latency.py
+++ b/scripts/compare_ds_td_latency.py
@@ -36,6 +36,7 @@ import numpy as np
 import pandas as pd
 
 from vocab_growth import comparison
+from vocab_growth import environment as env
 
 # Re-exported for backward compatibility with verify_ds_td_latency.py and
 # compare_ds_td_q_overlap.py, which import these names from this module.
@@ -66,6 +67,7 @@ N_GRID = np.array(
 
 
 def main() -> None:
+    env.preflight_disk(2.0, OUT_DIR, label="DS/TD latency outputs")
     plot_styles.set_matplotlib_default_style()
     os.makedirs(OUT_DIR, exist_ok=True)
 

--- a/scripts/compare_ds_td_q_overlap.py
+++ b/scripts/compare_ds_td_q_overlap.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-Population-level posterior overlap of q(a) = S/U for DS (VG10) and TD (VG06).
+Population-level posterior overlap of q(a) = S/U for DS (VG10) and TD (VG13).
 
 Two views:
 
@@ -45,7 +45,9 @@ from vocab_growth.comparison import (
 )
 
 DS_KEY = "vg10"
-TD_KEY = "vg06"
+# Repointed off the deleted non-RE VG06 trace to the RE TD joint (VG13, 8-18 mo).
+# Note: superseded by compare_ds_td_re.py; requires a fitted VG13 trace.
+TD_KEY = "vg13"
 DS_DIR = comparison.model_dir(DS_KEY)
 TD_DIR = comparison.model_dir(TD_KEY)
 N_TRIALS_DS = comparison.n_trials(DS_KEY)
@@ -106,7 +108,7 @@ def main() -> None:
 
     ax_qU = fig.add_subplot(gs[0, 0])
     comparison.plot_summary_band(ax_qU, qU_ds_sum, "N", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
-    comparison.plot_summary_band(ax_qU, qU_td_sum, "N", "TD (VG06)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
+    comparison.plot_summary_band(ax_qU, qU_td_sum, "N", "TD (VG13)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
     ax_qU.set_xscale("log")
     ax_qU.set_xlabel("Comprehension N (words)")
     ax_qU.set_ylabel("q(U=N) = E[S] / N")
@@ -117,7 +119,7 @@ def main() -> None:
 
     ax_qa = fig.add_subplot(gs[0, 1])
     comparison.plot_summary_band(ax_qa, qa_ds_sum, "age_months", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
-    comparison.plot_summary_band(ax_qa, qa_td_sum, "age_months", "TD (VG06)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
+    comparison.plot_summary_band(ax_qa, qa_td_sum, "age_months", "TD (VG13)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
     ax_qa.set_xlabel("Age (months)")
     ax_qa.set_ylabel("q(a) = E[S(a)] / E[U(a)]")
     ax_qa.set_title("Production ratio at matched age")
@@ -142,7 +144,7 @@ def main() -> None:
     ax_pa.set_ylim(0, 1)
     ax_pa.grid(True, alpha=0.3)
 
-    fig.suptitle("Posterior overlap of population q = S/U — DS (VG10) vs TD (VG06)", fontsize=13)
+    fig.suptitle("Posterior overlap of population q = S/U — DS (VG10) vs TD (VG13)", fontsize=13)
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_overlap.png"), dpi=300, bbox_inches="tight")
     fig.savefig(os.path.join(OUT_DIR, "ds_td_q_overlap.svg"), bbox_inches="tight")
     plt.close(fig)

--- a/scripts/compare_ds_td_q_overlap.py
+++ b/scripts/compare_ds_td_q_overlap.py
@@ -35,6 +35,7 @@ import pandas as pd
 from scipy.stats import gaussian_kde
 
 from vocab_growth import comparison
+from vocab_growth import environment as env
 from vocab_growth.comparison import (
     compute_q_at_age,
     compute_q_at_U,
@@ -66,6 +67,7 @@ MIN_COVERAGE = 0.80
 
 
 def main() -> None:
+    env.preflight_disk(2.0, OUT_DIR, label="DS/TD q-overlap outputs")
     plot_styles.set_matplotlib_default_style()
     os.makedirs(OUT_DIR, exist_ok=True)
     rng = np.random.default_rng(0)

--- a/scripts/compare_ds_td_q_vs_understood.py
+++ b/scripts/compare_ds_td_q_vs_understood.py
@@ -22,6 +22,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 from vocab_growth import comparison
+from vocab_growth import environment as env
 
 DS_DIR = comparison.model_dir("vg10")
 TD_DIR = comparison.model_dir("vg06")
@@ -29,6 +30,7 @@ OUT_DIR = "output/comparisons"
 
 
 def main() -> None:
+    env.preflight_disk(2.0, OUT_DIR, label="DS/TD q-vs-understood outputs")
     plot_styles.set_matplotlib_default_style()
     os.makedirs(OUT_DIR, exist_ok=True)
 

--- a/scripts/compare_ds_td_re.py
+++ b/scripts/compare_ds_td_re.py
@@ -1,0 +1,435 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+DS-vs-TD population contrasts between RE-based models (separate-model, per-draw).
+
+Honest comparators only: the DS side is the spoken / understood **sub-curve of a
+random-effects DS model** (VG10 by default — study + subject REs), not the
+no-RE VG01/VG02. The TD side is the univariate study-RE models VG11 (spoken) /
+VG12 (understood).
+
+Why separate models suffice for credible intervals
+--------------------------------------------------
+The DS and TD datasets are disjoint (no shared studies or children), so the
+joint posterior factorises and a per-draw difference gives an *exact* credible
+interval for any contrast — no joint model required. Accordingly every estimand
+here is computed **draw-by-draw** (contrast the draws, never the summaries),
+on a **common age grid restricted to the empirical overlap**, using the
+**population-level (RE-excluded) outcome-scale** curve on both sides so the
+estimand is identical. A joint/stacked model that makes the TD-DS gap itself a
+generative object (partial pooling, a directly-estimated delay, difference-in-
+differences, the "delayed/scaled TD trajectory" hypothesis) is the reserved
+future **VG16** and is intentionally NOT built here.
+
+Estimands, per outcome, written to ``output/comparisons/``:
+
+* ``ds_td_<outcome>_re_expected_words.csv``   — TD & DS expected words, the
+  difference δ(a)=TD-DS (+90/50% HDI, P(TD>DS)) and the ratio.
+* ``ds_td_<outcome>_re_learning_rate.csv``    — dY/da for each population and
+  the difference Δ(a) (words/month).
+* ``ds_td_<outcome>_re_attainment_delay.csv`` — D(v)=age_DS(v)-age_TD(v): how
+  many months behind TD the DS population reaches each vocabulary level v
+  (a flat D(v) ⇒ pure shift; a rising D(v) ⇒ developmental stretch).
+* ``ds_td_<outcome>_re_dispersion.csv``        — concentration κ, implied word
+  SD σ_Y, and the mean-independent overdispersion factor φ for each population,
+  with the contrasts Δκ, Δσ_Y, φ_TD/φ_DS. (κ and σ_Y tell different stories;
+  φ isolates pure concentration.)
+
+plus a 2x3 summary figure ``ds_td_<outcome>_re.{png,svg}``.
+
+Usage::
+
+    python scripts/compare_ds_td_re.py                 # spoken + understood
+    python scripts/compare_ds_td_re.py spoken          # one outcome
+    python scripts/compare_ds_td_re.py --verify        # self-checks then run
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import dse_research_utils.plot.styles as plot_styles
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from vocab_growth import comparison as C
+from vocab_growth import environment as env
+
+# DS comparator: VG10 spoken/understood sub-curve (study+subject REs). One-line
+# swap to vg07/vg08/vg09 for a sensitivity check (all carry random effects).
+DS_KEY = "vg10"
+# Dispersion needs a study-RE-ONLY DS model so the Beta-Binomial kappa is the
+# like-for-like between-child concentration: VG10's subject random intercepts
+# absorb child variance that the TD models (VG11/12, study-RE only) keep in
+# kappa, so a VG10-vs-TD kappa contrast is not consistent. VG07 is the
+# study-RE-only joint DS model. (Mean/rate/delay keep VG10 — subject REs are
+# mean-zero, so the population trajectory is unaffected.)
+DISP_DS_KEY = "vg07"
+# TD comparator per outcome: the univariate study-RE models.
+TD_KEYS = {"spoken": "vg11", "understood": "vg12"}
+
+OUT_DIR = os.path.join("output", "comparisons")
+SEED = 20260616
+GRID_STEP = 0.5  # months
+# Vocabulary levels (words) for the attainment-delay D(v) curve.
+N_GRID = np.array(
+    [10, 15, 20, 25, 30, 40, 50, 75, 100, 125, 150, 200,
+     250, 300, 350, 400, 450, 500, 550, 600],
+    dtype=float,
+)
+MIN_COVERAGE = 0.80
+KEY_AGES = [12, 18, 24, 30]
+
+# Comprehension-matched lens needs JOINT models (U and S coupled per draw): the
+# DS joint VG10 vs the TD joint VG13 (RE-based, 8-18 mo). VG06 is the non-RE TD
+# baseline and can be passed via --td-joint=vg06 for a sensitivity check.
+JOINT_DS_KEY = "vg10"
+JOINT_TD_KEY = "vg13"
+# Comprehension levels N (words understood) for the q(U=N) view. Small-N tail is
+# noisy (S/U unstable when U barely exceeds N); high-N tail is coverage-limited.
+N_GRID_Q = np.array(
+    [10, 15, 20, 25, 30, 40, 50, 75, 100, 125, 150, 175, 200, 250, 300, 350, 400],
+    dtype=float,
+)
+
+COL_TD = plot_styles.COLOUR_ORANGE
+COL_DS = plot_styles.COLOUR_BLUE
+COL_D = plot_styles.COLOUR_GREEN
+
+
+# ----------------------------------------------------------------------------
+# Frame assembly
+# ----------------------------------------------------------------------------
+def _merge(grid: np.ndarray, grid_name: str, **frames: pd.DataFrame) -> pd.DataFrame:
+    """Combine several summarise_draws frames (same grid) into one wide frame."""
+    base = pd.DataFrame({grid_name: grid.astype(float)})
+    for name, fr in frames.items():
+        rename = {c: f"{name}_{c}" for c in fr.columns if c != grid_name}
+        base = base.merge(fr.rename(columns=rename), on=grid_name, how="left")
+    return base
+
+
+def _at_age(frame: pd.DataFrame, age: float, col: str) -> float:
+    """Nearest-grid-point value of ``col`` at ``age`` (for console summaries)."""
+    i = int((frame["age_months"] - age).abs().idxmin())
+    return float(frame.loc[i, col])
+
+
+# ----------------------------------------------------------------------------
+# Per-outcome analysis
+# ----------------------------------------------------------------------------
+def run_outcome(outcome: str) -> None:
+    td_key = TD_KEYS[outcome]
+    print(f"\n=== {outcome.upper()}: DS={C.model_label(DS_KEY)} vs "
+          f"TD={C.model_label(td_key)} ===", flush=True)
+
+    ages_ds, p_ds, k_ds, n_ds = C.load_outcome_trajectory(DS_KEY, outcome)
+    ages_td, p_td, k_td, n_td = C.load_outcome_trajectory(td_key, outcome)
+    if n_ds != n_td:
+        raise ValueError(f"n_trials mismatch: DS={n_ds}, TD={n_td}.")
+    n = n_ds
+    w_ds, w_td = p_ds * n, p_td * n
+
+    # Empirical overlap window and shared grid.
+    lo = max(ages_ds.min(), ages_td.min())
+    hi = min(ages_ds.max(), ages_td.max())
+    grid = np.arange(np.ceil(lo / GRID_STEP) * GRID_STEP, hi + 1e-9, GRID_STEP)
+    print(f"  DS draws={w_ds.shape[0]} ages {ages_ds.min():.0f}-{ages_ds.max():.0f} | "
+          f"TD draws={w_td.shape[0]} ages {ages_td.min():.0f}-{ages_td.max():.0f} | "
+          f"overlap {lo:.0f}-{hi:.0f} mo, n_trials={n}", flush=True)
+
+    # Pair the two independent posteriors (valid under disjointness).
+    ia, ib = C.align_draws(w_ds.shape[0], w_td.shape[0], seed=SEED)
+    w_ds, p_ds, k_ds = w_ds[ia], p_ds[ia], k_ds[ia]
+    w_td, p_td, k_td = w_td[ib], p_td[ib], k_td[ib]
+
+    # ---- 1. Expected words: levels + difference + ratio ----
+    W_ds = C.interp_draws(ages_ds, w_ds, grid)
+    W_td = C.interp_draws(ages_td, w_td, grid)
+    dW = W_td - W_ds
+    ratio = np.where(W_ds > 0, W_td / np.where(W_ds == 0, np.nan, W_ds), np.nan)
+    ew = _merge(
+        grid, "age_months",
+        TD=C.summarise_draws(W_td, grid), DS=C.summarise_draws(W_ds, grid),
+        delta=C.summarise_draws(dW, grid, with_p_gt0=True),
+    )
+    ew["ratio_median"] = np.nanmedian(ratio, axis=0)
+
+    # ---- 2. Learning rate (words/month): derivative on native grid ----
+    R_ds = C.interp_draws(ages_ds, C.learning_rate(ages_ds, w_ds), grid)
+    R_td = C.interp_draws(ages_td, C.learning_rate(ages_td, w_td), grid)
+    lr = _merge(
+        grid, "age_months",
+        TD=C.summarise_draws(R_td, grid), DS=C.summarise_draws(R_ds, grid),
+        delta=C.summarise_draws(R_td - R_ds, grid, with_p_gt0=True),
+    )
+
+    # ---- 3. Attainment delay D(v) = age_DS(v) - age_TD(v) (per native grid) ----
+    A_ds = np.column_stack([C.first_crossing_age(w_ds, ages_ds, v) for v in N_GRID])
+    A_td = np.column_stack([C.first_crossing_age(w_td, ages_td, v) for v in N_GRID])
+    ad = C.summarise_draws(A_ds - A_td, N_GRID, "words", with_p_gt0=True)
+
+    # ---- 4. Dispersion: kappa, implied SD, overdispersion factor ----
+    # DS side uses the study-RE-only model (VG07), not VG10, so kappa is the
+    # like-for-like between-child concentration (see DISP_DS_KEY note). Pair its
+    # draws with the same TD subset; independence makes any pairing valid.
+    a7, p7, k7, _ = C.load_outcome_trajectory(DISP_DS_KEY, outcome)
+    i7 = C.align_draws(p7.shape[0], p_td.shape[0], seed=SEED + 1)[0]
+    P_ds, K_ds = C.interp_draws(a7, p7[i7], grid), C.interp_draws(a7, k7[i7], grid)
+    P_td, K_td = C.interp_draws(ages_td, p_td, grid), C.interp_draws(ages_td, k_td, grid)
+    SD_ds, SD_td = C.implied_sd_y(P_ds, K_ds, n), C.implied_sd_y(P_td, K_td, n)
+    PHI_ds, PHI_td = C.overdispersion_factor(K_ds, n), C.overdispersion_factor(K_td, n)
+    disp = _merge(
+        grid, "age_months",
+        kappa_TD=C.summarise_draws(K_td, grid), kappa_DS=C.summarise_draws(K_ds, grid),
+        dkappa=C.summarise_draws(K_td - K_ds, grid, with_p_gt0=True),
+        sdY_TD=C.summarise_draws(SD_td, grid), sdY_DS=C.summarise_draws(SD_ds, grid),
+        dsdY=C.summarise_draws(SD_td - SD_ds, grid, with_p_gt0=True),
+        phi_TD=C.summarise_draws(PHI_td, grid), phi_DS=C.summarise_draws(PHI_ds, grid),
+        phi_ratio=C.summarise_draws(PHI_td / PHI_ds, grid),
+    )
+
+    # ---- Write CSVs ----
+    os.makedirs(OUT_DIR, exist_ok=True)
+    prefix = os.path.join(OUT_DIR, f"ds_td_{outcome}_re_")
+    ew.to_csv(prefix + "expected_words.csv", index=False)
+    lr.to_csv(prefix + "learning_rate.csv", index=False)
+    ad.to_csv(prefix + "attainment_delay.csv", index=False)
+    disp.to_csv(prefix + "dispersion.csv", index=False)
+
+    _plot_outcome(outcome, td_key, grid,
+                  C.summarise_draws(W_td, grid), C.summarise_draws(W_ds, grid),
+                  C.summarise_draws(R_td, grid), C.summarise_draws(R_ds, grid),
+                  ad,
+                  C.summarise_draws(SD_td, grid), C.summarise_draws(SD_ds, grid),
+                  C.summarise_draws(SD_td - SD_ds, grid),
+                  C.summarise_draws(PHI_td, grid), C.summarise_draws(PHI_ds, grid),
+                  C.model_label(DISP_DS_KEY))
+
+    _print_summary(outcome, ew, lr, ad, disp, C.model_label(DISP_DS_KEY))
+
+
+# ----------------------------------------------------------------------------
+# Plot + console summary
+# ----------------------------------------------------------------------------
+def _band(ax, frame, x, label, colour, *, cov=0.0):
+    C.plot_summary_band(ax, frame, x, label, colour, min_coverage=cov)
+
+
+def _plot_outcome(outcome, td_key, grid, W_td, W_ds, R_td, R_ds, ad,
+                  SD_td, SD_ds, dSD, PHI_td, PHI_ds, disp_ds_lab) -> None:
+    plot_styles.set_matplotlib_default_style()
+    fig, ax = plt.subplots(2, 3, figsize=(16, 9))
+    td_lab, ds_lab = C.model_label(td_key), C.model_label(DS_KEY)
+
+    _band(ax[0, 0], W_td, "age_months", td_lab, COL_TD)
+    _band(ax[0, 0], W_ds, "age_months", ds_lab, COL_DS)
+    ax[0, 0].set(xlabel="Age (months)", ylabel=f"Expected words {outcome}",
+                 title="Expected vocabulary")
+
+    _band(ax[0, 1], R_td, "age_months", td_lab, COL_TD)
+    _band(ax[0, 1], R_ds, "age_months", ds_lab, COL_DS)
+    ax[0, 1].set(xlabel="Age (months)", ylabel="Words / month",
+                 title="Learning rate")
+
+    _band(ax[0, 2], ad, "words", "DS - TD", COL_D, cov=MIN_COVERAGE)
+    ax[0, 2].axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
+    ax[0, 2].set(xlabel="Vocabulary level v (words)",
+                 ylabel="Months DS reaches v after TD",
+                 title="Attainment delay D(v)")
+    ax[0, 2].set_xscale("log")
+
+    _band(ax[1, 0], SD_td, "age_months", td_lab, COL_TD)
+    _band(ax[1, 0], SD_ds, "age_months", disp_ds_lab, COL_DS)
+    ax[1, 0].set(xlabel="Age (months)", ylabel=r"Implied $\sigma_Y$ (words)",
+                 title="Between-child spread")
+
+    _band(ax[1, 1], dSD, "age_months", f"{td_lab} - {disp_ds_lab}", COL_D)
+    ax[1, 1].axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
+    ax[1, 1].set(xlabel="Age (months)", ylabel=r"$\Delta\sigma_Y$ (words)",
+                 title="Spread contrast (TD - DS)")
+
+    _band(ax[1, 2], PHI_td, "age_months", td_lab, COL_TD)
+    _band(ax[1, 2], PHI_ds, "age_months", disp_ds_lab, COL_DS)
+    ax[1, 2].set(xlabel="Age (months)", ylabel=r"Overdispersion $\varphi$",
+                 title="Concentration (mean-independent, study-RE only)")
+
+    for a in ax.flat:
+        a.legend(loc="best", frameon=True, fontsize=8)
+        a.grid(True, alpha=0.3)
+    fig.suptitle(
+        f"DS vs TD — words {outcome} (RE models, population level, "
+        f"per-draw contrasts over the empirical overlap)", fontsize=13)
+    fig.tight_layout()
+    fig.savefig(os.path.join(OUT_DIR, f"ds_td_{outcome}_re.png"), dpi=200)
+    fig.savefig(os.path.join(OUT_DIR, f"ds_td_{outcome}_re.svg"))
+    plt.close(fig)
+
+
+def _print_summary(outcome, ew, lr, ad, disp, disp_ds_lab) -> None:
+    print(f"  Expected words & learning rate at key ages ({outcome}):")
+    for a in KEY_AGES:
+        print(f"    {a:>2} mo: TD={_at_age(ew,a,'TD_median'):6.1f}  "
+              f"DS={_at_age(ew,a,'DS_median'):6.1f}  "
+              f"ratio={_at_age(ew,a,'ratio_median'):4.1f}x  "
+              f"|  rate TD={_at_age(lr,a,'TD_median'):5.1f}  "
+              f"DS={_at_age(lr,a,'DS_median'):4.1f} w/mo  "
+              f"(P(TD>DS)={_at_age(lr,a,'delta_p_gt0'):.2f})")
+    print("  Attainment delay D(v) (months DS behind TD), coverage-filtered:")
+    for _, r in ad[ad["coverage"] >= MIN_COVERAGE].iterrows():
+        print(f"    {int(r['words']):>3} words: {r['median']:5.1f} "
+              f"[{r['hdi90_lo']:.1f}, {r['hdi90_hi']:.1f}]")
+    print(f"  Dispersion contrasts at key ages (DS={disp_ds_lab}, study-RE only):")
+    for a in KEY_AGES:
+        print(f"    {a:>2} mo: kappa TD={_at_age(disp,a,'kappa_TD_median'):4.1f} "
+              f"DS={_at_age(disp,a,'kappa_DS_median'):4.1f} "
+              f"(Δκ P>0={_at_age(disp,a,'dkappa_p_gt0'):.2f})  |  "
+              f"σ_Y TD={_at_age(disp,a,'sdY_TD_median'):4.1f} "
+              f"DS={_at_age(disp,a,'sdY_DS_median'):4.1f} "
+              f"(Δσ_Y P>0={_at_age(disp,a,'dsdY_p_gt0'):.2f})  |  "
+              f"φ_TD/φ_DS={_at_age(disp,a,'phi_ratio_median'):.2f}")
+
+
+# ----------------------------------------------------------------------------
+# Comprehension-matched analysis (joint models only)
+# ----------------------------------------------------------------------------
+def run_comprehension_matched(ds_key: str = JOINT_DS_KEY,
+                              td_key: str = JOINT_TD_KEY) -> None:
+    """Contrast the production ratio q = S/U *given words understood*.
+
+    Matching on comprehension N (rather than age) strips out the TD/DS timescale
+    difference: it asks "when a child understands N words, what fraction does
+    she speak, and how much sooner does TD say them?". Requires JOINT models so
+    U and S are coupled per draw (VG10 DS vs VG13 TD).
+    """
+    print(f"\n=== COMPREHENSION-MATCHED: DS={C.model_label(ds_key)} vs "
+          f"TD={C.model_label(td_key)} ===", flush=True)
+    ages_ds, U_ds, S_ds = C.load_population_trajectory(
+        C.trace_path(ds_key), C.n_trials(ds_key))
+    ages_td, U_td, S_td = C.load_population_trajectory(
+        C.trace_path(td_key), C.n_trials(td_key))
+    print(f"  DS draws={U_ds.shape[0]} ages {ages_ds.min():.0f}-{ages_ds.max():.0f} | "
+          f"TD draws={U_td.shape[0]} ages {ages_td.min():.0f}-{ages_td.max():.0f}",
+          flush=True)
+    ia, ib = C.align_draws(U_ds.shape[0], U_td.shape[0], seed=SEED)
+
+    # q at matched comprehension U = N (the headline: spoken fraction given U).
+    qU_ds = C.compute_q_at_U(ages_ds, U_ds, S_ds, N_GRID_Q)[ia]
+    qU_td = C.compute_q_at_U(ages_td, U_td, S_td, N_GRID_Q)[ib]
+    q_ds_s = C.summarise_draws(qU_ds, N_GRID_Q, "words")
+    q_td_s = C.summarise_draws(qU_td, N_GRID_Q, "words")
+    dq_s = C.summarise_draws(qU_td - qU_ds, N_GRID_Q, "words", with_p_gt0=True)
+
+    # Learn-to-say latency a_S(N) - a_U(N): months between understanding and
+    # saying N words, per population.
+    da_ds, _ = C.compute_latency(ages_ds, U_ds[ia], S_ds[ia], N_GRID_Q)
+    da_td, _ = C.compute_latency(ages_td, U_td[ib], S_td[ib], N_GRID_Q)
+
+    # q at matched age, over the chronological overlap, for reference.
+    lo = max(ages_ds.min(), ages_td.min())
+    hi = min(ages_ds.max(), ages_td.max())
+    age_grid = np.linspace(lo, hi, 41)
+    qa_ds = C.summarise_draws(C.compute_q_at_age(ages_ds, U_ds[ia], S_ds[ia], age_grid), age_grid)
+    qa_td = C.summarise_draws(C.compute_q_at_age(ages_td, U_td[ib], S_td[ib], age_grid), age_grid)
+
+    os.makedirs(OUT_DIR, exist_ok=True)
+    _merge(N_GRID_Q, "words", q_TD=q_td_s, q_DS=q_ds_s, dq=dq_s).to_csv(
+        os.path.join(OUT_DIR, "ds_td_comprehension_q_at_U.csv"), index=False)
+
+    plot_styles.set_matplotlib_default_style()
+    fig, ax = plt.subplots(2, 2, figsize=(13, 9))
+    td_lab, ds_lab = C.model_label(td_key), C.model_label(ds_key)
+
+    _band(ax[0, 0], q_td_s, "words", td_lab, COL_TD, cov=MIN_COVERAGE)
+    _band(ax[0, 0], q_ds_s, "words", ds_lab, COL_DS, cov=MIN_COVERAGE)
+    ax[0, 0].set(xscale="log", ylim=(0, 1.05), xlabel="Words understood N",
+                 ylabel="q(U=N) = spoken / understood",
+                 title="Proportion spoken given understood")
+
+    _band(ax[0, 1], dq_s, "words", "TD - DS", COL_D, cov=MIN_COVERAGE)
+    ax[0, 1].axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
+    ax[0, 1].set(xscale="log", xlabel="Words understood N",
+                 ylabel=r"$\Delta q$ (TD - DS)",
+                 title="Spoken-fraction gap at matched comprehension")
+
+    _band(ax[1, 0], da_td, "N", td_lab, COL_TD, cov=MIN_COVERAGE)
+    _band(ax[1, 0], da_ds, "N", ds_lab, COL_DS, cov=MIN_COVERAGE)
+    ax[1, 0].set(xscale="log", xlabel="Words understood / spoken N",
+                 ylabel=r"$a_S(N) - a_U(N)$ (months)",
+                 title="Learn-to-say latency")
+
+    _band(ax[1, 1], qa_td, "age_months", td_lab, COL_TD)
+    _band(ax[1, 1], qa_ds, "age_months", ds_lab, COL_DS)
+    ax[1, 1].set(ylim=(0, 1.05), xlabel="Age (months)",
+                 ylabel="q(a) = E[S(a)] / E[U(a)]",
+                 title="Production ratio at matched age")
+
+    for a in ax.flat:
+        a.legend(loc="best", frameon=True, fontsize=8)
+        a.grid(True, which="both", alpha=0.3)
+    fig.suptitle(
+        f"Comprehension-matched: words spoken given words understood — "
+        f"{ds_lab} vs {td_lab}", fontsize=13)
+    fig.tight_layout()
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_comprehension.png"), dpi=200)
+    fig.savefig(os.path.join(OUT_DIR, "ds_td_comprehension.svg"))
+    plt.close(fig)
+
+    print("  Spoken fraction given understood q(U=N) (coverage-filtered):")
+    qtab = _merge(N_GRID_Q, "words", q_TD=q_td_s, q_DS=q_ds_s, dq=dq_s)
+    for _, r in qtab[qtab["dq_coverage"] >= MIN_COVERAGE].iterrows():
+        print(f"    U={int(r['words']):>3}: TD q={r['q_TD_median']:.2f}  "
+              f"DS q={r['q_DS_median']:.2f}  "
+              f"Δq(TD-DS)={r['dq_median']:+.2f} "
+              f"[{r['dq_hdi90_lo']:+.2f}, {r['dq_hdi90_hi']:+.2f}]  "
+              f"P(TD>DS)={r['dq_p_gt0']:.2f}")
+
+
+# ----------------------------------------------------------------------------
+# Self-checks
+# ----------------------------------------------------------------------------
+def _verify() -> None:
+    from scipy.stats import betabinom
+    n = 800
+    for p, kap in [(0.05, 5.0), (0.30, 20.0), (0.60, 3.0)]:
+        want = float(betabinom(n, p * kap, (1 - p) * kap).std())
+        got = float(C.implied_sd_y(np.array(p), np.array(kap), n))
+        assert abs(want - got) < 1e-6 * max(1.0, want), (p, kap, want, got)
+    ages = np.linspace(8, 40, 321)
+    shift = 10.0
+    w_td = np.stack([20.0 * (ages - 8)] * 5)
+    w_ds = np.stack([np.clip(20.0 * (ages - 8 - shift), 0, None)] * 5)
+    for v in (50.0, 100.0, 200.0):
+        d = C.first_crossing_age(w_ds, ages, v) - C.first_crossing_age(w_td, ages, v)
+        assert np.allclose(d, shift, atol=0.2), (v, d)
+    print("self-check OK: implied_sd_y == scipy.betabinom.std; "
+          "D(v) recovers a constant age shift.\n")
+
+
+def main() -> None:
+    env.preflight_disk(2.0, OUT_DIR, label="DS/TD comparison outputs")
+    argv = sys.argv[1:]
+    if "--verify" in argv:
+        _verify()
+    td_joint = next(
+        (a.split("=", 1)[1] for a in argv if a.startswith("--td-joint=")),
+        JOINT_TD_KEY,
+    )
+    tokens = [a for a in argv if not a.startswith("-")] or ["spoken", "understood"]
+    for tok in tokens:
+        if tok == "comprehension":
+            run_comprehension_matched(JOINT_DS_KEY, td_joint)
+        elif tok in TD_KEYS:
+            run_outcome(tok)
+        else:
+            raise SystemExit(
+                f"unknown token {tok!r}; choose from "
+                f"{list(TD_KEYS) + ['comprehension']}"
+            )
+    print(f"\nWrote CSVs + figures to {OUT_DIR}/", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_ds_td_trajectories.py
+++ b/scripts/compare_ds_td_trajectories.py
@@ -27,6 +27,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 from vocab_growth import comparison
+from vocab_growth import environment as env
 
 DS_DIR = comparison.model_dir("vg10")
 TD_DIR = comparison.model_dir("vg06")
@@ -93,6 +94,7 @@ def plot_gap_panel(ax, df: pd.DataFrame, title: str, hdi_prob: int = 90) -> None
 
 
 def main() -> None:
+    env.preflight_disk(2.0, OUT_DIR, label="DS/TD trajectory outputs")
     plot_styles.set_matplotlib_default_style()
     os.makedirs(OUT_DIR, exist_ok=True)
 

--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -13,6 +13,7 @@ from multiprocessing import freeze_support
 
 import dse_research_utils.environment.setup as setup
 
+from vocab_growth import environment as env
 from vocab_growth.models import (
     model_vg01,
     model_vg02,
@@ -105,6 +106,15 @@ if __name__ == "__main__":
             ("Upload to blob storage", args.upload),
             ("Include traces in upload", args.include_traces),
         ],
+    )
+
+    # Disk preflight: reporting-config traces are >10 GB each, so fail fast
+    # before a multi-hour sample if the volume can't hold the output.
+    heavy = args.config in {"rep", "rep-lite"}
+    env.preflight_disk(
+        (20.0 if heavy else 2.0) * len(selected),
+        env.OUTPUT_DIR,
+        label=f"{len(selected)} fit(s) [{args.config}]",
     )
 
     run_started = time.perf_counter()

--- a/scripts/time_to_milestone.py
+++ b/scripts/time_to_milestone.py
@@ -33,6 +33,7 @@ import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
 import pandas as pd
 
+from vocab_growth import environment as env
 from vocab_growth.comparison import invert_curve
 
 MODELS_DIR = "output/models"
@@ -45,6 +46,8 @@ UNIVARIATE = {
     "VG02": ("VG02-age-understood-ds", "understood", "DS"),
     "VG03": ("VG03-age-spoken-td", "spoken", "TD"),
     "VG04": ("VG04-age-understood-td", "understood", "TD"),
+    "VG11": ("VG11-age-spoken-td-re", "spoken", "TD"),
+    "VG12": ("VG12-age-understood-td-re", "understood", "TD"),
 }
 
 BIVARIATE = {
@@ -54,6 +57,7 @@ BIVARIATE = {
     "VG08": ("VG08-age-understood-spoken-ds-re-subj", "DS"),
     "VG09": ("VG09-age-understood-spoken-ds-re-subj-uq", "DS"),
     "VG10": ("VG10-age-understood-spoken-ds-re-subj-uq-anchored", "DS"),
+    "VG13": ("VG13-age-understood-spoken-td-re-young", "TD"),
 }
 
 
@@ -92,7 +96,11 @@ def plot_milestone(df: pd.DataFrame, title: str, out_base: str) -> None:
 def process_univariate(short: str, label: str, outcome: str, pop: str,
                        merged_rows: list[dict]) -> None:
     model_dir = os.path.join(MODELS_DIR, label)
-    summary = pd.read_csv(os.path.join(model_dir, "posterior_summary.csv"))
+    summary_path = os.path.join(model_dir, "posterior_summary.csv")
+    if not os.path.exists(summary_path):
+        print(f"  skip {short}: not fitted yet ({summary_path} absent)")
+        return
+    summary = pd.read_csv(summary_path)
     inv = invert_curve(summary, TARGETS)
     inv.insert(0, "outcome", outcome)
     inv.insert(0, "population", pop)
@@ -110,7 +118,11 @@ def process_bivariate(short: str, label: str, pop: str,
                       merged_rows: list[dict]) -> None:
     model_dir = os.path.join(MODELS_DIR, label)
     for outcome, suffix in (("understood", "u"), ("spoken", "s")):
-        summary = pd.read_csv(os.path.join(model_dir, f"posterior_summary_{suffix}.csv"))
+        summary_path = os.path.join(model_dir, f"posterior_summary_{suffix}.csv")
+        if not os.path.exists(summary_path):
+            print(f"  skip {short} ({outcome}): not fitted yet ({summary_path} absent)")
+            continue
+        summary = pd.read_csv(summary_path)
         inv = invert_curve(summary, TARGETS)
         inv.insert(0, "outcome", outcome)
         inv.insert(0, "population", pop)
@@ -128,6 +140,7 @@ def process_bivariate(short: str, label: str, pop: str,
 
 
 def main() -> None:
+    env.preflight_disk(2.0, env.OUTPUT_DIR, label="milestone outputs")
     plot_styles.set_matplotlib_default_style()
     os.makedirs(COMPARE_DIR, exist_ok=True)
 

--- a/src/vocab_growth/comparison.py
+++ b/src/vocab_growth/comparison.py
@@ -40,7 +40,7 @@ import numpy as np
 import pandas as pd
 
 from vocab_growth import environment as env
-from vocab_growth.models.definitions import MODEL_REGISTRY
+from vocab_growth.models.definitions import MODEL_REGISTRY, ModelType
 
 DEFAULT_MILESTONES = (25, 50, 100, 200, 400)
 DEFAULT_MIN_COVERAGE = 0.80
@@ -363,3 +363,154 @@ def plot_summary_band(
             color=colour, alpha=0.30, linewidth=0, label=f"{label} 50% HDI",
         )
     ax.plot(df_ok[x_col], df_ok["median"], color=colour, lw=2.5, label=f"{label} median")
+
+
+# ----------------------------------------------------------------------------
+# Cross-model population contrasts (separate-model, per-draw)
+# ----------------------------------------------------------------------------
+# These support contrasting a DS RE-model against a TD RE-model. Because the DS
+# and TD datasets are disjoint, the joint posterior factorises and any per-draw
+# pairing is valid, so a difference-of-draws gives an *exact* credible interval
+# for the contrast (no joint model required). All curves are read at the
+# population level (study/subject random effects excluded) so the estimand is
+# consistent on both sides. Contrasts are meaningful only over the age range
+# where both models have data; callers restrict to that overlap. A joint/stacked
+# model that makes the TD-DS gap a generative object is a separate exercise
+# (the reserved VG16), not provided here.
+
+
+def load_outcome_trajectory(
+    key: str, outcome: str = "spoken"
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+    """Return ``(ages, p, kappa, n_trials)`` for one outcome's population curve.
+
+    Dispatches on model type so the same call works for univariate RE models
+    (VG11/VG12: ``p_plot`` / ``kappa_plot``) and bivariate RE models
+    (VG07-VG10: ``p_{s,u}_plot`` / ``kappa_{s,u}_plot``). ``p`` and ``kappa``
+    are ``(n_draw, n_age)`` over the model's own plot grid with random effects
+    excluded; ``ages`` is sorted ascending (months). ``outcome`` is
+    ``"spoken"`` or ``"understood"``.
+    """
+    d = MODEL_REGISTRY[key]
+    mt = d.model_type
+    if mt is ModelType.UNIVARIATE:
+        if d.outcome.value != outcome:
+            raise ValueError(
+                f"{key} is a '{d.outcome.value}' model; cannot serve '{outcome}'."
+            )
+        p_name, k_name = "p_plot", "kappa_plot"
+    elif mt is ModelType.BIVARIATE:
+        if outcome == "spoken":
+            p_name, k_name = "p_s_plot", "kappa_s_plot"
+        elif outcome == "understood":
+            p_name, k_name = "p_u_plot", "kappa_u_plot"
+        else:
+            raise ValueError(
+                f"outcome must be 'spoken' or 'understood', got {outcome!r}."
+            )
+    else:
+        raise ValueError(
+            f"{key}: model_type {mt} is not supported by load_outcome_trajectory."
+        )
+
+    d_idata = az.from_netcdf(trace_path(key))
+    post = _dataset(d_idata, "posterior")
+    cdata = _dataset(d_idata, "constant_data")
+    p = post[p_name].values  # (chain, draw, n_age)
+    k = post[k_name].values
+    n_chain, n_draw, n_age = p.shape
+    p = p.reshape(n_chain * n_draw, n_age)
+    k = k.reshape(n_chain * n_draw, n_age)
+    ages = np.asarray(cdata["X_plot"].values, dtype=float)
+    order = np.argsort(ages)
+    return ages[order], p[:, order], k[:, order], n_trials(key)
+
+
+def implied_sd_y(p: np.ndarray, kappa: np.ndarray, n: int) -> np.ndarray:
+    """Beta-Binomial implied SD of the word count Y (words).
+
+    For ``BetaBinomial(n, alpha=p*kappa, beta=(1-p)*kappa)`` the variance is
+    ``n*p*(1-p)*(kappa+n)/(kappa+1)``; this returns its square root. This is the
+    observable between-child spread at age ``a`` — closer to what clinicians see
+    than ``kappa`` itself, but note it also moves with the mean level ``p``.
+    """
+    var = n * p * (1.0 - p) * (kappa + n) / (kappa + 1.0)
+    return np.sqrt(var)
+
+
+def overdispersion_factor(kappa: np.ndarray, n: int) -> np.ndarray:
+    """Variance inflation vs a Binomial at the same mean: ``(kappa+n)/(kappa+1)``.
+
+    Mean-independent (a function of ``kappa`` and ``n`` only), so contrasting it
+    across populations isolates the pure concentration difference, unlike
+    :func:`implied_sd_y` which is confounded by where each population sits on the
+    mean-variance curve.
+    """
+    return (kappa + n) / (kappa + 1.0)
+
+
+def align_draws(
+    n_a: int, n_b: int, *, seed: int = 0
+) -> tuple[np.ndarray, np.ndarray]:
+    """Index arrays pairing two *independent* posteriors to a common draw count.
+
+    DS and TD models are fit to disjoint data, so the joint posterior factorises
+    and any pairing is valid; permute each and truncate to ``min(n_a, n_b)`` to
+    get an unbiased paired sample for per-draw contrasts.
+    """
+    n = min(n_a, n_b)
+    rng = np.random.default_rng(seed)
+    return rng.permutation(n_a)[:n], rng.permutation(n_b)[:n]
+
+
+def interp_draws(ages: np.ndarray, Y: np.ndarray, grid: np.ndarray) -> np.ndarray:
+    """Linear-interpolate each row of ``Y`` (n_draw, n_age) onto a shared ``grid``."""
+    out = np.empty((Y.shape[0], grid.size), dtype=float)
+    for i in range(Y.shape[0]):
+        out[i] = np.interp(grid, ages, Y[i])
+    return out
+
+
+def learning_rate(ages: np.ndarray, Y: np.ndarray) -> np.ndarray:
+    """Per-draw derivative ``dY/d(age)`` via central differences (shape of ``Y``)."""
+    return np.gradient(Y, ages, axis=1)
+
+
+def summarise_draws(
+    samples: np.ndarray,
+    grid: np.ndarray,
+    grid_name: str = "age_months",
+    *,
+    with_p_gt0: bool = False,
+) -> pd.DataFrame:
+    """Median + 50%/90% HDI per grid column (over axis 0), NaN-aware.
+
+    Adds ``coverage`` (fraction of non-NaN draws) and, when ``with_p_gt0``,
+    the posterior probability ``P(contrast > 0)``.
+    """
+    rows = []
+    n_draw = samples.shape[0]
+    for i, g in enumerate(grid):
+        col = samples[:, i]
+        valid = ~np.isnan(col)
+        n_valid = int(valid.sum())
+        row: dict[str, float] = {grid_name: float(g), "coverage": n_valid / n_draw}
+        if n_valid == 0:
+            row.update(
+                median=np.nan, hdi50_lo=np.nan, hdi50_hi=np.nan,
+                hdi90_lo=np.nan, hdi90_hi=np.nan,
+            )
+            if with_p_gt0:
+                row["p_gt0"] = np.nan
+        else:
+            c = col[valid]
+            l50, u50 = hdi_from_samples(c, 0.50)
+            l90, u90 = hdi_from_samples(c, 0.90)
+            row.update(
+                median=float(np.median(c)), hdi50_lo=l50, hdi50_hi=u50,
+                hdi90_lo=l90, hdi90_hi=u90,
+            )
+            if with_p_gt0:
+                row["p_gt0"] = float(np.mean(c > 0.0))
+        rows.append(row)
+    return pd.DataFrame(rows)

--- a/src/vocab_growth/environment.py
+++ b/src/vocab_growth/environment.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import os
+import shutil
 
 _MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 _SRC_DIR = os.path.dirname(_MODULE_DIR)
@@ -18,3 +19,40 @@ DOCS_DIR = os.path.join(ROOT_DIR, "docs")
 
 REPORT_DIR = os.path.join(DOCS_DIR, "report")
 REPORT_FIGS_DIR = os.path.join(REPORT_DIR, "figures")
+
+
+def free_space_gb(path: str | None = None) -> float:
+    """Free space (GiB) on the volume backing ``path`` (default ``OUTPUT_DIR``).
+
+    Walks up to the nearest existing parent if ``path`` does not exist yet, so it
+    works for an output directory that is about to be created.
+    """
+    target = os.path.abspath(path or OUTPUT_DIR)
+    while not os.path.exists(target):
+        parent = os.path.dirname(target)
+        if parent == target:
+            break
+        target = parent
+    return shutil.disk_usage(target).free / (1024 ** 3)
+
+
+def preflight_disk(
+    min_gb: float, path: str | None = None, *, label: str = "operation"
+) -> float:
+    """Report free disk space and raise ``RuntimeError`` if below ``min_gb`` (GiB).
+
+    Call at the start of any script that writes large artefacts (model traces are
+    >10 GB at reporting configs) so a full volume fails fast rather than after a
+    multi-hour sample. Returns the free space in GiB when the check passes.
+    """
+    target = os.path.abspath(path or OUTPUT_DIR)
+    free = free_space_gb(target)
+    drive = os.path.splitdrive(target)[0] or target
+    print(f"[disk] {free:.1f} GiB free on {drive} "
+          f"(need >= {min_gb:.0f} GiB for {label})", flush=True)
+    if free < min_gb:
+        raise RuntimeError(
+            f"Insufficient disk space for {label}: {free:.1f} GiB free on {drive}, "
+            f"need >= {min_gb:.0f} GiB. Free space and retry."
+        )
+    return free


### PR DESCRIPTION
## Summary

Tooling and a report for comparing Down syndrome (DS) and typically developing (TD) vocabulary trajectories, plus a disk-space preflight for model fits.

### Comparison tooling
- `src/vocab_growth/comparison.py`: cross-model, per-draw DS↔TD contrast helpers (`load_outcome_trajectory`, `implied_sd_y`, `overdispersion_factor`, `align_draws`, `interp_draws`, `learning_rate`, `summarise_draws`).
- `scripts/compare_ds_td_re.py` (new): chronological (spoken/understood) and comprehension-matched (q given understood) lenses. DS=VG10 for mean/rate/delay; VG07 (study-RE only) for the dispersion contrast so κ is like-for-like; VG10 vs VG13 for q-given-U. Self-checks against `scipy.betabinom`.
- `scripts/time_to_milestone.py`: wire in VG11/VG12/VG13; skip not-yet-fitted models.
- Repoint legacy `compare_ds_td_latency.py` / `compare_ds_td_q_overlap.py` off the deleted non-RE VG06 trace to the RE TD joint VG13.

### Disk-space preflight
- `src/vocab_growth/environment.py`: `preflight_disk(min_gb, path, label)` prints free space and fails fast below a floor.
- Wired into `fit_model.py` (20 GiB/model for rep/rep-lite) and all `compare_ds_td_*` scripts (2 GiB). Reporting-config traces are >10 GB, and a full volume otherwise crashes a fit at the final save step.

### Report template fix
- `docs/models/vg13/index.qmd`: read the bivariate `posterior_summary_u.csv` (VG13 never produced the univariate `posterior_summary.csv`), so the report renders.

## Methodology
DS and TD models are fitted to disjoint data, so per-draw differences give exact credible intervals. Contrasts are computed draw-by-draw on the empirical age overlap, at the population level (random effects excluded), on the outcome scale. A joint/stacked gap model (VG16) is noted as future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
