### PR TITLE
Fix model-report figure rendering (VG #56)

### DIFF
--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -835,6 +835,7 @@ def diagnostics(context: ModelFitContext):
     az.plot_trace(
         context.trace,
         var_names=trace_var_names,
+        figure_kwargs={"figsize": plot_styles.FIGSIZE_XL},
     )
     plt.savefig(os.path.join(context.reporting.output_dir, "trace_plot.png"), dpi=300)
     context.plots["trace_plot"] = plt.gcf()
@@ -843,7 +844,7 @@ def diagnostics(context: ModelFitContext):
     # Energy transition distribution
     az.plot_energy(
         context.trace,
-        figure_kwargs={"figsize": plot_styles.FIGSIZE_SM},
+        figure_kwargs={"figsize": plot_styles.FIGSIZE_XL},
     )
     plt.savefig(os.path.join(context.reporting.output_dir, "energy_plot.png"), dpi=300)
     context.plots["energy_plot"] = plt.gcf()

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -886,20 +886,15 @@ def prior_predictive_checks(context: BivariateContext):
         .transpose("plot_id", "sample")
     )
 
-    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-    X_plot_vals = prior_samples.constant_data["X_plot"].values
-    n_curves = min(500, q_plot_samples.shape[1])
-    for i in range(n_curves):
-        ax.plot(X_plot_vals, q_plot_samples.values[:, i], alpha=0.01)
-    ax.set_xlabel("Age (months)")
-    ax.set_ylabel("q(a) = p_S(a) / p_U(a)")
-    ax.set_ylim(0, 1)
-    fig.savefig(
-        os.path.join(context.reporting.output_dir, "prior_samples_q.png"), dpi=300
+    fig = plotting.plot_prior_samples_ratio(
+        prior_samples.constant_data["X_plot"].values,
+        q_plot_samples.values,
+        y_label="q(a) = p_S(a) / p_U(a)",
+        filename="prior_samples_q",
+        output_dir=context.reporting.output_dir,
     )
-    fig.savefig(os.path.join(context.reporting.output_dir, "prior_samples_q.svg"))
     context.plots["prior_samples_q"] = fig
-    plt.close()
+    plt.close(fig)
 
 
 def sample(context: BivariateContext):
@@ -964,6 +959,7 @@ def diagnostics(context: BivariateContext):
     az.plot_trace(
         context.trace,
         var_names=trace_var_names,
+        figure_kwargs={"figsize": plot_styles.FIGSIZE_XL},
     )
     plt.savefig(os.path.join(context.reporting.output_dir, "trace_plot.png"), dpi=300)
     context.plots["trace_plot"] = plt.gcf()
@@ -972,7 +968,7 @@ def diagnostics(context: BivariateContext):
     # Energy plot
     az.plot_energy(
         context.trace,
-        figure_kwargs={"figsize": plot_styles.FIGSIZE_SM},
+        figure_kwargs={"figsize": plot_styles.FIGSIZE_XL},
     )
     plt.savefig(os.path.join(context.reporting.output_dir, "energy_plot.png"), dpi=300)
     context.plots["energy_plot"] = plt.gcf()

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -76,7 +76,7 @@ from vocab_growth.models.common import (
 )
 from vocab_growth.models.definitions import JointModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
-from vocab_growth.plotting import _save_csv
+from vocab_growth.plotting import _save_csv, plot_prior_samples_ratio
 from vocab_growth.reporting import (
     config_table,
     console,
@@ -727,15 +727,13 @@ def prior_predictive_checks(context: JointContext):
     for var, ylab, fname in [("r_plot", "r(a) = P(sign | understood)", "prior_samples_r"),
                              ("q_plot", "q(a) = P(speak | understood)", "prior_samples_q")]:
         s = prior.prior[var].stack(sample=("chain", "draw")).transpose("plot_id", "sample")
-        fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-        Xp = prior.constant_data["X_plot"].values
-        for i in range(min(400, s.shape[1])):
-            ax.plot(Xp, s.values[:, i], alpha=0.02)
-        ax.set_xlabel("Age (months)")
-        ax.set_ylabel(ylab)
-        ax.set_ylim(0, 1)
-        fig.savefig(os.path.join(context.reporting.output_dir, f"{fname}.png"), dpi=300)
-        fig.savefig(os.path.join(context.reporting.output_dir, f"{fname}.svg"))
+        fig = plot_prior_samples_ratio(
+            prior.constant_data["X_plot"].values,
+            s.values,
+            y_label=ylab,
+            filename=fname,
+            output_dir=context.reporting.output_dir,
+        )
         plt.close(fig)
 
 
@@ -760,10 +758,10 @@ def diagnostics(context: JointContext):
     dataframe_table(diag, title="Posterior diagnostics")
     _report_diagnostic_warnings(diag)
     tv = capped_plot_var_names(context.trace, var_names + ["psi", "conc"])
-    az.plot_trace(context.trace, var_names=tv)
+    az.plot_trace(context.trace, var_names=tv, figure_kwargs={"figsize": plot_styles.FIGSIZE_XL})
     plt.savefig(os.path.join(context.reporting.output_dir, "trace_plot.png"), dpi=300)
     plt.close()
-    az.plot_energy(context.trace, figure_kwargs={"figsize": plot_styles.FIGSIZE_SM})
+    az.plot_energy(context.trace, figure_kwargs={"figsize": plot_styles.FIGSIZE_XL})
     plt.savefig(os.path.join(context.reporting.output_dir, "energy_plot.png"), dpi=300)
     plt.close()
 

--- a/src/vocab_growth/models/common_trivariate.py
+++ b/src/vocab_growth/models/common_trivariate.py
@@ -1115,18 +1115,15 @@ def _plot_ratio_prior_samples(context, prior_samples, var_name, y_label, filenam
         .stack(sample=("chain", "draw"))
         .transpose("plot_id", "sample")
     )
-    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-    X_plot_vals = prior_samples.constant_data["X_plot"].values
-    n_curves = min(500, ratio_samples.shape[1])
-    for i in range(n_curves):
-        ax.plot(X_plot_vals, ratio_samples.values[:, i], alpha=0.01)
-    ax.set_xlabel("Age (months)")
-    ax.set_ylabel(y_label)
-    ax.set_ylim(0, 1)
-    fig.savefig(os.path.join(context.reporting.output_dir, f"{filename}.png"), dpi=300)
-    fig.savefig(os.path.join(context.reporting.output_dir, f"{filename}.svg"))
+    fig = plotting.plot_prior_samples_ratio(
+        prior_samples.constant_data["X_plot"].values,
+        ratio_samples.values,
+        y_label=y_label,
+        filename=filename,
+        output_dir=context.reporting.output_dir,
+    )
     context.plots[filename] = fig
-    plt.close()
+    plt.close(fig)
 
 
 def prior_predictive_checks(context: TrivariateContext):
@@ -1273,6 +1270,7 @@ def diagnostics(context: TrivariateContext):
     az.plot_trace(
         context.trace,
         var_names=trace_var_names,
+        figure_kwargs={"figsize": plot_styles.FIGSIZE_XL},
     )
     plt.savefig(os.path.join(context.reporting.output_dir, "trace_plot.png"), dpi=300)
     context.plots["trace_plot"] = plt.gcf()
@@ -1281,7 +1279,7 @@ def diagnostics(context: TrivariateContext):
     # Energy plot
     az.plot_energy(
         context.trace,
-        figure_kwargs={"figsize": plot_styles.FIGSIZE_SM},
+        figure_kwargs={"figsize": plot_styles.FIGSIZE_XL},
     )
     plt.savefig(os.path.join(context.reporting.output_dir, "energy_plot.png"), dpi=300)
     context.plots["energy_plot"] = plt.gcf()

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -95,6 +95,57 @@ def plot_prior_samples(
     return fig
 
 
+def plot_prior_samples_ratio(
+    x: np.ndarray,
+    ratio_samples: np.ndarray,
+    *,
+    y_label: str,
+    filename: str | None = None,
+    output_dir: str | None = None,
+    colour: str = plot_styles.COLOUR_ORANGE,
+    alpha: float = 0.1,
+    lw: float = 1.0,
+    n_curves: int = 500,
+    ylim: tuple[float, float] | None = (0.0, 1.0),
+    x_label: str = "Age (months)",
+) -> Figure:
+    """
+    Plot prior-sample curves for a production/signed ratio (q or r) in [0, 1].
+
+    All curves share a single colour at a legible alpha — unlike matplotlib's
+    default colour cycle at near-zero alpha, which renders the curves a faint,
+    multi-coloured wash. Matches the single-colour convention of
+    ``plot_prior_samples`` (the observed-data scatter elsewhere is blue, so the
+    curves default to orange to contrast).
+
+    Parameters
+    ----------
+    x
+        Plotting grid (e.g. age in months), shape ``(n_plot,)``.
+    ratio_samples
+        Prior-sample ratio curves, shape ``(n_plot, n_samples)``.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+    n = min(n_curves, ratio_samples.shape[1])
+    for i in range(n):
+        ax.plot(x, ratio_samples[:, i], c=colour, alpha=alpha, lw=lw)
+    ax.set_xlabel(x_label)
+    ax.set_ylabel(y_label)
+    if ylim is not None:
+        ax.set_ylim(*ylim)
+
+    if filename is not None and output_dir is not None:
+        os.makedirs(output_dir, exist_ok=True)
+        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
+        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
+
+    return fig
+
+
 def plot_prior_predictions(
     x: np.ndarray,
     y_pred: np.ndarray,


### PR DESCRIPTION
Closes #56.

Polish-only pass over the model-report figures (prior-sample, energy, trace). **No modelling changes.**

## What was actually wrong (corrected diagnosis)

The issue assumed the fix lived in the shared `dse_research_utils` plotting library. Checking the code + rendered figures showed otherwise — the real problems were **vocab-growth-local**:

- The shared `plot_prior_samples_binomial` was *already* single-colour at a sensible alpha; the count plots render fine.
- The "nearly invisible, multi-colour" plots are the **ratio** prior-sample plots (`q(a)`, `r(a)`), drawn by **three duplicated local blocks** that called `ax.plot(...)` with **no colour** (matplotlib's default cycle → a different colour per curve) at `alpha=0.01–0.02`.
- The energy plot is **not** wrapped in `diagnostics_mcmc`; it's four direct call sites passing `figure_kwargs={"figsize": FIGSIZE_SM}` — too small for ArviZ 1.x's two-panel BFMI+KDE layout.

## The three fixes

1. **Prior-sample legibility.** New shared helper `plot_prior_samples_ratio` in `plotting.py` (single `COLOUR_ORANGE`, legible `alpha=0.1`, parameterised colour/alpha/lw). The three duplicated ratio blocks (`common_bivariate`, `common_trivariate`, `common_joint_modality`) now route through it. Kept orange (not the issue's suggested blue — observed-data scatter is already blue).
2. **Energy figsize.** `FIGSIZE_SM → FIGSIZE_XL` at all four call sites, so the BFMI panel and its tick labels are no longer crushed.
3. **ArviZ 1.x options.** Added `figure_kwargs={"figsize": FIGSIZE_XL}` to the four `az.plot_trace` calls for legible panels. In ArviZ 1.x, `plot_trace`/`plot_energy` take figure size via `figure_kwargs` (no top-level `figsize`); the old `combined=` arg no longer exists, so it was **not** added. The pair plot (`plot_kde_pair`) already uses current arviz_plots kwargs and renders well — left untouched.

## Scope & LRP #62

Per discussion, this is **vocabulary-growth only** — the shared `research` plotting library is deliberately left untouched, so it folds cleanly ahead of dseinternational/language-reading-predictors#62 (PyMC 6.0 / ArviZ 1.0 migration), which can own any shared-library changes. Trade-off: LRP's reports aren't improved by this PR, and the ratio-plot logic stays duplicated across the three engines (now consistent, at least).

## Verification

- `ruff check src/ scripts/` — clean. `pytest` — 20 passed.
- Re-ran the **real** `fit()` pipeline for VG14 (`dev` config) end-to-end through the edited `prior_predictive_checks()` + `diagnostics()`, then `quarto render` of `docs/models/vg14/index.qmd` → `index.html` built cleanly with the new figures embedded.

### Before / After

> **Note:** ratio plots are from the real `dev` prior-predictive run. The **energy** after-image is re-rendered from the *same committed 6-chain `rep` trace* (true apples-to-apples — only `figsize` changed). The **trace** after-image is the real `dev` run (2 chains vs the committed 6), so chain count differs — but this PR is about *rendering* (legibility / figsize / colour), not statistical content.

**Ratio prior samples — `q(a)`** (multi-colour wash at α=0.01 → legible single orange)
| Before | After |
|---|---|
| ![q before](https://raw.githubusercontent.com/dseinternational/vocabulary-growth/vg56-evidence/vg56-evidence/ratio_q_before.png) | ![q after](https://raw.githubusercontent.com/dseinternational/vocabulary-growth/vg56-evidence/vg56-evidence/ratio_q_after.png) |

**Ratio prior samples — `r(a)`**
| Before | After |
|---|---|
| ![r before](https://raw.githubusercontent.com/dseinternational/vocabulary-growth/vg56-evidence/vg56-evidence/ratio_r_before.png) | ![r after](https://raw.githubusercontent.com/dseinternational/vocabulary-growth/vg56-evidence/vg56-evidence/ratio_r_after.png) |

**Energy plot** (BFMI panel crushed, `0.500.75` ticks collide → roomy, labels clear)
| Before | After |
|---|---|
| ![energy before](https://raw.githubusercontent.com/dseinternational/vocabulary-growth/vg56-evidence/vg56-evidence/energy_before.png) | ![energy after](https://raw.githubusercontent.com/dseinternational/vocabulary-growth/vg56-evidence/vg56-evidence/energy_after.png) |

**Trace plot** (cramped, overlapping titles → legible panels)
| Before | After |
|---|---|
| ![trace before](https://raw.githubusercontent.com/dseinternational/vocabulary-growth/vg56-evidence/vg56-evidence/trace_before.png) | ![trace after](https://raw.githubusercontent.com/dseinternational/vocabulary-growth/vg56-evidence/vg56-evidence/trace_after.png) |

<sub>Evidence images live on the temporary `vg56-evidence` branch (not for merge) so this PR's diff stays code-only.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
