### PR TITLE
Wire ie_02 dataset into data preparation

### DIFF
--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -26,6 +26,7 @@ heading("Preparing vocabulary data")
 
 _sources = {
     "vocab_ie_01": "./data/vocab_data_ie_01.csv",
+    "vocab_ie_02": "./data/vocab_data_ie_02.csv",
     "vocab_it_01": "./data/vocab_data_it_01.csv",
     "vocab_uk_01": "./data/vocab_data_uk_01.csv",
     "vocab_uk_02": "./data/vocab_data_uk_02.csv",
@@ -44,6 +45,7 @@ key_value_table(
 )
 
 vocab_ie_01_df = _loaded["vocab_ie_01"]
+vocab_ie_02_df = _loaded["vocab_ie_02"]
 vocab_it_01_df = _loaded["vocab_it_01"]
 vocab_uk_01_df = _loaded["vocab_uk_01"]
 vocab_uk_02_df = _loaded["vocab_uk_02"]
@@ -117,6 +119,18 @@ vocab_us_02_to_merge["study"] = 8
 vocab_uk_06_to_merge = vocab_uk_06_df.copy()
 vocab_uk_06_to_merge["study"] = 9
 
+# Ireland 2 (ie_02): a longitudinal Down syndrome dataset already in long format
+# (one row per timepoint t1/t2), carrying understood/spoken/signed counts. The
+# instruments measure English vocabulary, so non-English-speaking children are
+# excluded (english_speaking == 'yes'). Both recruitment groups are pooled as DS.
+ireland_2_to_merge = (
+    vocab_ie_02_df.loc[
+        vocab_ie_02_df["english_speaking"] == "yes",
+        ["subject_id", "age", "understood", "spoken"],
+    ].copy()
+)
+ireland_2_to_merge["study"] = 10
+
 
 merged_df = pd.concat(
     [
@@ -130,6 +144,7 @@ merged_df = pd.concat(
         vocab_uk_05_to_merge,
         vocab_us_02_to_merge,
         vocab_uk_06_to_merge,
+        ireland_2_to_merge,
     ],
     ignore_index=True,
 )
@@ -210,6 +225,13 @@ con.execute(
     """
     CREATE TABLE vocab_uk_06 AS
     SELECT * FROM vocab_uk_06_df
+    """
+)
+
+con.execute(
+    """
+    CREATE TABLE vocab_ie_02 AS
+    SELECT * FROM vocab_ie_02_df
     """
 )
 
@@ -364,6 +386,18 @@ con.execute(
         vuk06.spoken                      as produced,
         800                                 as survey_vocab_max
     FROM vocab_uk_06 as vuk06
+        UNION
+    SELECT 'ie_02'                           as study,
+        vie2.subject_id,
+        NULL                                as sex,
+        vie2.age,
+        vie2.understood,
+        vie2.spoken,
+        vie2.signed                         as signed,
+        vie2.spoken                         as produced,
+        800                                 as survey_vocab_max
+    FROM vocab_ie_02 as vie2
+    WHERE vie2.english_speaking = 'yes'
 
     """
 )


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

Wires the new **Ireland 2 (`ie_02`)** longitudinal Down syndrome dataset into `scripts/prepare_data.py`. `ie_02` is in long format (one row per timepoint `t1`/`t2`) and is the second DS source — after `uk_01` — to carry **understood, spoken _and_ signed** counts.

Four additions to the pipeline:

1. Source entry in `_sources` and the loaded-frame assignment.
2. Merge block (`study = 10`), English-only, contributing to `vocab_data_merged.csv`.
3. `vocab_ie_02` DuckDB table (full raw fidelity).
4. A `vocab_combined` view `UNION` mapping `ie_02` to `study/subject_id/sex/age/understood/spoken/signed/produced/survey_vocab_max`, filtered to `english_speaking = 'yes'`.

## Decisions applied

- **Both recruitment groups pooled** as a single DS study (`group` is undocumented; treated as DS, with study-level random intercepts absorbing between-study variation — consistent with every other study).
- **Non-English-speaking child excluded** (`english_speaking = 'yes'`; 1 child / 2 rows) to match the English-only instrument scope already used for the Wordbank DS subset.
- `sex` set `NULL` (the `gender` encoding is undocumented and `sex` is unused by the DS fits); `survey_vocab_max = 800` to match `ie_01` (also unused by the DS loader, which reads only `understood/spoken/signed`).

## Verification

Ran `scripts/prepare_data.py` and queried `vocab_combined` / `load_combined_data()`:

| Check | Result |
| --- | --- |
| `ie_02` rows in view | 114 (116 raw − 2 non-English) |
| `ie_02` subjects | 66 (1 non-English child dropped) |
| Counts ≤ 800; `spoken`/`signed` ≤ `understood` | no guard violations |
| DS loader total | 1078 rows across 11 studies |
| **Signed pool** | **414 → 528 observations (+114, +27.5%)** — `ie_02` now the 2nd-largest signed source after `uk_01` |

`ruff check` clean; test suite passes (`MPLBACKEND=Agg`).

## Notes

- Prepared artifacts (`vocabulary.duckdb`, `vocab_data_merged.csv`) are gitignored and not part of this PR.
- A full reporting-quality (`--config rep`) refit of all 9 DS models (VG01/02/05/07/08/09/10/14/15) is running separately; reports are being published to blob storage as each completes.
