### PR TITLE
Add h5py to environment so model fits can write trace.nc

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
       - arviz-stats>=1.2.0
       - arviz-plots>=1.2.0
       - h5netcdf
+      - h5py # h5netcdf backend; pip h5netcdf no longer pulls this transitively (was via conda-forge)
       - duckdb>=1.5.4
       - hatch
       - ipython>=9.14.1


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## What

Add `h5py` to the pip dependencies in `environment.yml`.

## Why

The `model-fit-tests` job on `main` is failing at the **Fit model VG01 (dev)** step ([run 28245389101](https://github.com/dseinternational/vocabulary-growth/actions/runs/28245389101)):

```
ImportError: No module named 'h5py', backend not available.
```

It fails at `trace.to_netcdf(...)` (`src/vocab_growth/models/common.py:939`), which writes the posterior trace through xarray's h5netcdf backend.

The trigger was the recent `environment.yml` restructure (44beebd), which moved `h5netcdf` from the conda-forge dependencies into pip:

- conda-forge's `h5netcdf` recipe lists `h5py` as a runtime dependency, so it was always pulled in transitively.
- The PyPI `h5netcdf` wheel declares `h5py` only as an optional extra (`h5py; extra == "h5py"`).

So a fresh pip-based env (what CI builds) has no `h5py`. Existing local envs still had `h5py` from before the restructure, which masked the break.

## Verification

- Confirmed from installed metadata that `h5netcdf` makes `h5py` an optional extra.
- Confirmed `h5py` 3.16.0 ships cp314 wheels for Linux and Windows, so CI's pip install gets a wheel rather than a source build.
- Ran the exact write path locally — `xr.DataTree(...).to_netcdf(...)` round-trips successfully via the h5netcdf engine.