### PR TITLE
Filter TD study-intercept models to studies with ≥200 observations (#55)

### DIFF
--- a/src/vocab_growth/data_utils.py
+++ b/src/vocab_growth/data_utils.py
@@ -33,6 +33,43 @@ set (or ``None`` for all languages) to the loaders to widen the scope later.
 """
 
 
+def filter_studies_by_min_obs(
+    df: pd.DataFrame,
+    min_obs: int | None,
+    study_col: str = "study",
+) -> tuple[pd.DataFrame, list[str]]:
+    """Drop studies (datasets) with fewer than ``min_obs`` observations.
+
+    Used by the study-random-intercept models (e.g. VG11/VG12/VG13) to trim
+    tiny studies that would otherwise each add a near-unidentified intercept
+    without materially informing the estimates.
+
+    Parameters
+    ----------
+    df
+        Analysis frame (one row per observation), already filtered to the rows
+        that inform the model.
+    min_obs
+        Minimum observations a study must have to be kept. ``None`` or ``0``
+        keeps every study.
+    study_col
+        Column identifying the study/dataset grouping.
+
+    Returns
+    -------
+    tuple[pandas.DataFrame, list[str]]
+        The filtered frame (index reset) and the sorted list of dropped study
+        labels.
+    """
+    if not min_obs:
+        return df.reset_index(drop=True), []
+    sizes = df.groupby(study_col).size()
+    keep = sizes[sizes >= min_obs].index
+    dropped = sorted(set(sizes.index) - set(keep))
+    filtered = df[df[study_col].isin(keep)].reset_index(drop=True)
+    return filtered, dropped
+
+
 def load_combined_data(max_age_months=None):
     """
     Load the combined data from the DuckDB database.

--- a/src/vocab_growth/models/common_bivariate_re.py
+++ b/src/vocab_growth/models/common_bivariate_re.py
@@ -95,6 +95,9 @@ def prepare_bivariate_re_data(
     has_u = analysis_df["understood"].notna()
     has_s = analysis_df["spoken"].notna()
     analysis_df = analysis_df[has_u | has_s].reset_index(drop=True)
+    analysis_df, dropped_studies = vocab_data_utils.filter_studies_by_min_obs(
+        analysis_df, definition.min_study_observations
+    )
 
     # Create integer study codes
     unique_studies = sorted(analysis_df["study"].unique())
@@ -136,6 +139,13 @@ def prepare_bivariate_re_data(
         ("Spoken only", n_s - n_both),
         ("Studies", f"{n_studies} ({', '.join(map(str, unique_studies))})"),
     ]
+    if definition.min_study_observations:
+        counts.append(
+            (
+                f"Studies dropped (<{definition.min_study_observations} obs)",
+                ", ".join(dropped_studies) if dropped_studies else "none",
+            )
+        )
     if n_subjects is not None:
         n_singletons = int(
             (analysis_df.groupby("subject_code").size() == 1).sum()

--- a/src/vocab_growth/models/common_univariate_re.py
+++ b/src/vocab_growth/models/common_univariate_re.py
@@ -90,6 +90,9 @@ def prepare_univariate_re_data(
         random_seed=definition.random_seed,
     )
     analysis_df = df[columns].dropna(subset=["age", y_col]).reset_index(drop=True)
+    analysis_df, dropped_studies = vocab_data_utils.filter_studies_by_min_obs(
+        analysis_df, definition.min_study_observations
+    )
 
     # Integer study codes (sorted for reproducibility)
     unique_studies = sorted(analysis_df["study"].unique())
@@ -107,16 +110,21 @@ def prepare_univariate_re_data(
         .sort_values("study")
     )
 
-    key_value_table(
-        "Data",
-        [
-            ("Population", definition.population.name),
-            ("Outcome column", y_col),
-            ("Total observations", len(analysis_df)),
-            ("Sample fraction", definition.sample_fraction),
-            ("Studies", f"{n_studies} ({', '.join(map(str, unique_studies))})"),
-        ],
-    )
+    data_rows = [
+        ("Population", definition.population.name),
+        ("Outcome column", y_col),
+        ("Total observations", len(analysis_df)),
+        ("Sample fraction", definition.sample_fraction),
+        ("Studies", f"{n_studies} ({', '.join(map(str, unique_studies))})"),
+    ]
+    if definition.min_study_observations:
+        data_rows.append(
+            (
+                f"Studies dropped (<{definition.min_study_observations} obs)",
+                ", ".join(dropped_studies) if dropped_studies else "none",
+            )
+        )
+    key_value_table("Data", data_rows)
     dataframe_table(study_counts, title="Observations per study")
     dataframe_table(desc, title="Descriptive statistics")
 

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -107,6 +107,10 @@ class UnivariateModelDefinition:
     # -- Study-level random intercepts --
     tau_study_sigma: float = 0.5
     """HalfNormal scale for study intercept SD (logit scale)."""
+    min_study_observations: int | None = None
+    """Drop studies with fewer than this many observations before fitting study
+    intercepts (None = keep all). Trims tiny, near-unidentified study intercepts
+    that add parameters without informing the estimates."""
 
     # -- GP anchor constraint (per-draw zero at reference age) --
     anchor_g_at_ref: bool = False
@@ -182,6 +186,10 @@ class BivariateModelDefinition:
     """HalfNormal scale for study intercept SD on understood (logit scale)."""
     tau_q_sigma: float = 0.5
     """HalfNormal scale for study intercept SD on production ratio (logit scale)."""
+    min_study_observations: int | None = None
+    """Drop studies with fewer than this many observations before fitting study
+    intercepts (None = keep all). Trims tiny, near-unidentified study intercepts
+    that add parameters without informing the estimates."""
 
     # -- Subject-level random intercepts --
     use_subject_re_u: bool = False
@@ -641,6 +649,9 @@ VG11 = UnivariateModelDefinition(
     sample_fraction=1.0,
     # Study-level random intercepts on the spoken trajectory
     tau_study_sigma=0.5,
+    # Drop datasets with <200 observations (issue #55): roughly halves the study
+    # count while retaining >97% of observations.
+    min_study_observations=200,
     # Anchor the GP at the midpoint of slope_anchors (19 months) to remove the
     # GP–intercept ridge that arises when study REs are present.
     anchor_g_at_ref=True,
@@ -668,6 +679,9 @@ VG12 = UnivariateModelDefinition(
     sample_fraction=1.0,
     # Study-level random intercepts on the understood trajectory
     tau_study_sigma=0.5,
+    # Drop datasets with <200 observations (issue #55): roughly halves the study
+    # count while retaining >97% of observations.
+    min_study_observations=200,
     # Anchor the GP at the midpoint of slope_anchors (19 months).
     anchor_g_at_ref=True,
     gp_anchor_age_months=19.0,
@@ -700,6 +714,9 @@ VG13 = BivariateModelDefinition(
     # Dataset-level study random intercepts on both trajectories
     tau_u_sigma=0.5,
     tau_q_sigma=0.5,
+    # Drop datasets with <200 observations (issue #55): roughly halves the study
+    # count while retaining >97% of observations.
+    min_study_observations=200,
     # Anchor GPs at the midpoint of slope_anchors (13 months)
     anchor_g_u_at_ref=True,
     anchor_g_q_at_ref=True,


### PR DESCRIPTION
Closes #55.

The TD models with dataset-level study random intercepts (VG11/VG12/VG13) include some Wordbank datasets with very few observations — each adds a near-unidentified study intercept (some studies have only 1–2 rows) without materially informing the estimates. This drops studies below a configurable minimum before fitting.

## Change (vocabulary-growth only, 4 files, +82/−10)

- **`definitions.py`** — new `min_study_observations: int | None = None` field on `UnivariateModelDefinition` and `BivariateModelDefinition` (default `None` = keep all studies, so VG05–VG10 are unaffected). Set to **200** on VG11, VG12, VG13.
- **`data_utils.py`** — new `filter_studies_by_min_obs()` helper (drops studies below the threshold, returns the dropped list).
- **`common_univariate_re.py` / `common_bivariate_re.py`** — apply the filter right after row selection and report the dropped studies in the data table.

## Effect (English TD, threshold 200)

| Model | Studies | Observations retained | Dropped (each 1–140 obs) |
|---|---|---|---|
| VG11 (spoken) | 13 → **7** | 16,552 → **16,235** (98.1%) | 6 studies / 317 obs |
| VG12 (understood) | 8 → **4** | 6,134 → **5,997** (97.8%) | 4 studies / 137 obs |
| VG13 (U+S, ≤18mo) | 11 → **6** | 8,060 → **7,920** (98.3%) | 5 studies / 140 obs |

Matches the issue's expectation: roughly half the studies drop, >97% of observations stay. The dropped datasets include several with only 1–2 rows (e.g. Edgin). The report data table now shows the retained studies and a "Studies dropped (<200 obs)" line; `study_counts.csv` (read dynamically by the reports) reflects the filtered set, so no hardcoded counts go stale.

## Verification

- `ruff check src/ scripts/` — clean. `pytest` — 20 passed.
- VG12 `dev` fit runs end-to-end with the filter applied (study REs over the 4 retained studies); the data table reports `Studies: 4 (ByersHeinlein, Floccia, Marchman, Thal)` and `Studies dropped (<200 obs): Byers, Edgin, Frank, Poulin-Dubois`.

## Not done (follow-up)

This implements the proposed filter; it does **not** yet prove estimates are materially unchanged. Confirming that hypothesis needs a `rep`-quality before/after comparison (multi-hour fits, >10 GB traces), which I've left as a separate step — happy to run it if wanted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
