### PR TITLE
Non-centred study random intercepts in build_model_re (#65)

### DIFF
--- a/src/vocab_growth/models/common_bivariate_re.py
+++ b/src/vocab_growth/models/common_bivariate_re.py
@@ -14,6 +14,10 @@ production ratio:
     delta_u[s] ~ Normal(0, tau_u)
     delta_q[s] ~ Normal(0, tau_q)
 
+The study intercepts are implemented non-centred (delta = tau * z,
+z ~ Normal(0, 1)) for HMC-friendly geometry; this is the same distribution as
+above (see issue #65).
+
 Plot and query predictions use the population-level trajectory (delta=0).
 """
 
@@ -459,11 +463,18 @@ def build_model_re(
         # Study-level random intercepts
         # ============================================================
 
+        # Non-centred (delta = tau * z, z ~ Normal(0, 1)) for HMC-friendly
+        # geometry with few studies — consistent with the subject REs below and
+        # the rest of the codebase. Mathematically identical to the centred form;
+        # the public names delta_u/delta_q/tau_u/tau_q are preserved (downstream
+        # scripts extract them by name from the trace). See issue #65.
         tau_u = pm.HalfNormal("tau_u", sigma=definition.tau_u_sigma)
-        delta_u = pm.Normal("delta_u", mu=0, sigma=tau_u, dims="study_id")
+        delta_u_raw = pm.Normal("delta_u_raw", mu=0.0, sigma=1.0, dims="study_id")
+        delta_u = pm.Deterministic("delta_u", tau_u * delta_u_raw, dims="study_id")
 
         tau_q = pm.HalfNormal("tau_q", sigma=definition.tau_q_sigma)
-        delta_q = pm.Normal("delta_q", mu=0, sigma=tau_q, dims="study_id")
+        delta_q_raw = pm.Normal("delta_q_raw", mu=0.0, sigma=1.0, dims="study_id")
+        delta_q = pm.Deterministic("delta_q", tau_q * delta_q_raw, dims="study_id")
 
         # ============================================================
         # Subject-level random intercepts (non-centered)

--- a/tests/test_study_re_parameterisation.py
+++ b/tests/test_study_re_parameterisation.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Guard the study random-intercept parameterisation in ``build_model_re``.
+
+Issue #65 switched the study-level random intercepts (``delta_u`` / ``delta_q``)
+from a centred form (``delta ~ Normal(0, tau)``) to the non-centred form used
+everywhere else in the codebase (``delta = tau * delta_raw``, ``delta_raw ~
+Normal(0, 1)``). This test pins two things that downstream code depends on:
+
+1. the non-centred raw variables ``delta_u_raw`` / ``delta_q_raw`` exist, and
+   the named ``delta_u`` / ``delta_q`` are *deterministic* (not free RVs) — i.e.
+   we have not regressed to the centred form; and
+2. the public names ``delta_u`` / ``delta_q`` / ``tau_u`` / ``tau_q`` are still
+   exposed, because ``scripts/vg07_study_effects.py`` and ``scripts/loso_compare*``
+   extract them from the trace by name.
+
+It builds the real VG07 model (no sampling), so it needs the prepared DuckDB; it
+skips cleanly when that isn't present (the CI fit job runs ``prepare_data`` first,
+but bare ``pytest`` may not).
+"""
+
+import os
+
+import dse_research_utils.statistics.models.reporting as reporting
+import dse_research_utils.statistics.models.sampling as sampling
+import pytest
+
+import vocab_growth.data_utils as vocab_data_utils
+from vocab_growth.models import common_bivariate_re as cbr
+from vocab_growth.models.common import ModelFitContext
+from vocab_growth.models.definitions import VG07
+
+
+@pytest.fixture
+def vg07_model(tmp_path, monkeypatch):
+    if not os.path.exists(vocab_data_utils.VOCABULARY_DATA_PATH):
+        pytest.skip("prepared vocabulary DuckDB not available")
+
+    # The model-graph render shells out to graphviz `dot`; not needed here.
+    monkeypatch.setattr(cbr, "render_model_graph", lambda *a, **k: None)
+
+    context = ModelFitContext(
+        reporting=reporting.ReportingConfiguration(
+            model_name=VG07.model_id,
+            config_name=VG07.config_name,
+            output_root_dir=str(tmp_path),
+            hdi=0.90,
+        ),
+        sampling=sampling.get_sampling_configuration("dev"),
+    )
+    os.makedirs(context.reporting.output_dir, exist_ok=True)
+
+    cbr.prepare_bivariate_re_data(context, VG07)
+    cbr.configure_bivariate_priors(context, VG07)
+    cbr.build_model_re(context, VG07)
+    return context.model
+
+
+def test_study_intercepts_are_non_centred(vg07_model):
+    named = set(vg07_model.named_vars)
+    # Non-centred raw offsets for each study trajectory.
+    assert {"delta_u_raw", "delta_q_raw"}.issubset(named)
+    # Public names preserved for downstream extraction.
+    assert {"delta_u", "delta_q", "tau_u", "tau_q"}.issubset(named)
+
+
+def test_study_deltas_are_deterministic_not_free(vg07_model):
+    deterministics = {d.name for d in vg07_model.deterministics}
+    free = {v.name for v in vg07_model.free_RVs}
+    # delta_u/delta_q are now derived (tau * raw), so deterministic, not sampled.
+    assert {"delta_u", "delta_q"}.issubset(deterministics)
+    assert {"delta_u", "delta_q"}.isdisjoint(free)
+    # The raw offsets and scales are the sampled quantities.
+    assert {"delta_u_raw", "delta_q_raw", "tau_u", "tau_q"}.issubset(free)


### PR DESCRIPTION
Closes #65.

## What

Switches the study-level random intercepts (`delta_u`, `delta_q`) in `build_model_re` (`src/vocab_growth/models/common_bivariate_re.py`) from a **centred** parameterisation (`delta ~ Normal(0, tau)`) to the **non-centred** form used everywhere else in the codebase (`delta = tau * z`, `z ~ Normal(0, 1)`) — matching the subject REs in the same file, `common_univariate_re.py`, and `common_joint_modality.py`.

With few studies (the DS studies number well under ~10) the centred form has the classic hierarchical "funnel" geometry that HMC samples poorly. The non-centred form is **mathematically the same model** with friendlier geometry.

## Why it's low-risk

The public trace variables `delta_u` / `delta_q` (now `pm.Deterministic`) and `tau_u` / `tau_q` keep their names, so downstream consumers that extract them by name need **no changes**: `scripts/vg07_study_effects.py`, `scripts/loso_compare.py`, `scripts/loso_compare_v2.py`. The only new variables are `delta_u_raw` / `delta_q_raw`. `diagnostics.csv` (size≤2 vars only) is unchanged.

A new build-time regression test (`tests/test_study_re_parameterisation.py`) pins this contract: `delta_*_raw` exist, `delta_u`/`delta_q` are deterministics (not free RVs), and the public names survive.

## Validation (before vs after, `test` tier)

Affected models: **VG07, VG08, VG09, VG10, VG13** (VG11/VG12 are univariate and already non-centred). Compared the four DS models (VG07–10):

**Population estimands — unchanged within MC error:** for U/S/q, the after-median lies inside the before-HDI at **100%** of query ages; max |Δ median| ≤ 0.019; milestone ages stable to <1 month.

**Sampler diagnostics:** group-level (`delta`) ess rose for all four models — the expected non-centred signature — and VG07 lost its 12 divergences. Other test-tier metrics are mixed/noisy (VG09 is under-converged under both parameterisations at `test`), so the **definitive convergence comparison should be done at `rep`**.

| model | divergences | r̂max | ess_tail_min | δ ess_min |
|---|---|---|---|---|
| VG07 | 12 → 0 | 1.003→1.002 | 1628→1949 | 2671→3609 |
| VG08 | 0→1 | 1.026→1.015 | 181→437 | 472→631 |
| VG09 | 0→0 | 1.029→1.052 | 75→31 | 712→853 |
| VG10 | 1→1 | 1.015→1.008 | 262→379 | 542→610 |

`ruff check src/ scripts/` clean; full `pytest` (40 tests) passes.

## Follow-ups (not in this PR)

- **`rep`-tier refits of VG07–VG10** for the definitive convergence read (test tier is too noisy to settle VG09).
- **VG13** validation at `rep`. (It builds and samples fine under the change, but is much heavier — `sample_fraction=1.0` keeps all ~7,920 obs — so a `test`-tier fit takes too long to be a useful gate; it is unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)