### PR TITLE
Require AI-tool attribution label on drafted content

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -116,6 +116,23 @@ Quarto documents in `docs/models/vgNN/index.qmd` render model-specific reports. 
 
 ## Conventions
 
+### AI tool attribution
+
+Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool. Put the label at the very top of the content, using a GitHub-flavoured Markdown alert and substituting the actual tool and model that produced it:
+
+> [!WARNING]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+
+This requirement applies to:
+
+- Document drafts (Markdown, Quarto `.qmd`, and similar)
+- Pull request descriptions
+- Issue descriptions
+- Comments on pull requests
+- Comments on issues
+
+Replace `Claude Code/Opus 4.8` with whichever assistant was used (for example, `GitHub Copilot`).
+
 ### File headers
 
 Every Python source file starts with:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,7 +120,7 @@ Quarto documents in `docs/models/vgNN/index.qmd` render model-specific reports. 
 
 Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool. Put the label at the very top of the content, using a GitHub-flavoured Markdown alert and substituting the actual tool and model that produced it:
 
-> [!WARNING]
+> [!NOTE]
 > Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
 
 This requirement applies to:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,23 @@ Quarto documents in `docs/models/vgNN/index.qmd` render model-specific reports. 
 
 ## Conventions
 
+### AI tool attribution
+
+Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool. Put the label at the very top of the content, using a GitHub-flavoured Markdown alert and substituting the actual tool and model that produced it:
+
+> [!WARNING]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+
+This requirement applies to:
+
+- Document drafts (Markdown, Quarto `.qmd`, and similar)
+- Pull request descriptions
+- Issue descriptions
+- Comments on pull requests
+- Comments on issues
+
+Replace `Claude Code/Opus 4.8` with whichever assistant was used (for example, `GitHub Copilot`).
+
 ### File headers
 
 Every Python source file starts with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Quarto documents in `docs/models/vgNN/index.qmd` render model-specific reports. 
 
 Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool. Put the label at the very top of the content, using a GitHub-flavoured Markdown alert and substituting the actual tool and model that produced it:
 
-> [!WARNING]
+> [!NOTE]
 > Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
 
 This requirement applies to:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,23 @@ Quarto documents in `docs/models/vgNN/index.qmd` render model-specific reports. 
 
 ## Conventions
 
+### AI tool attribution
+
+Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool. Put the label at the very top of the content, using a GitHub-flavoured Markdown alert and substituting the actual tool and model that produced it:
+
+> [!WARNING]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+
+This requirement applies to:
+
+- Document drafts (Markdown, Quarto `.qmd`, and similar)
+- Pull request descriptions
+- Issue descriptions
+- Comments on pull requests
+- Comments on issues
+
+Replace `Claude Code/Opus 4.8` with whichever assistant was used (for example, `GitHub Copilot`).
+
 ### File headers
 
 Every Python source file starts with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Quarto documents in `docs/models/vgNN/index.qmd` render model-specific reports. 
 
 Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool. Put the label at the very top of the content, using a GitHub-flavoured Markdown alert and substituting the actual tool and model that produced it:
 
-> [!WARNING]
+> [!NOTE]
 > Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
 
 This requirement applies to:

--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -21,6 +21,7 @@ Kruschke
 Kucharski
 lengthscale
 Lewandowsky
+LLM
 logit
 LOSO
 MCMC


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## What changed

Adds an **AI tool attribution** convention to the agent-instruction files. Any content drafted or generated with the help of an LLM-based AI tool must now carry a clearly visible label (a GitHub-flavoured Markdown alert) identifying the tool, placed at the top of the content.

The requirement explicitly covers:

- Document drafts (Markdown, Quarto `.qmd`, and similar)
- Pull request descriptions
- Issue descriptions
- Comments on pull requests
- Comments on issues

## Files

- `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md` — added an identical `### AI tool attribution` subsection at the top of `## Conventions`. These three files share the same content by design (per their "keep in sync" note), so the change was applied to all three.
- `config/spellcheck/allow-en.txt` — added `LLM` to the CSpell allow-list. The dictionary doesn't accept arbitrary acronyms (e.g. `MCMC`, `HSGP`, `LOSO` are all hand-added), so the new wording would otherwise fail the `npm run spellcheck` CI gate.

## Why

To ensure AI-assisted contributions are transparently labelled wherever they appear (docs, PRs, issues, and comments).

## Reviewer notes

- The callout uses `[!NOTE]` (the info-styled GitHub alert). `[!INFO]` is not a valid GitHub alert type and would not render as a styled callout.
- The label in the instructions is written generically — contributors substitute the actual tool/model used (e.g. `GitHub Copilot`), with `Claude Code/Opus 4.8` shown as the template.
- This PR's own description follows the new convention (see the callout above).
- `npm run format:check` / `npm run spellcheck` were not run locally (Node deps aren't installed in the worktree). The new Markdown follows the surrounding Prettier conventions; CI will confirm.
