### PR TITLE
Fix model-fit robustness bugs, trim trace memory, and add tests

### DIFF
--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -302,6 +302,26 @@ def get_hsgp_hyperparams(
     return L, M
 
 
+def render_model_graph(model: pm.Model, output_dir: str) -> None:
+    """Render the model DAG to ``gp_model_graph.svg`` in ``output_dir``.
+
+    Best-effort: if the graphviz ``dot`` executable is not installed the render
+    is skipped with a warning rather than aborting the fit, so the pipeline runs
+    on machines without graphviz. The model-diagram figure is a non-essential
+    reporting artefact (a missing SVG only shows as a broken figure in the
+    optional Quarto report).
+    """
+    try:
+        digraph = pymc_utils.model_to_graphviz(model)
+        digraph.render(
+            filename=os.path.join(output_dir, "gp_model_graph"),
+            format="svg",
+            cleanup=True,
+        )
+    except Exception as exc:  # e.g. graphviz 'dot' not on PATH — non-fatal
+        console.print(f"[yellow]Skipped model graph: {exc}[/yellow]")
+
+
 def extract_model_samples(trace: xr.DataTree) -> ModelSamples:
     """
     Extract model samples into a structured format for plotting and reporting.
@@ -688,13 +708,7 @@ def build_model(context: ModelFitContext):
 
     pymc_utils.report_model_summary(model)
 
-    digraph = pymc_utils.model_to_graphviz(model)
-
-    digraph.render(
-        filename=os.path.join(context.reporting.output_dir, "gp_model_graph"),
-        format="svg",
-        cleanup=True,
-    )
+    render_model_graph(model, context.reporting.output_dir)
 
     context.set_model(model, variables)
 

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -13,6 +13,7 @@ Uses a production-ratio reparameterization:
 
 import os
 import shutil
+import sys
 import time
 from dataclasses import dataclass
 
@@ -47,6 +48,7 @@ from vocab_growth.models.common import (
     _plot_and_print_dist,
     _report_diagnostic_warnings,
     get_hsgp_hyperparams,
+    render_model_graph,
     report,
 )
 from vocab_growth.models.definitions import BivariateModelDefinition
@@ -540,20 +542,19 @@ def build_model(context: BivariateContext):
         # ============================================================
         # Derived quantities: p_U, q, p_S
         # ============================================================
+        # Full-grid (n_all,) quantities are kept as plain tensors rather than
+        # stored Deterministics: only their obs/plot/query slices below are
+        # extracted, so materialising the full grid for every posterior draw
+        # would waste a large amount of trace memory. (Matches the memory
+        # discipline in common_bivariate_re.py and common_trivariate.py.)
 
-        p_u_all = pm.Deterministic(
-            "p_u_all", pm.math.sigmoid(f_u_all), dims=("all_id",)
-        )
-        q_all = pm.Deterministic("q_all", pm.math.sigmoid(h_all), dims=("all_id",))
-        p_s_all = pm.Deterministic("p_s_all", p_u_all * q_all, dims=("all_id",))
+        p_u_all = pm.math.sigmoid(f_u_all)
+        q_all = pm.math.sigmoid(h_all)
+        p_s_all = p_u_all * q_all
 
         # f_S derived for diagnostics/plotting
         p_s_all_clip = pm.math.clip(p_s_all, EPSILON, 1 - EPSILON)
-        f_s_all = pm.Deterministic(
-            "f_s_all",
-            pm.math.log(p_s_all_clip) - pm.math.log(1 - p_s_all_clip),
-            dims=("all_id",),
-        )
+        f_s_all = pm.math.log(p_s_all_clip) - pm.math.log(1 - p_s_all_clip)
 
         # ---- Slice into obs/plot/query ----
 
@@ -678,12 +679,7 @@ def build_model(context: BivariateContext):
 
     pymc_utils.report_model_summary(model_pm)
 
-    digraph = pymc_utils.model_to_graphviz(model_pm)
-    digraph.render(
-        filename=os.path.join(context.reporting.output_dir, "gp_model_graph"),
-        format="svg",
-        cleanup=True,
-    )
+    render_model_graph(model_pm, context.reporting.output_dir)
 
     context.set_model(model_pm, variables)
 
@@ -909,6 +905,10 @@ def sample(context: BivariateContext):
             cores=context.sampling.cores,
             target_accept=context.sampling.target_accept,
             nuts_sampler="nutpie",
+            # The rich progress bar segfaults under nutpie's worker threads when
+            # stdout is not a TTY (redirected/backgrounded); keep it for
+            # interactive terminals only. (Matches common.py.)
+            progressbar=sys.stdout.isatty(),
             return_inferencedata=True,
             random_seed=context.sampling.random_seed,
         )
@@ -1116,6 +1116,7 @@ def sample_posterior_predictive(context: BivariateContext, definition=None):
                 "y_s_obs",
             ],
             extend_inferencedata=True,
+            progressbar=sys.stdout.isatty(),
             random_seed=context.sampling.random_seed,
         )
 
@@ -1685,6 +1686,7 @@ def _run_bivariate_outcome_plots(
         X_query=samples.X_query,
         y_query=y_query,
         n_trials=n_trials,
+        hdi_prob=hdi_prob,
         output_dir=output_dir,
         filename=f"posterior_predictive_count_distributions_{suffix}",
         x_label=f"{outcome_label} (count)",

--- a/src/vocab_growth/models/common_bivariate_re.py
+++ b/src/vocab_growth/models/common_bivariate_re.py
@@ -39,6 +39,7 @@ from vocab_growth.models.common import (
     PACKAGE_LIST,
     ModelFitContext,
     get_hsgp_hyperparams,
+    render_model_graph,
     report,
 )
 from vocab_growth.models.common_bivariate import (
@@ -655,12 +656,7 @@ def build_model_re(
 
     pymc_utils.report_model_summary(model_pm)
 
-    digraph = pymc_utils.model_to_graphviz(model_pm)
-    digraph.render(
-        filename=os.path.join(context.reporting.output_dir, "gp_model_graph"),
-        format="svg",
-        cleanup=True,
-    )
+    render_model_graph(model_pm, context.reporting.output_dir)
 
     context.set_model(model_pm, variables)
 

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -42,6 +42,7 @@ VG14 memory discipline.
 
 import os
 import shutil
+import sys
 import time
 from dataclasses import dataclass
 
@@ -72,6 +73,7 @@ from vocab_growth.models.common import (
     _plot_and_print_dist,
     _report_diagnostic_warnings,
     get_hsgp_hyperparams,
+    render_model_graph,
     report,
 )
 from vocab_growth.models.definitions import JointModelDefinition
@@ -190,18 +192,27 @@ JointContext = ModelFitContext[JointModelConfiguration, JointModelSamples]
 def _load_uk02_four_cell():
     """Load uk_02 rows, split into four-cell (cross-tab) and marginal-only rows.
 
-    Returns (four_cell_df, marginal_df). The four-cell rows are those whose
-    signed and spoken margins reconcile with the cross-tab cells
-    (signed == signed_only + signed_spoken, spoken == spoken_only + signed_spoken)
-    and whose four cells sum to a positive total; they identify psi. The rest
-    are marginal-only uk_02 rows (no usable cross-tab).
+    Returns (four_cell_df, marginal_df). The four-cell rows are those that have
+    all four cell counts recorded, whose signed and spoken margins reconcile
+    with the cross-tab cells (signed == signed_only + signed_spoken,
+    spoken == spoken_only + signed_spoken) and whose four cells sum to a
+    positive total; they identify psi. The rest are marginal-only uk_02 rows
+    (no usable cross-tab).
+
+    A row missing any cell — in particular ``understood_only`` (some uk_02 rows
+    record a produced sign/speech cross-tab but no comprehension total) — cannot
+    form the within-understood four-way composition, so it is routed to the
+    marginal-only set, where its recorded spoken/signed margins still inform the
+    model. (Without this guard a NaN cell casts to a negative integer and trips
+    the four-cell count validation in ``build_model``.)
     """
     path = os.path.join(local_env.DATA_DIR, "vocab_data_uk_02.csv")
     raw = pd.read_csv(path)
     cells = ["understood_only", "signed_only", "spoken_only", "signed_spoken"]
     raw["cell_total"] = raw[cells].sum(axis=1)
     reconciles = (
-        (raw["signed"] == raw["signed_only"] + raw["signed_spoken"])
+        raw[cells].notna().all(axis=1)
+        & (raw["signed"] == raw["signed_only"] + raw["signed_spoken"])
         & (raw["spoken"] == raw["spoken_only"] + raw["signed_spoken"])
         & (raw["cell_total"] > 0)
     )
@@ -831,14 +842,7 @@ def build_model(context: JointContext, definition: JointModelDefinition):
 
     pymc_utils.report_model_summary(model_pm)
     variables = pymc_utils.get_variables_dict(model_pm)
-    try:
-        digraph = pymc_utils.model_to_graphviz(model_pm)
-        digraph.render(
-            filename=os.path.join(context.reporting.output_dir, "gp_model_graph"),
-            format="svg", cleanup=True,
-        )
-    except Exception as exc:  # graphviz 'dot' not on PATH — non-fatal
-        console.print(f"[yellow]Skipped model graph: {exc}[/yellow]")
+    render_model_graph(model_pm, context.reporting.output_dir)
 
     context.set_model(model_pm, variables)
 
@@ -877,6 +881,9 @@ def sample(context: JointContext):
             chains=context.sampling.chains, cores=context.sampling.cores,
             target_accept=context.sampling.target_accept,
             nuts_sampler="nutpie", return_inferencedata=True,
+            # The rich progress bar segfaults under nutpie's worker threads when
+            # stdout is not a TTY (redirected/backgrounded); interactive only.
+            progressbar=sys.stdout.isatty(),
             random_seed=context.sampling.random_seed,
         )
     context.set_trace(trace)
@@ -907,6 +914,7 @@ def sample_posterior_predictive(context: JointContext, definition=None):
     with context.model:
         trace = pm.sample_posterior_predictive(
             context.trace, var_names=["cells_obs"], extend_inferencedata=True,
+            progressbar=sys.stdout.isatty(),
             random_seed=context.sampling.random_seed,
         )
     context.set_trace(trace)

--- a/src/vocab_growth/models/common_trivariate.py
+++ b/src/vocab_growth/models/common_trivariate.py
@@ -26,6 +26,7 @@ some duplication is intentional, to keep the signed logic fully isolated.
 
 import os
 import shutil
+import sys
 import time
 from dataclasses import dataclass
 
@@ -60,6 +61,7 @@ from vocab_growth.models.common import (
     _plot_and_print_dist,
     _report_diagnostic_warnings,
     get_hsgp_hyperparams,
+    render_model_graph,
     report,
 )
 from vocab_growth.models.definitions import TrivariateModelDefinition
@@ -910,12 +912,7 @@ def build_model(context: TrivariateContext):
 
     pymc_utils.report_model_summary(model_pm)
 
-    digraph = pymc_utils.model_to_graphviz(model_pm)
-    digraph.render(
-        filename=os.path.join(context.reporting.output_dir, "gp_model_graph"),
-        format="svg",
-        cleanup=True,
-    )
+    render_model_graph(model_pm, context.reporting.output_dir)
 
     context.set_model(model_pm, variables)
 
@@ -1220,6 +1217,10 @@ def sample(context: TrivariateContext):
             cores=context.sampling.cores,
             target_accept=context.sampling.target_accept,
             nuts_sampler="nutpie",
+            # The rich progress bar segfaults under nutpie's worker threads when
+            # stdout is not a TTY (redirected/backgrounded); keep it for
+            # interactive terminals only. (Matches common.py.)
+            progressbar=sys.stdout.isatty(),
             return_inferencedata=True,
             random_seed=context.sampling.random_seed,
         )
@@ -1410,6 +1411,7 @@ def sample_posterior_predictive(context: TrivariateContext, definition=None):
                 "y_sign_obs",
             ],
             extend_inferencedata=True,
+            progressbar=sys.stdout.isatty(),
             random_seed=context.sampling.random_seed,
         )
 
@@ -1939,6 +1941,7 @@ def _run_trivariate_outcome_plots(
         X_query=samples.X_query,
         y_query=y_query,
         n_trials=n_trials,
+        hdi_prob=hdi_prob,
         output_dir=output_dir,
         filename=f"posterior_predictive_count_distributions_{suffix}",
         x_label=f"{outcome_label} (count)",

--- a/src/vocab_growth/models/common_univariate_re.py
+++ b/src/vocab_growth/models/common_univariate_re.py
@@ -43,6 +43,7 @@ from vocab_growth.models.common import (
     get_hsgp_hyperparams,
     posterior_summary,
     prior_predictive_checks,
+    render_model_graph,
     report,
     run_standard_plots,
     sample,
@@ -423,12 +424,7 @@ def build_univariate_re_model(
 
     pymc_utils.report_model_summary(model_pm)
 
-    digraph = pymc_utils.model_to_graphviz(model_pm)
-    digraph.render(
-        filename=os.path.join(context.reporting.output_dir, "gp_model_graph"),
-        format="svg",
-        cleanup=True,
-    )
+    render_model_graph(model_pm, context.reporting.output_dir)
 
     context.set_model(model_pm, variables)
 

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -160,7 +160,10 @@ def plot_prior_predictions(
 
     plt.figure(figsize=plot_styles.FIGSIZE_XL)
 
-    for i in np.random.randint(0, y_pred.shape[1], 500):
+    # Seeded so the scatter of sampled prior-predictive draws is reproducible
+    # (matches the seeded RNG used by the other spaghetti/scatter plots).
+    rng = np.random.default_rng(42)
+    for i in rng.integers(0, y_pred.shape[1], 500):
         plt.scatter(x, y_pred[:, i], color=plot_styles.COLOUR_ORANGE, alpha=0.01, s=12)
 
     plt.scatter(

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -74,6 +74,43 @@ def test_td_load_data_can_widen_languages(tmp_path, monkeypatch):
     assert "Norwegian" in df["language"].tolist()
 
 
+def _study_frame():
+    # Studies A (3 rows), B (1 row), C (5 rows); index intentionally non-trivial.
+    studies = ["A", "A", "A", "B", "C", "C", "C", "C", "C"]
+    return pd.DataFrame({"study": studies, "age": range(len(studies))})
+
+
+def test_filter_studies_none_keeps_all_and_resets_index():
+    df = _study_frame().iloc[::-1]  # shuffle the index
+    out, dropped = data_utils.filter_studies_by_min_obs(df, None)
+    assert dropped == []
+    assert len(out) == len(df)
+    assert list(out.index) == list(range(len(df)))  # index reset
+
+
+def test_filter_studies_zero_is_noop():
+    df = _study_frame()
+    out, dropped = data_utils.filter_studies_by_min_obs(df, 0)
+    assert dropped == []
+    assert len(out) == len(df)
+
+
+def test_filter_studies_drops_small_studies():
+    df = _study_frame()
+    out, dropped = data_utils.filter_studies_by_min_obs(df, 3)
+    # B has a single observation -> dropped; A (3) and C (5) retained.
+    assert dropped == ["B"]
+    assert set(out["study"]) == {"A", "C"}
+    assert len(out) == 8
+    assert list(out.index) == list(range(8))  # index reset
+
+
+def test_filter_studies_dropped_list_is_sorted():
+    df = pd.DataFrame({"study": ["z", "a", "a", "m"], "age": [1, 2, 3, 4]})
+    _out, dropped = data_utils.filter_studies_by_min_obs(df, 2)
+    assert dropped == ["m", "z"]  # both singletons, sorted
+
+
 def _create_wordbank_db(tmp_path):
     db_path = tmp_path / "vocabulary.duckdb"
     with duckdb.connect(str(db_path)) as con:

--- a/tests/test_joint_four_cell.py
+++ b/tests/test_joint_four_cell.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Regression tests for the VG15 uk_02 four-cell loader.
+
+A row that records a produced sign/speech cross-tab but is missing a cell
+count — in practice ``understood_only`` (no comprehension total) — cannot form
+the within-understood four-way composition and must be routed to the
+marginal-only set. Otherwise the NaN cell casts to a negative integer and trips
+the four-cell count validation in ``build_model``.
+"""
+
+import numpy as np
+import pandas as pd
+
+import vocab_growth.environment as env
+from vocab_growth.models import common_joint_modality as cjm
+
+
+def _write_uk02_csv(path):
+    rows = [
+        # Complete, reconciling four-cell row -> belongs in `four`.
+        dict(
+            age=30.0, comprehension=19, signed=6, spoken=7,
+            understood_only=10, signed_only=2, spoken_only=3, signed_spoken=4,
+        ),
+        # Reconciles on the signed/spoken margins, but understood_only (and the
+        # comprehension total) is missing -> must be marginal-only.
+        dict(
+            age=32.0, comprehension=np.nan, signed=6, spoken=7,
+            understood_only=np.nan, signed_only=2, spoken_only=3, signed_spoken=4,
+        ),
+        # No cross-tab at all -> marginal-only.
+        dict(
+            age=28.0, comprehension=40, signed=5, spoken=5,
+            understood_only=np.nan, signed_only=np.nan, spoken_only=np.nan,
+            signed_spoken=np.nan,
+        ),
+    ]
+    pd.DataFrame(rows).to_csv(path, index=False)
+
+
+def test_four_cell_loader_routes_incomplete_rows_to_marginal(tmp_path, monkeypatch):
+    monkeypatch.setattr(env, "DATA_DIR", str(tmp_path))
+    _write_uk02_csv(tmp_path / "vocab_data_uk_02.csv")
+
+    four, marg = cjm._load_uk02_four_cell()
+
+    # Only the complete, reconciling row is treated as a four-cell row.
+    assert len(four) == 1
+    assert len(marg) == 2
+
+    cells = ["understood_only", "signed_only", "spoken_only", "signed_spoken"]
+    # All four cells present in the four-cell set...
+    assert four[cells].notna().all(axis=None)
+    # ...so the counts cast cleanly to non-negative integers (the original bug
+    # cast a NaN cell to INT_MIN, tripping build_model's validation).
+    assert np.asarray(four[cells], dtype=int).min() >= 0

--- a/tests/test_plotting_helpers.py
+++ b/tests/test_plotting_helpers.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import numpy as np
+import pytest
+
+from vocab_growth.plotting import _maybe_savgol, _resolve_savgol_window_length
+
+
+@pytest.mark.parametrize("n", [5, 7, 15, 21, 100])
+def test_resolve_window_is_valid(n):
+    polyorder = 3
+    wl = _resolve_savgol_window_length(n, window_length=None, polyorder=polyorder)
+    assert wl % 2 == 1          # odd
+    assert wl <= n              # fits the data
+    assert wl > polyorder       # valid for savgol
+
+
+def test_resolve_window_raises_when_polyorder_too_high_for_n():
+    # n=4 cannot accommodate a cubic (needs an odd window > 3, i.e. >= 5 > n).
+    with pytest.raises(ValueError):
+        _resolve_savgol_window_length(4, window_length=None, polyorder=3)
+
+
+def test_resolve_window_even_is_made_odd():
+    wl = _resolve_savgol_window_length(50, window_length=20, polyorder=3)
+    assert wl % 2 == 1
+    assert wl <= 20
+
+
+def test_resolve_window_below_polyorder_is_bumped():
+    # Requesting a window <= polyorder must be raised to a valid odd value.
+    wl = _resolve_savgol_window_length(50, window_length=2, polyorder=3)
+    assert wl > 3
+    assert wl % 2 == 1
+
+
+def test_resolve_window_too_few_points_raises():
+    with pytest.raises(ValueError):
+        _resolve_savgol_window_length(2, window_length=None, polyorder=3)
+
+
+def test_maybe_savgol_passthrough_when_disabled():
+    y = np.array([1.0, 5.0, 2.0, 8.0, 3.0])
+    out = _maybe_savgol(y, smooth=False, window_length=None, polyorder=2)
+    np.testing.assert_array_equal(out, y)
+    # The returned array is always float (the smoothing path returns floats too).
+    assert out.dtype == float

--- a/tests/test_posterior_analysis.py
+++ b/tests/test_posterior_analysis.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import numpy as np
+
+from vocab_growth.posterior_analysis import posterior_summary_table
+
+N_SAMPLES = 2000
+EXPECTED_COLUMNS = {
+    "age_months", "p_median", "p_hdi_lo", "p_hdi_hi",
+    "Ey_median", "Ey_hdi_lo", "Ey_hdi_hi",
+    "Y_median", "Y_hdi_lo", "Y_hdi_hi",
+    "P(Y=0)", "P(Y<=5)", "P(Y<=400)", "P(Y>400)",
+}
+
+
+def _summary():
+    # Row order is (age 24, age 12); the table should come back age-sorted.
+    X_query = np.array([24, 12])
+    p_query = np.vstack([np.full(N_SAMPLES, 0.5), np.full(N_SAMPLES, 0.25)])
+    y_query = np.vstack([np.full(N_SAMPLES, 400), np.zeros(N_SAMPLES, dtype=int)])
+    return posterior_summary_table(X_query, p_query, y_query, n_trials=800, hdi_prob=0.90)
+
+
+def test_posterior_summary_columns_and_sorting():
+    df = _summary()
+    assert EXPECTED_COLUMNS.issubset(df.columns)
+    # Sorted ascending by age regardless of input order.
+    assert list(df["age_months"]) == [12.0, 24.0]
+
+
+def test_posterior_summary_values_age_12():
+    df = _summary()
+    row = df[df["age_months"] == 12.0].iloc[0]
+    assert np.isclose(row["p_median"], 0.25)
+    assert np.isclose(row["Ey_median"], 0.25 * 800)  # p * n_trials
+    assert row["Y_median"] == 0.0
+    assert np.isclose(row["P(Y=0)"], 1.0)  # every draw is zero
+    assert np.isclose(row["P(Y>400)"], 0.0)
+
+
+def test_posterior_summary_values_age_24():
+    df = _summary()
+    row = df[df["age_months"] == 24.0].iloc[0]
+    assert np.isclose(row["p_median"], 0.5)
+    assert row["Y_median"] == 400.0
+    assert np.isclose(row["P(Y=0)"], 0.0)
+    assert np.isclose(row["P(Y<=400)"], 1.0)  # all draws == 400
+    assert np.isclose(row["P(Y>400)"], 0.0)


### PR DESCRIPTION
## Summary

A careful review of the VG01–VG15 model engines (`src/vocab_growth/models/common*.py`), the data/plotting/comparison layers, and the test suite, looking for bugs, inefficiencies, and maintainability/testing opportunities.

Every change here is **low-risk**: it fixes latent crashes, reduces trace size **without changing any sampled or reported quantity**, hardens data loading, and improves plot/reproducibility consistency. **No model structure, prior, or likelihood was changed**, so existing fitted outputs remain reproducible.

Each engine was reviewed independently; because they are deliberate copy-and-extend siblings, several findings were shared, so the fixes are applied consistently across all of them.

## Bugs fixed

### 1. Model-graph render aborted the fit when graphviz was missing
`common.py`, `common_bivariate.py`, `common_bivariate_re.py` and `common_trivariate.py` called `digraph.render(...)` **unguarded** during *Model definition and initialisation*. On any machine without the graphviz `dot` binary this raised `ExecutableNotFound` and aborted the whole fit before sampling — i.e. **VG01–VG14 could not run there at all**. Only VG15 (`common_joint_modality.py`) wrapped the render in `try/except`.

Fix: a shared `render_model_graph()` helper in `common.py` that skips with a warning when graphviz is unavailable (the model diagram is a non-essential reporting artefact — a missing SVG only shows as a broken figure in the optional Quarto report). All five engines now route through it, which also **de-duplicates five copies** of the render block and unifies VG15's previously-bespoke handling.

### 2. VG15 could not be built from a clean checkout (uk_02 four-cell loader)
Six of the 62 "reconciling" `uk_02` rows record a produced sign/speech cross-tab but **no comprehension total** (`understood_only`/`comprehension` are NaN). `_load_uk02_four_cell` only checked that the signed/spoken *margins* reconciled, so these incomplete rows entered the four-cell set; the NaN `understood_only` then cast to `INT_MIN` and tripped the `"negative four-cell count"` validation in `build_model`. The data file (#47) predates VG15 (#59), so **a fresh `fit vg15` raises before sampling on the committed data** (reproduced locally).

Fix: a row qualifies as a four-cell row only if **all four cells are present**. Incomplete rows fall through to the marginal-only path, where their recorded spoken/signed margins still inform `q`/`r` — no information lost, and `psi` is still identified from the 56 complete cross-tab rows. Covered by a new regression test.

### 3. nutpie progress bar can crash backgrounded / non-TTY fits
`common.py` passes `progressbar=sys.stdout.isatty()` with a comment that the rich progress bar segfaults under nutpie's worker threads when stdout is not a TTY (redirected/backgrounded fits, CI, `--upload` runs). The bivariate, trivariate and joint engines omitted this guard on their `sample()` / `sample_posterior_predictive()`. They now match `common.py`.

## Inefficiency fixed

`common_bivariate.build_model` materialised the full-grid `(n_all,)` quantities `p_u_all`, `q_all`, `p_s_all` and `f_s_all` as `Deterministic`s — stored for **every posterior draw** — even though only their obs/plot/query *slices* are ever extracted or read. Converted them to plain tensors (the stored slices are unchanged), matching the memory discipline already documented and used in `common_bivariate_re.py` and `common_trivariate.py`. This shrinks VG05/VG06 traces with **no change to any recorded value**.

## Consistency / reproducibility

- Bivariate & trivariate posterior-predictive **count-distribution** plots now use the model's configured HDI (`context.reporting.hdi` = 0.90) instead of the function default 0.89, matching the univariate pipeline (the figures previously disagreed across model families).
- Seeded the prior-predictions scatter in `plotting.py` — it was the only `np.random` call left on the unseeded global RNG; every other scatter/spaghetti plot already uses a seeded generator.

## Tests (20 → 38, all passing)

- `test_joint_four_cell.py` — regression test for the uk_02 loader fix (incomplete-cell rows routed to marginal-only; counts cast cleanly to non-negative ints).
- `test_posterior_analysis.py` — `posterior_summary_table` columns, age-sorting and `P(Y≤k)` values.
- `test_plotting_helpers.py` — `_resolve_savgol_window_length` (odd / ≤ n / > polyorder, and the small-`n` raise) and `_maybe_savgol` passthrough.
- `test_data_utils.py` — added coverage for the previously-untested `filter_studies_by_min_obs` (used by VG11/VG12/VG13).

## Verification

- `ruff check src/ scripts/ tests/` — clean.
- `pytest` — **38 passed**.
- **Model-build smoke test on real data** (one engine per family — VG01, VG05, VG07, VG14, VG15): all construct successfully, the graphviz guard skips non-fatally, and VG05's full-grid derived deterministics are confirmed absent while the extracted slices remain present.

> Note: this dev machine has a broken C toolchain / LAPACK in the conda env (`g++ not available`; `model_to_graphviz` and `scipy.linalg.lstsq` both crash natively), so full end-to-end *sampling* could not be exercised here. Verification was done at the model-build / data-loading / pure-function level, which is exactly where these changes live.

## Reviewed but intentionally **not** changed (recommendations)

These are larger or higher-risk and are left for maintainer decision, since they would alter validated fitted outputs or run against an explicit design choice:

- **Centred vs non-centred study random intercepts.** `common_bivariate_re.py` uses a *centred* parameterisation for the study intercepts (`delta_u ~ Normal(0, tau_u)`) while its own subject intercepts, the univariate-RE engine, and the joint engine all use the *non-centred* form (`delta = tau · z`, `z ~ N(0,1)`). Non-centred is generally better-behaved for hierarchical models with few groups (the funnel) and may relate to the `r_hat`/`ess_tail` issues VG09/VG10 were created to address. It is mathematically the same model but changes the trace and would need re-fitting + re-validation of VG07–VG13, so it is flagged rather than applied.
- **Shared model-build scaffolding.** Age standardisation, plot/query grid construction, length-scale validation, the slope-anchor logit math, `L/M` derivation, the `trend_and_gp` / `intercept_and_gp` builders (already factored in VG15), the `_extract_posterior*` helpers, and several plotting functions (`plot_production_rate`, `plot_comprehension_production_gap`) are duplicated across engines. Consolidating them is the main maintainability win, but the modules carry explicit "deliberate, self-contained copy-and-extend" comments, and refactoring model-build code risks subtly perturbing results, so it warrants its own focused PR with before/after fit comparison.
- **Holdout-mask alignment in `extract_model_samples` (bivariate-RE).** `obs_u_mask`/`obs_s_mask` are stored from the full `has_u`/`has_s` masks, while `observed_data` holds only the *training* rows. These align for standard fits (no holdout) but would misalign in the K-fold LOSO scripts if those used the standard extraction path. Worth tightening if/when the LOSO path is extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
