### PR TITLE
Add Quarto callout guidance to AI attribution convention

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,20 +118,28 @@ Quarto documents in `docs/models/vgNN/index.qmd` render model-specific reports. 
 
 ### AI tool attribution
 
-Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool. Put the label at the very top of the content, using a GitHub-flavoured Markdown alert and substituting the actual tool and model that produced it:
+Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool, placed at the top of the content. Substitute the actual tool and model that produced it — replace `Claude Code/Opus 4.8` with whichever assistant was used (for example, `GitHub Copilot`).
+
+For GitHub-rendered content — Markdown files, pull request and issue descriptions, and comments on pull requests and issues — use a GitHub-flavoured Markdown alert:
 
 > [!NOTE]
 > Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
 
+For Quarto documents (`.qmd`), GitHub alert syntax does not render, so use a Quarto callout block instead:
+
+```
+::: {.callout-note}
+Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+:::
+```
+
 This requirement applies to:
 
-- Document drafts (Markdown, Quarto `.qmd`, and similar)
+- Document drafts (Markdown and Quarto `.qmd`)
 - Pull request descriptions
 - Issue descriptions
 - Comments on pull requests
 - Comments on issues
-
-Replace `Claude Code/Opus 4.8` with whichever assistant was used (for example, `GitHub Copilot`).
 
 ### File headers
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,20 +118,28 @@ Quarto documents in `docs/models/vgNN/index.qmd` render model-specific reports. 
 
 ### AI tool attribution
 
-Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool. Put the label at the very top of the content, using a GitHub-flavoured Markdown alert and substituting the actual tool and model that produced it:
+Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool, placed at the top of the content. Substitute the actual tool and model that produced it — replace `Claude Code/Opus 4.8` with whichever assistant was used (for example, `GitHub Copilot`).
+
+For GitHub-rendered content — Markdown files, pull request and issue descriptions, and comments on pull requests and issues — use a GitHub-flavoured Markdown alert:
 
 > [!NOTE]
 > Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
 
+For Quarto documents (`.qmd`), GitHub alert syntax does not render, so use a Quarto callout block instead:
+
+```
+::: {.callout-note}
+Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+:::
+```
+
 This requirement applies to:
 
-- Document drafts (Markdown, Quarto `.qmd`, and similar)
+- Document drafts (Markdown and Quarto `.qmd`)
 - Pull request descriptions
 - Issue descriptions
 - Comments on pull requests
 - Comments on issues
-
-Replace `Claude Code/Opus 4.8` with whichever assistant was used (for example, `GitHub Copilot`).
 
 ### File headers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,20 +118,28 @@ Quarto documents in `docs/models/vgNN/index.qmd` render model-specific reports. 
 
 ### AI tool attribution
 
-Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool. Put the label at the very top of the content, using a GitHub-flavoured Markdown alert and substituting the actual tool and model that produced it:
+Content drafted or generated with the help of an LLM-based AI tool **must** carry a clearly visible label identifying the tool, placed at the top of the content. Substitute the actual tool and model that produced it — replace `Claude Code/Opus 4.8` with whichever assistant was used (for example, `GitHub Copilot`).
+
+For GitHub-rendered content — Markdown files, pull request and issue descriptions, and comments on pull requests and issues — use a GitHub-flavoured Markdown alert:
 
 > [!NOTE]
 > Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
 
+For Quarto documents (`.qmd`), GitHub alert syntax does not render, so use a Quarto callout block instead:
+
+```
+::: {.callout-note}
+Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+:::
+```
+
 This requirement applies to:
 
-- Document drafts (Markdown, Quarto `.qmd`, and similar)
+- Document drafts (Markdown and Quarto `.qmd`)
 - Pull request descriptions
 - Issue descriptions
 - Comments on pull requests
 - Comments on issues
-
-Replace `Claude Code/Opus 4.8` with whichever assistant was used (for example, `GitHub Copilot`).
 
 ### File headers
 

--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -3,6 +3,7 @@ Floccia
 approximator
 arrowsize
 ArviZ
+callout
 centered
 color
 Counterintuitively


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## What changed

Follow-up to #74. The AI-tool attribution label uses GitHub alert syntax (`> [!NOTE]`), which **does not render** inside Quarto (`.qmd`) documents — Quarto uses its own callout blocks. This PR splits the `AI tool attribution` convention into two cases and gives the correct syntax for each:

- **GitHub-rendered content** (Markdown files, PR/issue descriptions, comments) → GitHub alert (`> [!NOTE]`)
- **Quarto `.qmd` documents** → Quarto callout block:

  ```
  ::: {.callout-note}
  Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
  :::
  ```

## Files

- `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md` — updated the `### AI tool attribution` subsection identically (per their "keep in sync" note).
- `config/spellcheck/allow-en.txt` — added `callout` for the new prose (the `.callout-note` token inside code blocks is already ignored by CSpell, but the word appears in body text).

## Why

So the attribution label actually renders wherever it's placed, including in rendered Quarto reports.

## Reviewer notes

- The Quarto example is shown in a plain (no-language) code fence so Prettier doesn't attempt to reformat the embedded `:::` div syntax.
- `npm run format:check` / `npm run spellcheck` were not run locally (Node deps aren't installed in the worktree); CI will confirm.
