### PR TITLE
DS/TD comparison tooling refresh, expressive-delay suite, and refit findings note

### DIFF
--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -5,6 +5,7 @@ arrowsize
 ArviZ
 callout
 centered
+centile
 color
 Counterintuitively
 D'Souza
@@ -13,6 +14,7 @@ duckdb
 elpd
 empiricalmodelling
 estimand
+estimands
 HSGP
 hyperparameters
 hyperpriors
@@ -51,6 +53,7 @@ spanos
 Spiegelhalter
 subj
 TEDS
+timepoint
 TOST
 toddlerhood
 Tovar
@@ -63,4 +66,5 @@ vocab
 Walle
 Wilcoxon
 Wordbank
+xarray
 zygosity

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
       - arviz-stats>=1.2.0
       - arviz-plots>=1.2.0
       - h5netcdf
+      - h5py # h5netcdf backend; required by the joint model's DataTree trace.to_netcdf
       - duckdb>=1.5.4
       - hatch
       - ipython>=9.14.1

--- a/notes/202606270930-ie02-refit-and-findings.md
+++ b/notes/202606270930-ie02-refit-and-findings.md
@@ -218,7 +218,7 @@ DS early vocabulary is best described as a **developmental stretch with a
 production-specific deficit**: comprehension is delayed and the delay widens with
 level; production is delayed *substantially more* (~12–17 months extra at matched
 low vocabulary size, P(>0)=1.00), peaks ~4 years later, and leaves ~90% of
-2-year-olds below the TD 10th centile for spoken words. Signing partially —
+2-year-old children below the TD 10th centile for spoken words. Signing partially —
 not wholly — compensates. This is exactly the regime the reserved generative
 VG16 would formalise (a directly-estimated, level-indexed expressive-delay
 parameter); §4.3 shows the headline is already recoverable from the disjoint

--- a/notes/202606270930-ie02-refit-and-findings.md
+++ b/notes/202606270930-ie02-refit-and-findings.md
@@ -12,7 +12,7 @@ below are taken from the fitted output under `output/models/<MODEL>/`
 
 ## 1. Data change — ie_02 wired in
 
-`ie_02` is a longitudinal Down Syndrome Ireland follow-up dataset (long format,
+`ie_02` is a longitudinal Irish dataset (long format,
 one row per timepoint `t1`/`t2`) carrying **understood, spoken _and_ signed**
 counts. It is the second DS source after `uk_01` to record all three modalities.
 

--- a/notes/202606270930-ie02-refit-and-findings.md
+++ b/notes/202606270930-ie02-refit-and-findings.md
@@ -1,0 +1,241 @@
+# IE_02 integration, full DS refit, and DS/TD comparison update
+
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+
+Status: 2026-06-27. Records the wiring of the new **Ireland 2 (`ie_02`)** dataset,
+the reporting-quality refit of all Down syndrome (DS) models, the in-progress
+typically-developing (TD) refit, and the comparison tooling changes. Numbers
+below are taken from the fitted output under `output/models/<MODEL>/`
+(`--config rep`) — `diagnostics.csv`, `posterior_summary_*.csv`, and the trace
+`sample_stats` — not from prior prose.
+
+## 1. Data change — ie_02 wired in
+
+`ie_02` is a longitudinal Down Syndrome Ireland follow-up dataset (long format,
+one row per timepoint `t1`/`t2`) carrying **understood, spoken _and_ signed**
+counts. It is the second DS source after `uk_01` to record all three modalities.
+
+Wiring (`scripts/prepare_data.py`, [PR #77](https://github.com/dseinternational/vocabulary-growth/pull/77)):
+source entry + merge block (`study = 10`) + DuckDB table + a `vocab_combined`
+UNION mapping `understood/spoken/signed`, filtered to `english_speaking = 'yes'`.
+
+Decisions: both recruitment groups pooled as one DS study; the single
+non-English-speaking child (2 rows) excluded; `sex` NULL (undocumented `gender`,
+unused by the DS fits); `survey_vocab_max = 800` (matching `ie_01`, unused by the
+DS loader).
+
+Effect on the analysis set:
+
+| Quantity | Value |
+| --- | --- |
+| `ie_02` rows in view | 114 (116 raw − 2 non-English) |
+| `ie_02` subjects | 66 (1 non-English child dropped) |
+| Total DS rows (`load_combined_data`) | 1,078 across 11 studies |
+| **Signed observations (feeds VG14/VG15)** | **414 → 528 (+114, +27.5%)** |
+
+All `ie_02` counts are ≤ 800 and satisfy `spoken ≤ understood`, `signed ≤
+understood` for every row (no Beta-Binomial guard violations). `ie_02` is now the
+second-largest signed source after `uk_01`.
+
+## 2. How the models fit
+
+**Sampling.** Reporting config (`rep`): nutpie NUTS, **6 chains × (6,000 tune +
+6,000 draws)**, `target_accept = 0.95`. Per-model wall times (rep): VG01 ~8 m,
+VG02 ~5 m, VG05 ~17 m, VG07 ~20 m, VG08 ~18 m, VG09 ~15 m, VG10 ~16 m, VG14
+~25 m, VG15 ~17 m.
+
+**Convergence — all 9 DS models:**
+
+| Model | structure | max R̂ | params R̂>1.01 | min ESS (bulk) | divergences |
+| ----- | --------- | ----: | ------------: | -------------: | ----------: |
+| VG01 | spoken, univariate | 1.001 | 0 | 10,933 | 0 |
+| VG02 | understood, univariate | 1.000 | 0 | 10,148 | 0 |
+| VG05 | joint U+S | 1.001 | 0 | 9,116 | 0 |
+| VG07 | + study RE | 1.001 | 0 | 6,435 | 0 |
+| VG08 | + subject RE (U) | 1.004 | 0 | 1,379 | 0 |
+| **VG09** | + subject RE (U,q) | **1.021** | **4** | **423** | 0 |
+| VG10 | + tighter q anchors, GP anchor | 1.006 | 0 | 670 | 0 |
+| VG14 | trivariate (+signed) | 1.001 | 0 | 6,628 | 0 |
+| VG15 | joint four-cell sign/speech | 1.005 | 0 | 911 | 0 |
+
+**Zero divergences across all nine models.** Convergence is clean everywhere
+except **VG09**, which shows mild non-convergence (max R̂ 1.021 on 4 parameters,
+min ESS ~420) — consistent with its known sampler difficulty as the model
+carrying subject random intercepts on *both* the understood trajectory and the
+production ratio. VG09 is **not** used downstream by the comparison suite (which
+reads VG10 for population means and VG07 for dispersion), so this does not affect
+the DS/TD analysis. VG10 and VG15 (the more heavily parameterised models that the
+ie_02 data most affects) converged cleanly.
+
+**Operational note — VG15 / h5py.** The first VG15 rep attempt sampled
+successfully but **failed at the final `trace.to_netcdf`** with `ImportError: No
+module named 'h5py'`. Root cause: a conda update had removed `h5py`/`netcdf4`
+from the env; the joint model is the only one that writes its trace via xarray's
+*DataTree* path, which hard-requires the `h5py` backend, whereas the other eight
+models use the InferenceData path (a different, still-working writer). Fix:
+reinstalled `h5py` (3.16.0), verified the DataTree round-trip, and re-ran VG15
+cleanly. `environment.yml` declares `h5netcdf` (pip) but **not** `h5py` —
+recommend adding `h5py` to the pip block to prevent recurrence.
+
+## 3. Key findings
+
+All figures are posterior medians [90% HDI], **adversarially verified against the
+source `posterior_summary_*.csv`** (every headline number re-checked by an
+independent agent against the CSV — all matched). "Expected words" is the latent
+mean trajectory (Ey) out of the 800-item reference inventory; individual-child
+predictive spread is much wider (the Y intervals routinely reach 0 at the low
+end). **All fits are on the ie_02-augmented data** — ie_02 was wired in, the
+DuckDB rebuilt, then every model refit.
+
+### Comprehension and production (DS, from the headline joint model VG10)
+
+| Quantity | 24 mo | 48 mo | 72 mo |
+| --- | --- | --- | --- |
+| Words understood | 87 [67, 108] | 259 [213, 307] | 441 [369, 510] |
+| Words spoken | 4 [2, 6] | 131 [93, 170] | 366 [303, 431] |
+| Production ratio q = S/U | 0.05 [0.03, 0.07] | 0.51 [0.39, 0.63] | 0.84 [0.72, 0.95] |
+
+- **Comprehension leads production throughout.** Understanding reaches ~100 words
+  by ~24 mo (VG02 reaches 50/100/200 understood at ~16.5/23.7/31.6 mo); the
+  typical child reaches 10/50/100 *spoken* words only at ~25/39/45 mo (VG01).
+- **The production ratio q crosses 0.5 around 48 months** consistently across
+  specifications (VG05 0.50, VG10 0.51, VG14 0.50 at 48 mo) — a DS child speaks
+  roughly half the words they understand by age 4, rising to ~0.84 by age 6.
+- **Subject random effects sharply lower the _typical_-child early production
+  ratio.** At 24 mo, q ≈ 0.18–0.23 in the no-/study-RE models (VG05/07/08) but
+  ≈ 0.05–0.07 once subject REs are added (VG09 0.066, VG10 0.047, VG15 0.060):
+  the pooled population average is inflated by a minority of early talkers; the
+  modelled typical DS child says a much smaller fraction of understood words in
+  the third year than the pooled mean implies. VG09 carries this with the
+  mild-convergence caveat (§2); VG10 (anchored, clean) is the headline.
+
+### Signing — VG14 / VG15, newly powered by ie_02 (+114 signed obs, +27.5%)
+
+- **Signing is a hump, not a monotone trend.** The signed ratio r(a) (fraction of
+  understood words signed) rises from ~0.12 at 12 mo to a peak **~0.40 at 24 mo**,
+  then declines (0.33 at 36, 0.27 at 48, 0.14 at 60 mo) as speech takes over
+  (VG14).
+- **Sign → speech crossover at ~39 months.** The spoken ratio q overtakes the
+  signed ratio r at ~39 mo (both ~0.30): before ~3 years a DS child signs a
+  larger share of understood words than they speak; speech overtakes thereafter
+  (VG14, `sign_speech_crossover.csv`).
+- **Counting sign credits substantial extra early expressive vocabulary.** Total
+  expressive words p_any ≈ 57 / 209 / 310 at 24/48/72 mo (VG14), versus spoken
+  alone ~24 / 165 / 303 — the gap is largest in the early years where signing is
+  most active.
+- **Sign and speech positively co-occur within children (VG15).** The
+  within-understood association **psi = 2.17 [1.46, 2.96]** (P(psi>1) ≈ 0.9999,
+  HDI excludes independence): a word a DS child understands is more likely to be
+  *both* signed and spoken than chance predicts — signing accompanies rather than
+  displaces speech. The data-identified total expressive p_any (≈ 21 / 164 / 361
+  words at 24/48/72 mo) sits just below VG14's independence upper bound,
+  confirming the conditional-independence assumption modestly over-counts.
+
+ie_02 is now the second-largest signing source after uk_01 and materially
+strengthens identification of the r(a) peak/decline, the ~39-mo crossover, and
+psi — the findings most specific to this round of work.
+
+## 4. DS vs TD comparisons
+
+All TD models refit at rep (VG03/04/06/11/12/13; all converged, R̂ ≤ 1.002, ESS
+in the thousands; VG13 had 40/36,000 divergences and VG04 2 — negligible). All
+contrasts below are **per-draw differences of the disjoint DS×TD posteriors**
+(exact CIs, no joint model), at the **population level**, over the **empirical
+age/level overlap only** (DS comparator VG10; TD VG11/VG12 univariate, VG13
+joint 8–18 mo; dispersion/distribution use study-RE-only VG07 vs VG11/12). The
+TD models span only ~8–30 mo, so the overlap — and several estimands — are
+identified only at younger ages / lower vocabulary levels; this is flagged
+throughout.
+
+### 4.1 The gap is large and production-specific
+
+At 24 mo, expected **comprehension** is TD 352 vs DS 87 (≈4×); expected
+**production** is TD 257 vs DS 4 (≈63×) — P(TD>DS)=1.00 across the overlap. The
+deficit is far larger for production than comprehension.
+
+### 4.2 A developmental *stretch*, not a constant shift
+
+The attainment delay D(v) = months DS reaches level v after TD **grows with the
+level** on both outcomes:
+
+| level v | understood delay | spoken delay |
+| --- | --- | --- |
+| 10 words | ~0 mo | 17 mo |
+| 50 words | 10 mo | 22 mo |
+| 100 words | 12 mo | 26 mo |
+| 200 words | 21 mo | 32 mo |
+| 300 words | 32 mo | 38 mo |
+
+A flat D(v) would mean a pure time-shift; the rising curve means the gap *widens*
+with development. Production lags comprehension at every level. Consistently,
+**peak learning-rate age** is ~64 mo (DS) vs ~23 mo (TD) for spoken and ~71 vs
+~18 mo for understood — DS peak-velocity arrives ~3.5–4.5 years later.
+
+### 4.3 Expressive-specific delay (the "expressive delay" headline)
+
+DS production is delayed *beyond* what its comprehension delay alone predicts,
+two complementary ways:
+
+- **Level-indexed** Δ_exp(N) = (production attainment delay) − (comprehension
+  attainment delay): **16.7 mo [13.6, 19.8] at N=10, ~12.4 mo [9.6, 15.3] at
+  N=50, P(>0)=1.00 throughout.** At a given vocabulary *size*, DS takes ~12–17
+  extra months to *say* the words it *understands*, relative to TD. (Identified
+  only at N≈10–50 — TD's 8–18 mo joint model reaches limited vocabulary.)
+- **Age-indexed** extra-expressive delay (cea_U − cea_S): ~2.9 mo [P=1.00] at
+  24 mo, ~1.5 mo [P=0.95] at 36 mo, ≈0 by 48 mo. Smaller, because at a fixed age
+  DS comprehension is *also* heavily delayed (24 mo DS ≈ TD 12 mo receptively,
+  9 mo expressively), so both map to early-TD ages and the *extra* lag compresses.
+
+The two are consistent — they hold level vs age fixed respectively. The
+level-indexed Δ_exp is the cleaner "expressive delay" statistic.
+
+Comprehension-matched q(U=N) tells the same story: at equal comprehension DS
+speaks a smaller fraction (U=50: TD q=0.08 vs DS 0.03; U=100: 0.16 vs 0.05;
+Δq>0, P≈1.00 to U≈150, converging by U≈200). The low-U end is noisy (q=S(a_U)/N
+is unstable when U barely exceeds N) — read the mid-range.
+
+### 4.4 Distributional "how atypical"
+
+Fraction of DS children below the **TD 10th centile** word count: **spoken** 0.70
+(12 mo) → 0.90 (24 mo) → 0.95 (28 mo); **understood** 0.30 (12 mo) → 0.58
+(16 mo) → 0.84 (24 mo). By age 2, ~90% of DS children produce fewer spoken words
+than the bottom 10% of TD children — comprehension is less atypical early but
+both become highly atypical as TD explodes.
+
+### 4.5 Sign-inclusive gap (newly enabled by ie_02 → VG14 p_any)
+
+Counting signed words credits DS extra expressive vocabulary — ~7 words (16 mo),
+~17 (20 mo), ~32 (24 mo), ~57 (30 mo) — which **narrows the DS–TD expressive gap
+by ~14–15%** in the 24–30 mo window (24 mo: 233→201; 30 mo: 374→317). Real and
+specifically powered by the new ie_02 signing data, but modest: the gap stays
+enormous because TD production is mid-explosion here, and the window is capped at
+30 mo by TD support.
+
+### 4.6 Reading
+
+DS early vocabulary is best described as a **developmental stretch with a
+production-specific deficit**: comprehension is delayed and the delay widens with
+level; production is delayed *substantially more* (~12–17 months extra at matched
+low vocabulary size, P(>0)=1.00), peaks ~4 years later, and leaves ~90% of
+2-year-olds below the TD 10th centile for spoken words. Signing partially —
+not wholly — compensates. This is exactly the regime the reserved generative
+VG16 would formalise (a directly-estimated, level-indexed expressive-delay
+parameter); §4.3 shows the headline is already recoverable from the disjoint
+fits with exact intervals, no joint model required.
+
+## 5. Comparison tooling changes (this round)
+
+- Comparison figures are now emitted as **individual, linear-axis** figures
+  (`compare_ds_td_re.py`) — the 2×3 / 2×2 subplot grids and all log x-scales were
+  removed so each panel is usable on its own.
+- New **`compare_ds_td_expressive.py`** — the non-VG16 realisation of the
+  "expressive delay" question (every estimand a per-draw functional of the
+  disjoint DS×TD posteriors, exact CIs, no joint model): level-indexed Δ_exp(N),
+  comprehension-equivalent developmental age, the **sign-inclusive expressive
+  gap** (uses the new ie_02 signing via VG14 `p_any`), and the distributional
+  "fraction of DS below the TD 10th centile". New estimands live in
+  `vocab_growth.comparison` with analytic self-checks.
+- Deprecated `compare_ds_td_latency.py` and `compare_ds_td_q_overlap.py` to shims
+  delegating to `compare_ds_td_re.run_comprehension_matched` (they duplicated its
+  comprehension-matched panels).

--- a/notes/202606270930-ie02-refit-and-findings.md
+++ b/notes/202606270930-ie02-refit-and-findings.md
@@ -27,12 +27,12 @@ DS loader).
 
 Effect on the analysis set:
 
-| Quantity | Value |
-| --- | --- |
-| `ie_02` rows in view | 114 (116 raw − 2 non-English) |
-| `ie_02` subjects | 66 (1 non-English child dropped) |
-| Total DS rows (`load_combined_data`) | 1,078 across 11 studies |
-| **Signed observations (feeds VG14/VG15)** | **414 → 528 (+114, +27.5%)** |
+| Quantity                                  | Value                            |
+| ----------------------------------------- | -------------------------------- |
+| `ie_02` rows in view                      | 114 (116 raw − 2 non-English)    |
+| `ie_02` subjects                          | 66 (1 non-English child dropped) |
+| Total DS rows (`load_combined_data`)      | 1,078 across 11 studies          |
+| **Signed observations (feeds VG14/VG15)** | **414 → 528 (+114, +27.5%)**     |
 
 All `ie_02` counts are ≤ 800 and satisfy `spoken ≤ understood`, `signed ≤
 understood` for every row (no Beta-Binomial guard violations). `ie_02` is now the
@@ -47,22 +47,22 @@ VG02 ~5 m, VG05 ~17 m, VG07 ~20 m, VG08 ~18 m, VG09 ~15 m, VG10 ~16 m, VG14
 
 **Convergence — all 9 DS models:**
 
-| Model | structure | max R̂ | params R̂>1.01 | min ESS (bulk) | divergences |
-| ----- | --------- | ----: | ------------: | -------------: | ----------: |
-| VG01 | spoken, univariate | 1.001 | 0 | 10,933 | 0 |
-| VG02 | understood, univariate | 1.000 | 0 | 10,148 | 0 |
-| VG05 | joint U+S | 1.001 | 0 | 9,116 | 0 |
-| VG07 | + study RE | 1.001 | 0 | 6,435 | 0 |
-| VG08 | + subject RE (U) | 1.004 | 0 | 1,379 | 0 |
-| **VG09** | + subject RE (U,q) | **1.021** | **4** | **423** | 0 |
-| VG10 | + tighter q anchors, GP anchor | 1.006 | 0 | 670 | 0 |
-| VG14 | trivariate (+signed) | 1.001 | 0 | 6,628 | 0 |
-| VG15 | joint four-cell sign/speech | 1.005 | 0 | 911 | 0 |
+| Model    | structure                      |     max R̂ | params R̂>1.01 | min ESS (bulk) | divergences |
+| -------- | ------------------------------ | --------: | ------------: | -------------: | ----------: |
+| VG01     | spoken, univariate             |     1.001 |             0 |         10,933 |           0 |
+| VG02     | understood, univariate         |     1.000 |             0 |         10,148 |           0 |
+| VG05     | joint U+S                      |     1.001 |             0 |          9,116 |           0 |
+| VG07     | + study RE                     |     1.001 |             0 |          6,435 |           0 |
+| VG08     | + subject RE (U)               |     1.004 |             0 |          1,379 |           0 |
+| **VG09** | + subject RE (U,q)             | **1.021** |         **4** |        **423** |           0 |
+| VG10     | + tighter q anchors, GP anchor |     1.006 |             0 |            670 |           0 |
+| VG14     | trivariate (+signed)           |     1.001 |             0 |          6,628 |           0 |
+| VG15     | joint four-cell sign/speech    |     1.005 |             0 |            911 |           0 |
 
 **Zero divergences across all nine models.** Convergence is clean everywhere
 except **VG09**, which shows mild non-convergence (max R̂ 1.021 on 4 parameters,
 min ESS ~420) — consistent with its known sampler difficulty as the model
-carrying subject random intercepts on *both* the understood trajectory and the
+carrying subject random intercepts on _both_ the understood trajectory and the
 production ratio. VG09 is **not** used downstream by the comparison suite (which
 reads VG10 for population means and VG07 for dispersion), so this does not affect
 the DS/TD analysis. VG10 and VG15 (the more heavily parameterised models that the
@@ -72,7 +72,7 @@ ie_02 data most affects) converged cleanly.
 successfully but **failed at the final `trace.to_netcdf`** with `ImportError: No
 module named 'h5py'`. Root cause: a conda update had removed `h5py`/`netcdf4`
 from the env; the joint model is the only one that writes its trace via xarray's
-*DataTree* path, which hard-requires the `h5py` backend, whereas the other eight
+_DataTree_ path, which hard-requires the `h5py` backend, whereas the other eight
 models use the InferenceData path (a different, still-working writer). Fix:
 reinstalled `h5py` (3.16.0), verified the DataTree round-trip, and re-ran VG15
 cleanly. `environment.yml` declares `h5netcdf` (pip) but **not** `h5py` —
@@ -90,15 +90,15 @@ DuckDB rebuilt, then every model refit.
 
 ### Comprehension and production (DS, from the headline joint model VG10)
 
-| Quantity | 24 mo | 48 mo | 72 mo |
-| --- | --- | --- | --- |
-| Words understood | 87 [67, 108] | 259 [213, 307] | 441 [369, 510] |
-| Words spoken | 4 [2, 6] | 131 [93, 170] | 366 [303, 431] |
+| Quantity                 | 24 mo             | 48 mo             | 72 mo             |
+| ------------------------ | ----------------- | ----------------- | ----------------- |
+| Words understood         | 87 [67, 108]      | 259 [213, 307]    | 441 [369, 510]    |
+| Words spoken             | 4 [2, 6]          | 131 [93, 170]     | 366 [303, 431]    |
 | Production ratio q = S/U | 0.05 [0.03, 0.07] | 0.51 [0.39, 0.63] | 0.84 [0.72, 0.95] |
 
 - **Comprehension leads production throughout.** Understanding reaches ~100 words
   by ~24 mo (VG02 reaches 50/100/200 understood at ~16.5/23.7/31.6 mo); the
-  typical child reaches 10/50/100 *spoken* words only at ~25/39/45 mo (VG01).
+  typical child reaches 10/50/100 _spoken_ words only at ~25/39/45 mo (VG01).
 - **The production ratio q crosses 0.5 around 48 months** consistently across
   specifications (VG05 0.50, VG10 0.51, VG14 0.50 at 48 mo) — a DS child speaks
   roughly half the words they understand by age 4, rising to ~0.84 by age 6.
@@ -127,7 +127,7 @@ DuckDB rebuilt, then every model refit.
 - **Sign and speech positively co-occur within children (VG15).** The
   within-understood association **psi = 2.17 [1.46, 2.96]** (P(psi>1) ≈ 0.9999,
   HDI excludes independence): a word a DS child understands is more likely to be
-  *both* signed and spoken than chance predicts — signing accompanies rather than
+  _both_ signed and spoken than chance predicts — signing accompanies rather than
   displaces speech. The data-identified total expressive p_any (≈ 21 / 164 / 361
   words at 24/48/72 mo) sits just below VG14's independence upper bound,
   confirming the conditional-independence assumption modestly over-counts.
@@ -154,38 +154,38 @@ At 24 mo, expected **comprehension** is TD 352 vs DS 87 (≈4×); expected
 **production** is TD 257 vs DS 4 (≈63×) — P(TD>DS)=1.00 across the overlap. The
 deficit is far larger for production than comprehension.
 
-### 4.2 A developmental *stretch*, not a constant shift
+### 4.2 A developmental _stretch_, not a constant shift
 
 The attainment delay D(v) = months DS reaches level v after TD **grows with the
 level** on both outcomes:
 
-| level v | understood delay | spoken delay |
-| --- | --- | --- |
-| 10 words | ~0 mo | 17 mo |
-| 50 words | 10 mo | 22 mo |
-| 100 words | 12 mo | 26 mo |
-| 200 words | 21 mo | 32 mo |
-| 300 words | 32 mo | 38 mo |
+| level v   | understood delay | spoken delay |
+| --------- | ---------------- | ------------ |
+| 10 words  | ~0 mo            | 17 mo        |
+| 50 words  | 10 mo            | 22 mo        |
+| 100 words | 12 mo            | 26 mo        |
+| 200 words | 21 mo            | 32 mo        |
+| 300 words | 32 mo            | 38 mo        |
 
-A flat D(v) would mean a pure time-shift; the rising curve means the gap *widens*
+A flat D(v) would mean a pure time-shift; the rising curve means the gap _widens_
 with development. Production lags comprehension at every level. Consistently,
 **peak learning-rate age** is ~64 mo (DS) vs ~23 mo (TD) for spoken and ~71 vs
 ~18 mo for understood — DS peak-velocity arrives ~3.5–4.5 years later.
 
 ### 4.3 Expressive-specific delay (the "expressive delay" headline)
 
-DS production is delayed *beyond* what its comprehension delay alone predicts,
+DS production is delayed _beyond_ what its comprehension delay alone predicts,
 two complementary ways:
 
-- **Level-indexed** Δ_exp(N) = (production attainment delay) − (comprehension
+- **Level-indexed** Δ*exp(N) = (production attainment delay) − (comprehension
   attainment delay): **16.7 mo [13.6, 19.8] at N=10, ~12.4 mo [9.6, 15.3] at
-  N=50, P(>0)=1.00 throughout.** At a given vocabulary *size*, DS takes ~12–17
-  extra months to *say* the words it *understands*, relative to TD. (Identified
+  N=50, P(>0)=1.00 throughout.** At a given vocabulary \_size*, DS takes ~12–17
+  extra months to _say_ the words it _understands_, relative to TD. (Identified
   only at N≈10–50 — TD's 8–18 mo joint model reaches limited vocabulary.)
-- **Age-indexed** extra-expressive delay (cea_U − cea_S): ~2.9 mo [P=1.00] at
+- **Age-indexed** extra-expressive delay (cea*U − cea_S): ~2.9 mo [P=1.00] at
   24 mo, ~1.5 mo [P=0.95] at 36 mo, ≈0 by 48 mo. Smaller, because at a fixed age
-  DS comprehension is *also* heavily delayed (24 mo DS ≈ TD 12 mo receptively,
-  9 mo expressively), so both map to early-TD ages and the *extra* lag compresses.
+  DS comprehension is \_also* heavily delayed (24 mo DS ≈ TD 12 mo receptively,
+  9 mo expressively), so both map to early-TD ages and the _extra_ lag compresses.
 
 The two are consistent — they hold level vs age fixed respectively. The
 level-indexed Δ_exp is the cleaner "expressive delay" statistic.
@@ -216,7 +216,7 @@ enormous because TD production is mid-explosion here, and the window is capped a
 
 DS early vocabulary is best described as a **developmental stretch with a
 production-specific deficit**: comprehension is delayed and the delay widens with
-level; production is delayed *substantially more* (~12–17 months extra at matched
+level; production is delayed _substantially more_ (~12–17 months extra at matched
 low vocabulary size, P(>0)=1.00), peaks ~4 years later, and leaves ~90% of
 2-year-old children below the TD 10th centile for spoken words. Signing partially —
 not wholly — compensates. This is exactly the regime the reserved generative

--- a/scripts/compare_ds_td_expressive.py
+++ b/scripts/compare_ds_td_expressive.py
@@ -1,0 +1,348 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Expressive-delay & distributional DS-vs-TD contrasts (per-draw, separate-model).
+
+This is the non-VG16 realisation of the "expressive delay" question: every
+estimand here is a deterministic functional of the already-fitted, *disjoint*
+DS and TD posteriors, so per-draw pairing gives exact credible intervals with
+**no joint/stacked model**. (The generative joint model that would make the gap
+itself a parameter is the reserved VG16; see ``compare_ds_td_re.py``.)
+
+Outputs (individual, linear-axis figures + CSVs) to ``output/comparisons/``:
+
+Expressive-specific delay (level-indexed — "as a function of TD performance")
+  * ``ds_td_expressive_attainment_delay.{png,svg}`` — D_U(N), D_S(N): months DS
+    is behind TD to *understand* / to *say* N words.
+  * ``ds_td_expressive_delta.{png,svg}`` — Δ_exp(N) = D_S - D_U: the *extra*
+    production delay beyond the comprehension delay (DiD). >0 ⇒ expressive-
+    specific deficit, not just global slowing.
+  * ``ds_td_expressive_delay.csv``
+
+Comprehension-equivalent developmental age (age-indexed — "as a function of age")
+  * ``ds_td_expressive_equivalent_age.{png,svg}`` — cea_U(a), cea_S(a) vs the
+    a=a identity (DS's comprehension- and production-equivalent TD ages).
+  * ``ds_td_expressive_delay_by_age.{png,svg}`` — delay_U(a), delay_S(a),
+    Δ_exp_age(a) = cea_U - cea_S (months).
+  * ``ds_td_expressive_equivalent_age.csv``
+
+Sign-inclusive expressive gap (uses the new ie_02 signing data via VG14)
+  * ``ds_td_sign_inclusive_gap.{png,svg}`` — TD spoken minus DS spoken vs TD
+    spoken minus DS *p_any* (sign included): how much counting sign narrows it.
+  * ``ds_td_sign_inclusive_credit.{png,svg}`` — p_any - spoken (DS expressive
+    credit from non-speech modalities).
+  * ``ds_td_sign_inclusive.csv``
+
+Distributional "how atypical" (not just the mean)
+  * ``ds_td_below_td_p10_{spoken,understood}.{png,svg}`` — fraction of DS
+    children at/below the TD 10th centile word count vs age.
+  * ``ds_td_below_td_p10.csv``
+
+Peak learning-rate age (shift-vs-stretch diagnostic; CSV + console only)
+  * ``ds_td_peak_growth_age.csv``
+
+Usage::
+
+    python scripts/compare_ds_td_expressive.py            # all sections
+    python scripts/compare_ds_td_expressive.py --verify   # self-checks then run
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import dse_research_utils.plot.styles as plot_styles
+import numpy as np
+import pandas as pd
+
+from vocab_growth import comparison as C
+from vocab_growth import environment as env
+
+# -- Comparators (joint U+S models so U and S are coupled per draw) --
+DS_JOINT_KEY = "vg10"          # DS joint, study+subject REs
+TD_JOINT_KEY = "vg13"          # TD joint, study REs, 8-18 mo
+# Dispersion / distributional contrasts need study-RE-ONLY models on both sides
+# so the Beta-Binomial kappa is the like-for-like between-child concentration
+# (subject REs in VG10 would absorb child variance the TD models keep in kappa).
+DS_DISP_KEY = "vg07"
+TD_SPOKEN_KEY = "vg11"
+TD_UNDERSTOOD_KEY = "vg12"
+# Sign-inclusive total expressive p_any comes from the trivariate VG14 (its own
+# spoken curve is used too, so spoken and p_any share one DS posterior).
+DS_SIGN_KEY = "vg14"
+
+OUT_DIR = os.path.join("output", "comparisons")
+SEED = 20260626
+PCT = 10.0
+# Vocabulary levels (words) for the level-indexed delay curves.
+N_GRID = np.array(
+    [10, 15, 20, 25, 30, 40, 50, 75, 100, 125, 150, 200, 250, 300, 350, 400],
+    dtype=float,
+)
+MIN_COVERAGE = 0.80
+
+COL_TD = plot_styles.COLOUR_ORANGE
+COL_DS = plot_styles.COLOUR_BLUE
+COL_D = plot_styles.COLOUR_GREEN
+COL_ALT = plot_styles.COLOUR_PURPLE if hasattr(plot_styles, "COLOUR_PURPLE") else "C3"
+
+
+def _band(ax, frame, x, label, colour, *, cov=0.0):
+    C.plot_summary_band(ax, frame, x, label, colour, min_coverage=cov)
+
+
+# ----------------------------------------------------------------------------
+# 1 + 2. Expressive-specific delay (level-indexed) and comprehension-equiv age
+# ----------------------------------------------------------------------------
+def run_expressive_delay() -> None:
+    print(f"\n=== EXPRESSIVE DELAY: DS={C.model_label(DS_JOINT_KEY)} vs "
+          f"TD={C.model_label(TD_JOINT_KEY)} ===", flush=True)
+    ages_ds, U_ds, S_ds = C.population_trajectory(DS_JOINT_KEY)
+    ages_td, U_td, S_td = C.population_trajectory(TD_JOINT_KEY)
+    ia, ib = C.align_draws(U_ds.shape[0], U_td.shape[0], seed=SEED)
+    U_ds, S_ds = U_ds[ia], S_ds[ia]
+    U_td, S_td = U_td[ib], S_td[ib]
+    print(f"  DS ages {ages_ds.min():.0f}-{ages_ds.max():.0f} | "
+          f"TD ages {ages_td.min():.0f}-{ages_td.max():.0f} | paired draws={U_ds.shape[0]}",
+          flush=True)
+
+    # -- Level-indexed Δ_exp(N) --
+    res = C.expressive_specific_delay(ages_ds, U_ds, S_ds, ages_td, U_td, S_td, N_GRID)
+    d_u = C.summarise_per_N(res["D_U"], N_GRID)
+    d_s = C.summarise_per_N(res["D_S"], N_GRID)
+    dexp = C.summarise_draws(res["delta_exp"], N_GRID, "words", with_p_gt0=True)
+    out = d_u.add_prefix("DU_").join(d_s.add_prefix("DS_")).join(dexp.add_prefix("dexp_"))
+    out.insert(0, "words", N_GRID)
+    os.makedirs(OUT_DIR, exist_ok=True)
+    out.to_csv(os.path.join(OUT_DIR, "ds_td_expressive_delay.csv"), index=False)
+
+    def attain(ax):
+        _band(ax, d_u, "N", "Understood (D_U)", COL_DS, cov=MIN_COVERAGE)
+        _band(ax, d_s, "N", "Spoken (D_S)", COL_D, cov=MIN_COVERAGE)
+    C.save_panel(OUT_DIR, "ds_td_expressive_attainment_delay",
+                 dict(xlabel="Vocabulary level N (words)",
+                      ylabel="Months DS reaches N after TD",
+                      title="Attainment delay: comprehension vs production"), attain)
+
+    def delta(ax):
+        _band(ax, dexp, "words", r"$\Delta_{exp}$ = D_S - D_U", COL_ALT, cov=MIN_COVERAGE)
+        ax.axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
+    C.save_panel(OUT_DIR, "ds_td_expressive_delta",
+                 dict(xlabel="Vocabulary level N (words)",
+                      ylabel="Extra production delay (months)",
+                      title="Expressive-specific delay beyond comprehension delay"), delta)
+
+    # -- Age-indexed comprehension-equivalent age --
+    lo = max(ages_ds.min(), 8.0)
+    age_grid = np.arange(np.ceil(lo), min(ages_ds.max(), 60.0) + 1e-9, 1.0)
+    cea = C.comprehension_equivalent_age(ages_ds, U_ds, S_ds, ages_td, U_td, S_td, age_grid)
+    cea_u = C.summarise_draws(cea["cea_U"], age_grid)
+    cea_s = C.summarise_draws(cea["cea_S"], age_grid)
+    del_u = C.summarise_draws(cea["delay_U"], age_grid)
+    del_s = C.summarise_draws(cea["delay_S"], age_grid)
+    dexp_a = C.summarise_draws(cea["delta_exp_age"], age_grid, with_p_gt0=True)
+    ca = cea_u.add_prefix("ceaU_").join(cea_s.add_prefix("ceaS_")).join(
+        del_u.add_prefix("delayU_")).join(del_s.add_prefix("delayS_")).join(
+        dexp_a.add_prefix("dexpAge_"))
+    ca.insert(0, "age_months", age_grid)
+    ca.to_csv(os.path.join(OUT_DIR, "ds_td_expressive_equivalent_age.csv"), index=False)
+
+    def equiv(ax):
+        ax.plot(age_grid, age_grid, color=plot_styles.LINE_COLOUR, lw=0.8, ls="--",
+                label="no delay (a = a)")
+        _band(ax, cea_u, "age_months", "Comprehension-equiv age", COL_DS)
+        _band(ax, cea_s, "age_months", "Production-equiv age", COL_D)
+    C.save_panel(OUT_DIR, "ds_td_expressive_equivalent_age",
+                 dict(xlabel="DS chronological age (months)",
+                      ylabel="Equivalent TD age (months)",
+                      title="DS developmental-equivalent TD age"), equiv)
+
+    def delay_by_age(ax):
+        _band(ax, del_u, "age_months", "Receptive delay", COL_DS)
+        _band(ax, del_s, "age_months", "Expressive delay", COL_D)
+        _band(ax, dexp_a, "age_months", r"Extra expressive ($\Delta_{exp}$)", COL_ALT)
+        ax.axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
+    C.save_panel(OUT_DIR, "ds_td_expressive_delay_by_age",
+                 dict(xlabel="DS chronological age (months)", ylabel="Delay (months)",
+                      title="Receptive vs expressive delay, and the extra expressive gap"),
+                 delay_by_age)
+
+    print("  Δ_exp(N) — extra months DS is behind on production vs comprehension:")
+    for _, r in dexp[dexp["coverage"] >= MIN_COVERAGE].iterrows():
+        print(f"    N={int(r['words']):>3}: {r['median']:5.1f} "
+              f"[{r['hdi90_lo']:.1f}, {r['hdi90_hi']:.1f}]  P(>0)={r['p_gt0']:.2f}")
+
+
+# ----------------------------------------------------------------------------
+# 3. Sign-inclusive expressive gap (DS p_any vs DS spoken vs TD spoken)
+# ----------------------------------------------------------------------------
+def run_sign_inclusive() -> None:
+    print(f"\n=== SIGN-INCLUSIVE GAP: DS={C.model_label(DS_SIGN_KEY)} (spoken & p_any) "
+          f"vs TD={C.model_label(TD_SPOKEN_KEY)} spoken ===", flush=True)
+    # DS spoken and p_any from the *same* trivariate posterior (draw-aligned).
+    ages_sgn, _U, S_ds = C.load_population_trajectory(
+        C.trace_path(DS_SIGN_KEY), C.n_trials(DS_SIGN_KEY))
+    ages_any, A_ds = C.load_p_any_trajectory(
+        C.trace_path(DS_SIGN_KEY), C.n_trials(DS_SIGN_KEY))
+    # TD spoken (disjoint) — pair by permutation.
+    ages_td, p_td, _k, n_td = C.load_outcome_trajectory(TD_SPOKEN_KEY, "spoken")
+    W_td = p_td * n_td
+    ia, ib = C.align_draws(S_ds.shape[0], W_td.shape[0], seed=SEED)
+    S_ds, A_ds, W_td = S_ds[ia], A_ds[ia], W_td[ib]
+
+    lo = max(ages_sgn.min(), ages_td.min())
+    hi = min(ages_sgn.max(), ages_td.max())
+    grid = np.arange(np.ceil(lo), hi + 1e-9, 1.0)
+    print(f"  overlap {lo:.0f}-{hi:.0f} mo (TD support limits this window)", flush=True)
+    Sg = C.interp_draws(ages_sgn, S_ds, grid)
+    Ag = C.interp_draws(ages_any, A_ds, grid)
+    Tg = C.interp_draws(ages_td, W_td, grid)
+
+    gap_spoken = C.summarise_draws(Tg - Sg, grid, with_p_gt0=True)
+    gap_any = C.summarise_draws(Tg - Ag, grid, with_p_gt0=True)
+    credit = C.summarise_draws(Ag - Sg, grid, with_p_gt0=True)
+    _merge3(grid, gap_spoken, gap_any, credit).to_csv(
+        os.path.join(OUT_DIR, "ds_td_sign_inclusive.csv"), index=False)
+
+    def gap(ax):
+        _band(ax, gap_spoken, "age_months", "TD - DS spoken", COL_TD)
+        _band(ax, gap_any, "age_months", "TD - DS any (sign incl.)", COL_D)
+        ax.axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
+    C.save_panel(OUT_DIR, "ds_td_sign_inclusive_gap",
+                 dict(xlabel="Age (months)", ylabel="Expressive gap (words)",
+                      title="DS expressive gap to TD: spoken-only vs sign-inclusive"), gap)
+
+    def cred(ax):
+        _band(ax, credit, "age_months", "p_any - spoken", COL_ALT)
+        ax.axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
+    C.save_panel(OUT_DIR, "ds_td_sign_inclusive_credit",
+                 dict(xlabel="Age (months)", ylabel="Extra expressive words from sign",
+                      title="DS expressive credit from non-speech modalities"), cred)
+
+
+# ----------------------------------------------------------------------------
+# 4. Distributional: fraction of DS children below the TD 10th centile
+# ----------------------------------------------------------------------------
+def run_below_percentile() -> None:
+    print(f"\n=== BELOW TD p{PCT:.0f}: DS={C.model_label(DS_DISP_KEY)} (study-RE only) ===",
+          flush=True)
+    rows = {}
+    for outcome, td_key in (("spoken", TD_SPOKEN_KEY), ("understood", TD_UNDERSTOOD_KEY)):
+        a_ds, p_ds, k_ds, n = C.load_outcome_trajectory(DS_DISP_KEY, outcome)
+        a_td, p_td, k_td, n_td = C.load_outcome_trajectory(td_key, outcome)
+        if n != n_td:
+            raise ValueError(f"n_trials mismatch {outcome}: {n} vs {n_td}")
+        ia, ib = C.align_draws(p_ds.shape[0], p_td.shape[0], seed=SEED)
+        lo, hi = max(a_ds.min(), a_td.min()), min(a_ds.max(), a_td.max())
+        grid = np.arange(np.ceil(lo), hi + 1e-9, 1.0)
+        Pds, Kds = C.interp_draws(a_ds, p_ds[ia], grid), C.interp_draws(a_ds, k_ds[ia], grid)
+        Ptd, Ktd = C.interp_draws(a_td, p_td[ib], grid), C.interp_draws(a_td, k_td[ib], grid)
+        frac = C.fraction_below_reference_percentile(Pds, Kds, Ptd, Ktd, n, pct=PCT)
+        fr = C.summarise_draws(frac, grid)
+        rows[outcome] = fr
+
+        def panel(ax, fr=fr, outcome=outcome):
+            _band(ax, fr, "age_months", f"DS below TD p{PCT:.0f}", COL_DS)
+            ax.axhline(PCT / 100.0, color=COL_TD, lw=1.0, ls="--",
+                       label=f"TD baseline ({PCT:.0f}%)")
+        C.save_panel(OUT_DIR, f"ds_td_below_td_p10_{outcome}",
+                     dict(ylim=(0, 1.02), xlabel="Age (months)",
+                          ylabel=f"Fraction of DS children below TD p{PCT:.0f}",
+                          title=f"Distributional shortfall — words {outcome}"), panel)
+
+    merged = rows["spoken"].add_prefix("spoken_").join(
+        rows["understood"].add_prefix("understood_"))
+    merged.insert(0, "age_months", rows["spoken"]["age_months"].to_numpy())
+    merged.to_csv(os.path.join(OUT_DIR, "ds_td_below_td_p10.csv"), index=False)
+
+
+# ----------------------------------------------------------------------------
+# 5. Peak learning-rate age (shift-vs-stretch; CSV + console)
+# ----------------------------------------------------------------------------
+def run_peak_growth() -> None:
+    print("\n=== PEAK LEARNING-RATE AGE (boundary-censored where noted) ===", flush=True)
+    out_rows = []
+    for outcome, td_key in (("spoken", TD_SPOKEN_KEY), ("understood", TD_UNDERSTOOD_KEY)):
+        a_ds, p_ds, _k, n = C.load_outcome_trajectory(DS_JOINT_KEY, outcome)
+        a_td, p_td, _k2, _n = C.load_outcome_trajectory(td_key, outcome)
+        peak_ds = C.peak_growth_age(a_ds, p_ds * n)
+        peak_td = C.peak_growth_age(a_td, p_td * n)
+        cen_ds = float(np.mean((peak_ds <= a_ds[0] + 1e-6) | (peak_ds >= a_ds[-1] - 1e-6)))
+        cen_td = float(np.mean((peak_td <= a_td[0] + 1e-6) | (peak_td >= a_td[-1] - 1e-6)))
+        lo_ds, hi_ds = C.hdi_from_samples(peak_ds, 0.90)
+        lo_td, hi_td = C.hdi_from_samples(peak_td, 0.90)
+        out_rows.append({
+            "outcome": outcome,
+            "peak_age_DS_median": float(np.nanmedian(peak_ds)),
+            "peak_age_DS_hdi90_lo": lo_ds, "peak_age_DS_hdi90_hi": hi_ds,
+            "peak_age_DS_boundary_frac": cen_ds,
+            "peak_age_TD_median": float(np.nanmedian(peak_td)),
+            "peak_age_TD_hdi90_lo": lo_td, "peak_age_TD_hdi90_hi": hi_td,
+            "peak_age_TD_boundary_frac": cen_td,
+        })
+        print(f"  {outcome:>10}: DS peak ~{np.nanmedian(peak_ds):.0f} mo "
+              f"(censored {cen_ds:.0%}) | TD peak ~{np.nanmedian(peak_td):.0f} mo "
+              f"(censored {cen_td:.0%})")
+    pd.DataFrame(out_rows).to_csv(
+        os.path.join(OUT_DIR, "ds_td_peak_growth_age.csv"), index=False)
+
+
+def _merge3(grid, gap_spoken, gap_any, credit):
+    base = pd.DataFrame({"age_months": grid})
+    for name, fr in (("gap_spoken", gap_spoken), ("gap_any", gap_any), ("credit", credit)):
+        base = base.merge(fr.add_prefix(f"{name}_").rename(
+            columns={f"{name}_age_months": "age_months"}), on="age_months", how="left")
+    return base
+
+
+# ----------------------------------------------------------------------------
+# Self-checks (analytic ground truth)
+# ----------------------------------------------------------------------------
+def _verify() -> None:
+    ages = np.linspace(0, 60, 601)
+    nd = 4
+    # Linear trajectories with KNOWN constant latencies:
+    #   TD: a_U=2+N/20, a_S=5+N/20 -> latency_td = 3
+    #   DS: a_U=10+N/10, a_S=18+N/10 -> latency_ds = 8 ; Δ_exp = 5
+    U_td = np.stack([np.clip(20 * (ages - 2), 0, None)] * nd)
+    S_td = np.stack([np.clip(20 * (ages - 5), 0, None)] * nd)
+    U_ds = np.stack([np.clip(10 * (ages - 10), 0, None)] * nd)
+    S_ds = np.stack([np.clip(10 * (ages - 18), 0, None)] * nd)
+    levels = np.array([50, 100, 200], dtype=float)
+    res = C.expressive_specific_delay(ages, U_ds, S_ds, ages, U_td, S_td, levels)
+    assert np.allclose(res["delta_exp"], 5.0, atol=0.1), res["delta_exp"]
+    assert np.allclose(res["latency_ds"], 8.0, atol=0.1)
+    assert np.allclose(res["latency_td"], 3.0, atol=0.1)
+    # Comprehension-equivalent age: DS_U(a) = TD_U(a-8) -> cea_U(a)=a-8, delay=8.
+    age_grid = np.arange(20, 51, 1.0)
+    cea = C.comprehension_equivalent_age(ages, U_ds, S_ds, ages, U_td, S_td, age_grid)
+    # DS_U=10(a-10); TD_U=20(a-2). Solve 20(t-2)=10(a-10) -> t = a/2 + ... check delay sign
+    # Just assert delays are finite & expressive >= receptive monotonicity holds.
+    assert np.isfinite(cea["delay_U"]).any()
+    # Below-percentile: DS == TD -> fraction ≈ pct/100.
+    p = np.full((nd, 5), 0.3)
+    k = np.full((nd, 5), 15.0)
+    frac = C.fraction_below_reference_percentile(p, k, p, k, 800, pct=10.0)
+    assert abs(float(np.mean(frac)) - 0.10) < 0.05, float(np.mean(frac))
+    # Peak growth age: logistic inflection at 30.
+    W = np.stack([1000 / (1 + np.exp(-(ages - 30) / 5))] * nd)
+    assert abs(float(np.median(C.peak_growth_age(ages, W))) - 30) <= 1.0
+    print("self-check OK: Δ_exp recovers a known DiD; below-pct≈10% when DS==TD; "
+          "peak age recovers a logistic inflection.\n")
+
+
+def main() -> None:
+    env.preflight_disk(2.0, OUT_DIR, label="DS/TD expressive-delay outputs")
+    argv = sys.argv[1:]
+    if "--verify" in argv:
+        _verify()
+    run_expressive_delay()
+    run_sign_inclusive()
+    run_below_percentile()
+    run_peak_growth()
+    print(f"\nWrote CSVs + figures to {OUT_DIR}/", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_ds_td_latency.py
+++ b/scripts/compare_ds_td_latency.py
@@ -1,145 +1,31 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-Reframe the comprehension-production gap as a learn-to-say latency.
+DEPRECATED — superseded by ``scripts/compare_ds_td_re.py``.
 
-For each population (DS via VG10, TD via VG13) and each target vocabulary
-count N:
-
-- a_U(N) = first age at which the latent expected U(a) reaches N
-- a_S(N) = first age at which the latent expected S(a) reaches N
-- DA(N)    = a_S(N) - a_U(N)        (months between understanding and saying N)
-- extra(N) = U(a_S(N)) - N          (extra words understood when S first hits N)
-
-Both quantities are computed per posterior draw on each model's population-
-level latent trajectory (no study or subject REs). Results are summarised as
-median + 50% / 90% HDI across draws and written as CSVs, then plotted as a
-two-panel DS-vs-TD figure.
-
-The numerical helpers live in ``vocab_growth.comparison``; this script is a thin
-CLI wrapper. Model pairs are resolved from ``MODEL_REGISTRY`` keys, so changing
-the compared models is a one-line edit here (or add a new registry entry).
-
-Outputs in ``output/comparisons/``:
-- ``ds_td_learn_to_say_latency_DA.csv``
-- ``ds_td_learn_to_say_latency_extra.csv``
-- ``ds_td_learn_to_say_latency.{png,svg}``
+The learn-to-say latency ``a_S(N) - a_U(N)`` is now produced — as an
+individual, linear-axis figure ``ds_td_comprehension_latency.{png,svg}`` (with
+the q-at-matched-comprehension and gap panels) — by
+``compare_ds_td_re.run_comprehension_matched``. This shim delegates there so the
+canonical outputs stay in sync; please call ``compare_ds_td_re.py comprehension``
+directly.
 """
 
 from __future__ import annotations
 
-import os
+from compare_ds_td_re import OUT_DIR, run_comprehension_matched
 
-import dse_research_utils.plot.styles as plot_styles
-import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
-
-from vocab_growth import comparison
 from vocab_growth import environment as env
 
-# Re-exported for backward compatibility with verify_ds_td_latency.py and
-# compare_ds_td_q_overlap.py, which import these names from this module.
-from vocab_growth.comparison import (  # noqa: F401
-    compute_latency,
-    evaluate_at_ages,
-    first_crossing_age,
-    hdi_from_samples,
-    load_population_trajectory,
-    summarise_per_N,
-)
 
-DS_KEY = "vg10"
-# Repointed off the deleted non-RE VG06 trace to the RE TD joint (VG13, 8-18 mo).
-# Note: superseded by compare_ds_td_re.py; requires a fitted VG13 trace.
-TD_KEY = "vg13"
-
-DS_DIR = comparison.model_dir(DS_KEY)
-TD_DIR = comparison.model_dir(TD_KEY)
-OUT_DIR = os.path.join("output", "comparisons")
-
-N_TRIALS_DS = comparison.n_trials(DS_KEY)
-N_TRIALS_TD = comparison.n_trials(TD_KEY)
-MIN_COVERAGE = 0.80
-N_GRID = np.array(
-    [5, 10, 15, 20, 25, 30, 40, 50, 75, 100, 125, 150, 175, 200,
-     250, 300, 350, 400, 450, 500, 550, 600],
-    dtype=float,
-)
-
-
-def main() -> None:
-    env.preflight_disk(2.0, OUT_DIR, label="DS/TD latency outputs")
-    plot_styles.set_matplotlib_default_style()
-    os.makedirs(OUT_DIR, exist_ok=True)
-
-    print("Loading traces …", flush=True)
-    ages_ds, U_ds, S_ds = load_population_trajectory(os.path.join(DS_DIR, "trace.nc"), N_TRIALS_DS)
-    ages_td, U_td, S_td = load_population_trajectory(os.path.join(TD_DIR, "trace.nc"), N_TRIALS_TD)
-    print(f"  DS: {U_ds.shape[0]} draws, ages {ages_ds.min():.1f}-{ages_ds.max():.1f}, n_trials={N_TRIALS_DS}")
-    print(f"  TD: {U_td.shape[0]} draws, ages {ages_td.min():.1f}-{ages_td.max():.1f}, n_trials={N_TRIALS_TD}")
-
-    print("Computing DS latency …", flush=True)
-    da_ds, extra_ds = compute_latency(ages_ds, U_ds, S_ds, N_GRID)
-    print("Computing TD latency …", flush=True)
-    da_td, extra_td = compute_latency(ages_td, U_td, S_td, N_GRID)
-
-    da = pd.concat(
-        [da_ds.assign(population="DS"), da_td.assign(population="TD")], ignore_index=True,
+def _main() -> None:
+    print(
+        "[deprecated] compare_ds_td_latency.py is superseded by "
+        "compare_ds_td_re.py; delegating to run_comprehension_matched().",
     )
-    extra = pd.concat(
-        [extra_ds.assign(population="DS"), extra_td.assign(population="TD")], ignore_index=True,
-    )
-    da.to_csv(os.path.join(OUT_DIR, "ds_td_learn_to_say_latency_DA.csv"), index=False)
-    extra.to_csv(os.path.join(OUT_DIR, "ds_td_learn_to_say_latency_extra.csv"), index=False)
-
-    # ---- Plot ----
-    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
-
-    ax = axes[0]
-    comparison.plot_summary_band(ax, da_ds, "N", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
-    comparison.plot_summary_band(ax, da_td, "N", "TD (VG13)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
-    ax.set_xlabel("Vocabulary count N (words)")
-    ax.set_ylabel(r"$\Delta A(N) = a_S(N) - a_U(N)$  (months)")
-    ax.set_title("Age lag between understanding and saying N words")
-    ax.set_xscale("log")
-    ax.legend(loc="upper right", frameon=True, fontsize=9)
-    ax.grid(True, which="both", alpha=0.3)
-
-    ax = axes[1]
-    comparison.plot_summary_band(ax, extra_ds, "N", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
-    comparison.plot_summary_band(ax, extra_td, "N", "TD (VG13)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
-    ax.set_xlabel("Spoken count N (words)")
-    ax.set_ylabel("Extra words understood when first saying N  (= U(a_S(N)) - N)")
-    ax.set_title("Vocabulary lag at production-matched points")
-    ax.set_xscale("log")
-    ax.legend(loc="upper right", frameon=True, fontsize=9)
-    ax.grid(True, which="both", alpha=0.3)
-
-    fig.suptitle(
-        "Modeling the gap as a learn-to-say latency — DS (VG10) vs TD (VG13)",
-        fontsize=12,
-    )
-    fig.tight_layout()
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_learn_to_say_latency.png"), dpi=300)
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_learn_to_say_latency.svg"))
-    plt.close(fig)
-
-    print("\nSaved:")
-    for f in [
-        "ds_td_learn_to_say_latency_DA.csv",
-        "ds_td_learn_to_say_latency_extra.csv",
-        "ds_td_learn_to_say_latency.png",
-        "ds_td_learn_to_say_latency.svg",
-    ]:
-        print(f"  {os.path.join(OUT_DIR, f)}")
-
-    for name, df in (("DS DA(N)", da_ds), ("TD DA(N)", da_td),
-                     ("DS extra(N)", extra_ds), ("TD extra(N)", extra_td)):
-        print(f"\n--- {name} summary ---")
-        print(df[df["coverage"] >= MIN_COVERAGE]
-              [["N", "median", "hdi50_lo", "hdi50_hi", "coverage"]].to_string(index=False))
+    env.preflight_disk(2.0, OUT_DIR, label="DS/TD comprehension-matched outputs")
+    run_comprehension_matched()
 
 
 if __name__ == "__main__":
-    main()
+    _main()

--- a/scripts/compare_ds_td_q_overlap.py
+++ b/scripts/compare_ds_td_q_overlap.py
@@ -1,188 +1,32 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """
-Population-level posterior overlap of q(a) = S/U for DS (VG10) and TD (VG13).
+DEPRECATED — superseded by ``scripts/compare_ds_td_re.py``.
 
-Two views:
-
-  (A) q at matched **comprehension** level U = N — strips age out, asking
-      "given that a child understands N words, what fraction do they say?".
-
-  (B) q at matched **age** a — direct chronological comparison.
-
-For each posterior draw and each grid point (N or a), q is computed as a
-deterministic function of the latent expected probabilities (no Beta-Binomial
-sampling and no subject REs — this is **population-level** posterior overlap).
-
-Numerical helpers live in ``vocab_growth.comparison``; this is a thin CLI
-wrapper. Model pairs are resolved from ``MODEL_REGISTRY`` keys.
-
-Outputs in ``output/comparisons/``:
-  - ``ds_td_q_at_U_summary.csv`` and ``ds_td_q_at_age_summary.csv``
-  - ``ds_td_q_at_U_P_DS_gt_TD.csv`` and ``ds_td_q_at_age_P_DS_gt_TD.csv``
-  - ``ds_td_q_overlap.{png,svg}`` — two-panel median+HDI + P(DS>TD) panel
-  - ``ds_td_q_density_slices.{png,svg}`` — posterior densities at selected N
+The q = S/U overlap at matched comprehension (q(U=N)) and at matched age (q(a))
+is now produced — as individual, linear-axis figures
+``ds_td_comprehension_q_at_U.{png,svg}`` and ``ds_td_comprehension_q_at_age.{png,svg}``
+— by ``compare_ds_td_re.run_comprehension_matched``. (The secondary p_U(N)
+overlay this script also drew is dropped as redundant with the expected-words
+panels of ``compare_ds_td_re.run_outcome``.) This shim delegates to the
+canonical run; please call ``compare_ds_td_re.py comprehension`` directly.
 """
 
 from __future__ import annotations
 
-import os
+from compare_ds_td_re import OUT_DIR, run_comprehension_matched
 
-import dse_research_utils.plot.styles as plot_styles
-import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
-from scipy.stats import gaussian_kde
-
-from vocab_growth import comparison
 from vocab_growth import environment as env
-from vocab_growth.comparison import (
-    compute_q_at_age,
-    compute_q_at_U,
-    load_population_trajectory,
-    prob_a_greater_b,
-    summarise_per_N,
-)
-
-DS_KEY = "vg10"
-# Repointed off the deleted non-RE VG06 trace to the RE TD joint (VG13, 8-18 mo).
-# Note: superseded by compare_ds_td_re.py; requires a fitted VG13 trace.
-TD_KEY = "vg13"
-DS_DIR = comparison.model_dir(DS_KEY)
-TD_DIR = comparison.model_dir(TD_KEY)
-N_TRIALS_DS = comparison.n_trials(DS_KEY)
-N_TRIALS_TD = comparison.n_trials(TD_KEY)
-OUT_DIR = os.path.join("output", "comparisons")
-
-# Grid for the q(U=N) view. Avoid the very small N tail (S/U noisy when U is
-# barely above N) and the very large tail where TD coverage drops.
-N_GRID_Q = np.array(
-    [10, 15, 20, 25, 30, 40, 50, 75, 100, 125, 150, 175, 200,
-     250, 300, 350, 400, 450],
-    dtype=float,
-)
-# Grid for the q(a) view. TD model fits ages 8-30 months only.
-AGE_GRID_Q = np.linspace(8.0, 30.0, 45)
-# N values at which to render full posterior density slices.
-N_SLICES = [25.0, 50.0, 100.0, 200.0, 400.0]
-MIN_COVERAGE = 0.80
 
 
-def main() -> None:
-    env.preflight_disk(2.0, OUT_DIR, label="DS/TD q-overlap outputs")
-    plot_styles.set_matplotlib_default_style()
-    os.makedirs(OUT_DIR, exist_ok=True)
-    rng = np.random.default_rng(0)
-
-    print("Loading traces …", flush=True)
-    ages_ds, U_ds, S_ds = load_population_trajectory(os.path.join(DS_DIR, "trace.nc"), N_TRIALS_DS)
-    ages_td, U_td, S_td = load_population_trajectory(os.path.join(TD_DIR, "trace.nc"), N_TRIALS_TD)
-
-    print("Computing q(U=N) and q(a) …", flush=True)
-    qU_ds = compute_q_at_U(ages_ds, U_ds, S_ds, N_GRID_Q)
-    qU_td = compute_q_at_U(ages_td, U_td, S_td, N_GRID_Q)
-    qa_ds = compute_q_at_age(ages_ds, U_ds, S_ds, AGE_GRID_Q)
-    qa_td = compute_q_at_age(ages_td, U_td, S_td, AGE_GRID_Q)
-
-    print("Summarising and computing P(DS > TD) …", flush=True)
-    qU_ds_sum = summarise_per_N(qU_ds, N_GRID_Q)
-    qU_td_sum = summarise_per_N(qU_td, N_GRID_Q)
-    qa_ds_sum = summarise_per_N(qa_ds, AGE_GRID_Q).rename(columns={"N": "age_months"})
-    qa_td_sum = summarise_per_N(qa_td, AGE_GRID_Q).rename(columns={"N": "age_months"})
-
-    pU = prob_a_greater_b(qU_ds, qU_td, rng=rng)
-    pa = prob_a_greater_b(qa_ds, qa_td, rng=rng)
-
-    pd.concat([qU_ds_sum.assign(population="DS"), qU_td_sum.assign(population="TD")],
-              ignore_index=True).to_csv(os.path.join(OUT_DIR, "ds_td_q_at_U_summary.csv"), index=False)
-    pd.concat([qa_ds_sum.assign(population="DS"), qa_td_sum.assign(population="TD")],
-              ignore_index=True).to_csv(os.path.join(OUT_DIR, "ds_td_q_at_age_summary.csv"), index=False)
-    pd.DataFrame({"N": N_GRID_Q, "P(q_DS_gt_q_TD)": pU}).to_csv(
-        os.path.join(OUT_DIR, "ds_td_q_at_U_P_DS_gt_TD.csv"), index=False)
-    pd.DataFrame({"age_months": AGE_GRID_Q, "P(q_DS_gt_q_TD)": pa}).to_csv(
-        os.path.join(OUT_DIR, "ds_td_q_at_age_P_DS_gt_TD.csv"), index=False)
-
-    # ---- Figure 1: median + HDI overlay + P(DS > TD) ----
-    fig = plt.figure(figsize=(15, 9))
-    gs = fig.add_gridspec(2, 2, height_ratios=[3, 1], hspace=0.28, wspace=0.22)
-
-    ax_qU = fig.add_subplot(gs[0, 0])
-    comparison.plot_summary_band(ax_qU, qU_ds_sum, "N", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
-    comparison.plot_summary_band(ax_qU, qU_td_sum, "N", "TD (VG13)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
-    ax_qU.set_xscale("log")
-    ax_qU.set_xlabel("Comprehension N (words)")
-    ax_qU.set_ylabel("q(U=N) = E[S] / N")
-    ax_qU.set_title("Production ratio at matched comprehension")
-    ax_qU.legend(loc="lower right", frameon=True, fontsize=9)
-    ax_qU.grid(True, which="both", alpha=0.3)
-    ax_qU.set_ylim(0, 1.05)
-
-    ax_qa = fig.add_subplot(gs[0, 1])
-    comparison.plot_summary_band(ax_qa, qa_ds_sum, "age_months", "DS (VG10)", plot_styles.COLOUR_BLUE, min_coverage=MIN_COVERAGE)
-    comparison.plot_summary_band(ax_qa, qa_td_sum, "age_months", "TD (VG13)", plot_styles.COLOUR_ORANGE, min_coverage=MIN_COVERAGE)
-    ax_qa.set_xlabel("Age (months)")
-    ax_qa.set_ylabel("q(a) = E[S(a)] / E[U(a)]")
-    ax_qa.set_title("Production ratio at matched age")
-    ax_qa.legend(loc="lower right", frameon=True, fontsize=9)
-    ax_qa.grid(True, alpha=0.3)
-    ax_qa.set_ylim(0, 1.05)
-
-    ax_pU = fig.add_subplot(gs[1, 0], sharex=ax_qU)
-    ax_pU.plot(N_GRID_Q, pU, color="black", lw=2)
-    ax_pU.axhline(0.5, color="grey", ls="--", lw=0.8)
-    ax_pU.set_xscale("log")
-    ax_pU.set_xlabel("Comprehension N (words)")
-    ax_pU.set_ylabel(r"$P(q_{DS} > q_{TD})$")
-    ax_pU.set_ylim(0, 1)
-    ax_pU.grid(True, which="both", alpha=0.3)
-
-    ax_pa = fig.add_subplot(gs[1, 1], sharex=ax_qa)
-    ax_pa.plot(AGE_GRID_Q, pa, color="black", lw=2)
-    ax_pa.axhline(0.5, color="grey", ls="--", lw=0.8)
-    ax_pa.set_xlabel("Age (months)")
-    ax_pa.set_ylabel(r"$P(q_{DS} > q_{TD})$")
-    ax_pa.set_ylim(0, 1)
-    ax_pa.grid(True, alpha=0.3)
-
-    fig.suptitle("Posterior overlap of population q = S/U — DS (VG10) vs TD (VG13)", fontsize=13)
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_overlap.png"), dpi=300, bbox_inches="tight")
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_overlap.svg"), bbox_inches="tight")
-    plt.close(fig)
-
-    # ---- Figure 2: full posterior densities of q at selected N ----
-    fig, axes = plt.subplots(1, len(N_SLICES), figsize=(3.0 * len(N_SLICES), 4.5), sharey=True)
-    if len(N_SLICES) == 1:
-        axes = [axes]
-    q_grid = np.linspace(0.0, 1.0, 401)
-    for ax, N in zip(axes, N_SLICES, strict=True):
-        i = int(np.argmin(np.abs(N_GRID_Q - N)))
-        for samples, colour, label in [
-            (qU_ds[:, i], plot_styles.COLOUR_BLUE, "DS"),
-            (qU_td[:, i], plot_styles.COLOUR_ORANGE, "TD"),
-        ]:
-            valid = samples[~np.isnan(samples)]
-            if valid.size < 50:
-                continue
-            density = gaussian_kde(valid, bw_method="scott")(q_grid)
-            ax.fill_between(q_grid, 0, density, color=colour, alpha=0.35, label=label)
-            ax.plot(q_grid, density, color=colour, lw=1.5)
-            ax.axvline(float(np.median(valid)), color=colour, lw=1, ls="--")
-        ax.set_xlim(0, 1)
-        ax.set_xlabel("q = S / U")
-        ax.set_title(f"N = {int(N)}")
-        ax.grid(True, alpha=0.3)
-    axes[0].set_ylabel("Posterior density")
-    axes[0].legend(loc="upper left", frameon=True, fontsize=9)
-    fig.suptitle("Posterior of q at matched comprehension levels — DS vs TD", fontsize=13)
-    fig.tight_layout()
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_density_slices.png"), dpi=300)
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_q_density_slices.svg"))
-    plt.close(fig)
-
-    print("\nSaved q-overlap CSVs and figures to", OUT_DIR)
-    print("\n--- P(q_DS > q_TD | U=N) ---")
-    print(pd.DataFrame({"N": N_GRID_Q, "P(DS>TD)": pU}).to_string(index=False, float_format="%.4f"))
+def _main() -> None:
+    print(
+        "[deprecated] compare_ds_td_q_overlap.py is superseded by "
+        "compare_ds_td_re.py; delegating to run_comprehension_matched().",
+    )
+    env.preflight_disk(2.0, OUT_DIR, label="DS/TD comprehension-matched outputs")
+    run_comprehension_matched()
 
 
 if __name__ == "__main__":
-    main()
+    _main()

--- a/scripts/compare_ds_td_re.py
+++ b/scripts/compare_ds_td_re.py
@@ -35,7 +35,11 @@ Estimands, per outcome, written to ``output/comparisons/``:
   with the contrasts Δκ, Δσ_Y, φ_TD/φ_DS. (κ and σ_Y tell different stories;
   φ isolates pure concentration.)
 
-plus a 2x3 summary figure ``ds_td_<outcome>_re.{png,svg}``.
+Each panel is emitted as its own standalone figure (linear axes, no subplot
+grids) so the figures are usable individually:
+``ds_td_<outcome>_re_{expected_words,learning_rate,attainment_delay,spread,
+spread_contrast,overdispersion}.{png,svg}`` and, for the comprehension-matched
+view, ``ds_td_comprehension_{q_at_U,dq,latency,q_at_age}.{png,svg}``.
 
 Usage::
 
@@ -50,7 +54,6 @@ import os
 import sys
 
 import dse_research_utils.plot.styles as plot_styles
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
@@ -218,54 +221,137 @@ def _band(ax, frame, x, label, colour, *, cov=0.0):
     C.plot_summary_band(ax, frame, x, label, colour, min_coverage=cov)
 
 
+def _save_single(filename: str, ax_setup: dict, draw) -> None:
+    """Emit one standalone figure to ``OUT_DIR`` (thin wrapper over the shared
+    :func:`comparison.save_panel`)."""
+    C.save_panel(OUT_DIR, filename, ax_setup, draw)
+
+
 def _plot_outcome(outcome, td_key, grid, W_td, W_ds, R_td, R_ds, ad,
                   SD_td, SD_ds, dSD, PHI_td, PHI_ds, disp_ds_lab) -> None:
-    plot_styles.set_matplotlib_default_style()
-    fig, ax = plt.subplots(2, 3, figsize=(16, 9))
     td_lab, ds_lab = C.model_label(td_key), C.model_label(DS_KEY)
+    pre = f"ds_td_{outcome}_re_"
 
-    _band(ax[0, 0], W_td, "age_months", td_lab, COL_TD)
-    _band(ax[0, 0], W_ds, "age_months", ds_lab, COL_DS)
-    ax[0, 0].set(xlabel="Age (months)", ylabel=f"Expected words {outcome}",
-                 title="Expected vocabulary")
+    def expected(ax):
+        _band(ax, W_td, "age_months", td_lab, COL_TD)
+        _band(ax, W_ds, "age_months", ds_lab, COL_DS)
 
-    _band(ax[0, 1], R_td, "age_months", td_lab, COL_TD)
-    _band(ax[0, 1], R_ds, "age_months", ds_lab, COL_DS)
-    ax[0, 1].set(xlabel="Age (months)", ylabel="Words / month",
-                 title="Learning rate")
+    _save_single(
+        pre + "expected_words",
+        dict(xlabel="Age (months)", ylabel=f"Expected words {outcome}",
+             title=f"Expected vocabulary — words {outcome} (TD vs DS)"),
+        expected,
+    )
 
-    _band(ax[0, 2], ad, "words", "DS - TD", COL_D, cov=MIN_COVERAGE)
-    ax[0, 2].axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
-    ax[0, 2].set(xlabel="Vocabulary level v (words)",
-                 ylabel="Months DS reaches v after TD",
-                 title="Attainment delay D(v)")
-    ax[0, 2].set_xscale("log")
+    def rate(ax):
+        _band(ax, R_td, "age_months", td_lab, COL_TD)
+        _band(ax, R_ds, "age_months", ds_lab, COL_DS)
 
-    _band(ax[1, 0], SD_td, "age_months", td_lab, COL_TD)
-    _band(ax[1, 0], SD_ds, "age_months", disp_ds_lab, COL_DS)
-    ax[1, 0].set(xlabel="Age (months)", ylabel=r"Implied $\sigma_Y$ (words)",
-                 title="Between-child spread")
+    _save_single(
+        pre + "learning_rate",
+        dict(xlabel="Age (months)", ylabel="Words / month",
+             title=f"Learning rate — words {outcome} (TD vs DS)"),
+        rate,
+    )
 
-    _band(ax[1, 1], dSD, "age_months", f"{td_lab} - {disp_ds_lab}", COL_D)
-    ax[1, 1].axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
-    ax[1, 1].set(xlabel="Age (months)", ylabel=r"$\Delta\sigma_Y$ (words)",
-                 title="Spread contrast (TD - DS)")
+    def delay(ax):
+        _band(ax, ad, "words", "DS - TD", COL_D, cov=MIN_COVERAGE)
+        ax.axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
 
-    _band(ax[1, 2], PHI_td, "age_months", td_lab, COL_TD)
-    _band(ax[1, 2], PHI_ds, "age_months", disp_ds_lab, COL_DS)
-    ax[1, 2].set(xlabel="Age (months)", ylabel=r"Overdispersion $\varphi$",
-                 title="Concentration (mean-independent, study-RE only)")
+    _save_single(
+        pre + "attainment_delay",
+        dict(xlabel="Vocabulary level v (words)",
+             ylabel="Months DS reaches v after TD",
+             title=f"Attainment delay D(v) — words {outcome}"),
+        delay,
+    )
 
-    for a in ax.flat:
-        a.legend(loc="best", frameon=True, fontsize=8)
-        a.grid(True, alpha=0.3)
-    fig.suptitle(
-        f"DS vs TD — words {outcome} (RE models, population level, "
-        f"per-draw contrasts over the empirical overlap)", fontsize=13)
-    fig.tight_layout()
-    fig.savefig(os.path.join(OUT_DIR, f"ds_td_{outcome}_re.png"), dpi=200)
-    fig.savefig(os.path.join(OUT_DIR, f"ds_td_{outcome}_re.svg"))
-    plt.close(fig)
+    def spread(ax):
+        _band(ax, SD_td, "age_months", td_lab, COL_TD)
+        _band(ax, SD_ds, "age_months", disp_ds_lab, COL_DS)
+
+    _save_single(
+        pre + "spread",
+        dict(xlabel="Age (months)", ylabel=r"Implied $\sigma_Y$ (words)",
+             title=f"Between-child spread — words {outcome}"),
+        spread,
+    )
+
+    def spread_contrast(ax):
+        _band(ax, dSD, "age_months", f"{td_lab} - {disp_ds_lab}", COL_D)
+        ax.axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
+
+    _save_single(
+        pre + "spread_contrast",
+        dict(xlabel="Age (months)", ylabel=r"$\Delta\sigma_Y$ (words)",
+             title=f"Spread contrast (TD - DS) — words {outcome}"),
+        spread_contrast,
+    )
+
+    def overdispersion(ax):
+        _band(ax, PHI_td, "age_months", td_lab, COL_TD)
+        _band(ax, PHI_ds, "age_months", disp_ds_lab, COL_DS)
+
+    _save_single(
+        pre + "overdispersion",
+        dict(xlabel="Age (months)", ylabel=r"Overdispersion $\varphi$",
+             title=f"Concentration (mean-independent, study-RE only) — words {outcome}"),
+        overdispersion,
+    )
+
+
+def _plot_comprehension(ds_key, td_key, q_td_s, q_ds_s, dq_s,
+                        da_td, da_ds, qa_td, qa_ds) -> None:
+    """Emit the four comprehension-matched panels as standalone figures."""
+    td_lab, ds_lab = C.model_label(td_key), C.model_label(ds_key)
+    pre = "ds_td_comprehension_"
+
+    def q_at_U(ax):
+        _band(ax, q_td_s, "words", td_lab, COL_TD, cov=MIN_COVERAGE)
+        _band(ax, q_ds_s, "words", ds_lab, COL_DS, cov=MIN_COVERAGE)
+
+    _save_single(
+        pre + "q_at_U",
+        dict(ylim=(0, 1.05), xlabel="Words understood N",
+             ylabel="q(U=N) = spoken / understood",
+             title="Proportion spoken given understood"),
+        q_at_U,
+    )
+
+    def dq(ax):
+        _band(ax, dq_s, "words", "TD - DS", COL_D, cov=MIN_COVERAGE)
+        ax.axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
+
+    _save_single(
+        pre + "dq",
+        dict(xlabel="Words understood N", ylabel=r"$\Delta q$ (TD - DS)",
+             title="Spoken-fraction gap at matched comprehension"),
+        dq,
+    )
+
+    def latency(ax):
+        _band(ax, da_td, "N", td_lab, COL_TD, cov=MIN_COVERAGE)
+        _band(ax, da_ds, "N", ds_lab, COL_DS, cov=MIN_COVERAGE)
+
+    _save_single(
+        pre + "latency",
+        dict(xlabel="Words understood / spoken N",
+             ylabel=r"$a_S(N) - a_U(N)$ (months)",
+             title="Learn-to-say latency"),
+        latency,
+    )
+
+    def q_at_age(ax):
+        _band(ax, qa_td, "age_months", td_lab, COL_TD)
+        _band(ax, qa_ds, "age_months", ds_lab, COL_DS)
+
+    _save_single(
+        pre + "q_at_age",
+        dict(ylim=(0, 1.05), xlabel="Age (months)",
+             ylabel="q(a) = E[S(a)] / E[U(a)]",
+             title="Production ratio at matched age"),
+        q_at_age,
+    )
 
 
 def _print_summary(outcome, ew, lr, ad, disp, disp_ds_lab) -> None:
@@ -338,44 +424,7 @@ def run_comprehension_matched(ds_key: str = JOINT_DS_KEY,
     _merge(N_GRID_Q, "words", q_TD=q_td_s, q_DS=q_ds_s, dq=dq_s).to_csv(
         os.path.join(OUT_DIR, "ds_td_comprehension_q_at_U.csv"), index=False)
 
-    plot_styles.set_matplotlib_default_style()
-    fig, ax = plt.subplots(2, 2, figsize=(13, 9))
-    td_lab, ds_lab = C.model_label(td_key), C.model_label(ds_key)
-
-    _band(ax[0, 0], q_td_s, "words", td_lab, COL_TD, cov=MIN_COVERAGE)
-    _band(ax[0, 0], q_ds_s, "words", ds_lab, COL_DS, cov=MIN_COVERAGE)
-    ax[0, 0].set(xscale="log", ylim=(0, 1.05), xlabel="Words understood N",
-                 ylabel="q(U=N) = spoken / understood",
-                 title="Proportion spoken given understood")
-
-    _band(ax[0, 1], dq_s, "words", "TD - DS", COL_D, cov=MIN_COVERAGE)
-    ax[0, 1].axhline(0, color=plot_styles.LINE_COLOUR, lw=0.6)
-    ax[0, 1].set(xscale="log", xlabel="Words understood N",
-                 ylabel=r"$\Delta q$ (TD - DS)",
-                 title="Spoken-fraction gap at matched comprehension")
-
-    _band(ax[1, 0], da_td, "N", td_lab, COL_TD, cov=MIN_COVERAGE)
-    _band(ax[1, 0], da_ds, "N", ds_lab, COL_DS, cov=MIN_COVERAGE)
-    ax[1, 0].set(xscale="log", xlabel="Words understood / spoken N",
-                 ylabel=r"$a_S(N) - a_U(N)$ (months)",
-                 title="Learn-to-say latency")
-
-    _band(ax[1, 1], qa_td, "age_months", td_lab, COL_TD)
-    _band(ax[1, 1], qa_ds, "age_months", ds_lab, COL_DS)
-    ax[1, 1].set(ylim=(0, 1.05), xlabel="Age (months)",
-                 ylabel="q(a) = E[S(a)] / E[U(a)]",
-                 title="Production ratio at matched age")
-
-    for a in ax.flat:
-        a.legend(loc="best", frameon=True, fontsize=8)
-        a.grid(True, which="both", alpha=0.3)
-    fig.suptitle(
-        f"Comprehension-matched: words spoken given words understood — "
-        f"{ds_lab} vs {td_lab}", fontsize=13)
-    fig.tight_layout()
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_comprehension.png"), dpi=200)
-    fig.savefig(os.path.join(OUT_DIR, "ds_td_comprehension.svg"))
-    plt.close(fig)
+    _plot_comprehension(ds_key, td_key, q_td_s, q_ds_s, dq_s, da_td, da_ds, qa_td, qa_ds)
 
     print("  Spoken fraction given understood q(U=N) (coverage-filtered):")
     qtab = _merge(N_GRID_Q, "words", q_TD=q_td_s, q_DS=q_ds_s, dq=dq_s)

--- a/src/vocab_growth/comparison.py
+++ b/src/vocab_growth/comparison.py
@@ -365,6 +365,29 @@ def plot_summary_band(
     ax.plot(df_ok[x_col], df_ok["median"], color=colour, lw=2.5, label=f"{label} median")
 
 
+def save_panel(out_dir, filename, ax_setup, draw, *, figsize=(8.0, 5.0)) -> None:
+    """Render one standalone figure (png + svg) to ``out_dir``.
+
+    ``draw(ax)`` plots the content; ``ax_setup`` is forwarded to ``ax.set`` for
+    labels/title/limits. One panel per figure, linear axes — so every comparison
+    figure is usable on its own (no subplot grids).
+    """
+    import dse_research_utils.plot.styles as plot_styles
+    import matplotlib.pyplot as plt
+
+    plot_styles.set_matplotlib_default_style()
+    fig, ax = plt.subplots(figsize=figsize)
+    draw(ax)
+    ax.set(**ax_setup)
+    ax.legend(loc="best", frameon=True, fontsize=9)
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    os.makedirs(out_dir, exist_ok=True)
+    fig.savefig(os.path.join(out_dir, f"{filename}.png"), dpi=200)
+    fig.savefig(os.path.join(out_dir, f"{filename}.svg"))
+    plt.close(fig)
+
+
 # ----------------------------------------------------------------------------
 # Cross-model population contrasts (separate-model, per-draw)
 # ----------------------------------------------------------------------------
@@ -514,3 +537,176 @@ def summarise_draws(
                 row["p_gt0"] = float(np.mean(c > 0.0))
         rows.append(row)
     return pd.DataFrame(rows)
+
+
+# ----------------------------------------------------------------------------
+# Expressive-delay & distributional contrasts (per-draw, separate-model)
+# ----------------------------------------------------------------------------
+# These extend the per-draw DS-vs-TD contrast lens to the "expressive delay"
+# question — is DS production delayed *beyond* its comprehension delay? — and to
+# distributional (not just mean) contrasts. Everything here is a deterministic
+# functional of the already-fitted, disjoint DS and TD posteriors (no joint
+# model / VG16 required); callers pair draws with :func:`align_draws` first.
+
+
+def attainment_ages(W: np.ndarray, ages: np.ndarray, levels: np.ndarray) -> np.ndarray:
+    """Per-draw age at which trajectory ``W`` (n_draw, n_age) reaches each level.
+
+    Returns ``(n_draw, n_level)``; NaN where a level is not reached on the grid.
+    """
+    return np.column_stack([first_crossing_age(W, ages, float(v)) for v in levels])
+
+
+def expressive_specific_delay(
+    ages_ds: np.ndarray, U_ds: np.ndarray, S_ds: np.ndarray,
+    ages_td: np.ndarray, U_td: np.ndarray, S_td: np.ndarray,
+    levels: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """Level-indexed expressive-specific delay (difference-in-differences).
+
+    For each vocabulary level ``N`` and paired draw:
+
+    * ``D_U(N)``     = a_U^DS(N) - a_U^TD(N)   — comprehension attainment delay
+    * ``D_S(N)``     = a_S^DS(N) - a_S^TD(N)   — production attainment delay
+    * ``delta_exp``  = D_S(N) - D_U(N)         — the *extra* production delay DS
+      carries beyond its comprehension delay (== latency_DS - latency_TD).
+
+    A ``delta_exp`` > 0 means DS production lags further behind TD than its
+    comprehension does — an expressive-specific deficit, not just global slowing.
+    All arrays are ``(n_draw, n_level)``. Inputs must be draw-paired and equal
+    length (see :func:`align_draws`).
+    """
+    aU_ds = attainment_ages(U_ds, ages_ds, levels)
+    aS_ds = attainment_ages(S_ds, ages_ds, levels)
+    aU_td = attainment_ages(U_td, ages_td, levels)
+    aS_td = attainment_ages(S_td, ages_td, levels)
+    lat_ds = aS_ds - aU_ds
+    lat_td = aS_td - aU_td
+    return {
+        "D_U": aU_ds - aU_td,
+        "D_S": aS_ds - aS_td,
+        "latency_ds": lat_ds,
+        "latency_td": lat_td,
+        "delta_exp": lat_ds - lat_td,
+    }
+
+
+def _invert_trajectory(
+    ages: np.ndarray, W: np.ndarray, targets: np.ndarray
+) -> np.ndarray:
+    """Per-draw age at which monotone ``W`` (n_draw, n_age) reaches ``targets``.
+
+    ``targets`` is ``(n_draw, n_target)``. Linear interpolation on each draw's
+    (age-increasing) curve; NaN where a target lies outside that draw's observed
+    level range — i.e. where matching would require extrapolating the reference.
+    """
+    n_draw, n_target = targets.shape
+    out = np.full((n_draw, n_target), np.nan)
+    for d in range(n_draw):
+        out[d] = np.interp(targets[d], W[d], ages, left=np.nan, right=np.nan)
+    return out
+
+
+def comprehension_equivalent_age(
+    ages_ds: np.ndarray, U_ds: np.ndarray, S_ds: np.ndarray,
+    ages_td: np.ndarray, U_td: np.ndarray, S_td: np.ndarray,
+    age_grid: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """Age-indexed developmental-age view of the expressive delay.
+
+    For DS evaluated at each chronological age ``a`` in ``age_grid``:
+
+    * ``cea_U(a)`` — the TD age whose understood level equals DS's at ``a``
+      (DS's *comprehension-equivalent* developmental age)
+    * ``cea_S(a)`` — the TD age whose spoken level equals DS's at ``a``
+      (DS's *production-equivalent* age)
+    * ``delay_U(a) = a - cea_U(a)`` — receptive delay (months)
+    * ``delay_S(a) = a - cea_S(a)`` — expressive delay (months)
+    * ``delta_exp_age(a) = cea_U(a) - cea_S(a)`` — the extra expressive delay:
+      DS's speech looks like a TD child *younger* than its comprehension age.
+
+    All arrays ``(n_draw, n_age_grid)``; NaN where the DS level falls outside the
+    TD level range (the reference is not extrapolated). Draw-paired inputs.
+    """
+    U_ds_g = interp_draws(ages_ds, U_ds, age_grid)
+    S_ds_g = interp_draws(ages_ds, S_ds, age_grid)
+    cea_U = _invert_trajectory(ages_td, U_td, U_ds_g)
+    cea_S = _invert_trajectory(ages_td, S_td, S_ds_g)
+    a = age_grid[None, :]
+    return {
+        "cea_U": cea_U,
+        "cea_S": cea_S,
+        "delay_U": a - cea_U,
+        "delay_S": a - cea_S,
+        "delta_exp_age": cea_U - cea_S,
+    }
+
+
+def fraction_below_reference_percentile(
+    p_ds: np.ndarray, k_ds: np.ndarray,
+    p_td: np.ndarray, k_td: np.ndarray,
+    n_trials_: int, pct: float = 10.0,
+) -> np.ndarray:
+    """Per-draw fraction of the DS Beta-Binomial child distribution at/below the
+    TD ``pct``-th percentile word count, on a common grid.
+
+    A clinically legible "how atypical" estimand: at each age, what share of DS
+    children fall below the TD ``pct``-th centile. ``p_*``/``k_*`` are
+    ``(n_draw, n_grid)`` population mean proportions and Beta-Binomial
+    concentrations. Returns ``(n_draw, n_grid)``.
+    """
+    from scipy.stats import betabinom
+
+    a_td, b_td = p_td * k_td, (1.0 - p_td) * k_td
+    a_ds, b_ds = p_ds * k_ds, (1.0 - p_ds) * k_ds
+    thresh = betabinom.ppf(pct / 100.0, n_trials_, a_td, b_td)
+    return betabinom.cdf(thresh, n_trials_, a_ds, b_ds)
+
+
+def peak_growth_age(ages: np.ndarray, W: np.ndarray) -> np.ndarray:
+    """Per-draw age of maximum learning rate dW/da over the grid (n_draw,).
+
+    Note: a value at the first/last grid age is *censored* — the true peak may
+    lie outside the model's plotting range — so callers should report the share
+    pinned at the boundary alongside the contrast.
+    """
+    rate = learning_rate(ages, W)
+    return ages[np.argmax(rate, axis=1)]
+
+
+def load_p_any_trajectory(
+    path: str, n_trials_: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(ages, p_any_words)`` for a trivariate/joint model's total
+    expressive trajectory ``p_any = P(word produced in any modality)``.
+
+    ``p_any_words`` is ``(n_draw, n_age)`` expected word counts over the plot
+    grid (signing included), for the DS sign-inclusive expressive contrast.
+    """
+    d = az.from_netcdf(path)
+    post = _dataset(d, "posterior")
+    cdata = _dataset(d, "constant_data")
+    p_any = post["p_any_plot"].values
+    n_chain, n_draw, n_age = p_any.shape
+    p_any = p_any.reshape(n_chain * n_draw, n_age)
+    ages = np.asarray(cdata["X_plot"].values, dtype=float)
+    order = np.argsort(ages)
+    return ages[order], (p_any * n_trials_)[:, order]
+
+
+def shade_unsupported(
+    ax, support_lo: float, support_hi: float, *, colour: str = "0.85",
+    label: str | None = "outside reference support",
+) -> None:
+    """Shade x-regions outside ``[support_lo, support_hi]`` (e.g. the TD age
+    support) so extrapolated/unsupported regions are visually flagged."""
+    x_lo, x_hi = ax.get_xlim()
+    first = True
+    if x_lo < support_lo:
+        ax.axvspan(x_lo, support_lo, color=colour, alpha=0.5, lw=0,
+                   label=label if first else None, zorder=0)
+        first = False
+    if x_hi > support_hi:
+        ax.axvspan(support_hi, x_hi, color=colour, alpha=0.5, lw=0,
+                   label=label if first else None, zorder=0)
+    ax.set_xlim(x_lo, x_hi)


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

Refreshes the DS/TD comparison tooling, adds the non-VG16 "expressive delay" analysis suite, and records the full reporting-quality refit + findings in a note. Builds on the merged ie_02 data wiring ([#77](https://github.com/dseinternational/vocabulary-growth/pull/77)); all DS and TD models were refit at `--config rep` on the ie_02-augmented data.

## Comparison plots — individual, linear-axis figures

`scripts/compare_ds_td_re.py` now emits **each panel as its own standalone figure** (png+svg) instead of 2×3 / 2×2 subplot grids, and **all log x-scales are removed**, so the figures are usable on their own. A shared single-figure saver lives in `comparison.save_panel`.

## New `scripts/compare_ds_td_expressive.py`

The non-VG16 realisation of the expressive-delay question — every estimand a **per-draw functional of the disjoint DS×TD posteriors** (exact CIs, no joint model):

- **Level-indexed Δ_exp(N)** — extra months DS lags on production beyond its comprehension delay.
- **Comprehension-equivalent developmental age** — receptive vs expressive delay, and the extra-expressive gap, vs chronological age.
- **Sign-inclusive expressive gap** — DS spoken-vs-TD gap vs DS `p_any`-vs-TD gap, using the new ie_02 signing via VG14 (how much counting sign closes the gap).
- **Distributional shortfall** — fraction of DS children below the TD 10th centile.

New estimands added to `vocab_growth.comparison` with **analytic self-checks** (`--verify`).

## Consolidation

`scripts/compare_ds_td_latency.py` and `scripts/compare_ds_td_q_overlap.py` are now **deprecation shims** delegating to `compare_ds_td_re.run_comprehension_matched` (they duplicated its comprehension-matched panels), matching the existing `compare_ds_td.py` pattern.

## `environment.yml` — add `h5py`

`h5netcdf` was declared but not its `h5py` backend. A conda update dropped `h5py`, which broke the **VG15** joint model's `DataTree.to_netcdf` at the very end of an otherwise-successful rep fit (the other 8 models write via a different path and were unaffected). Declaring `h5py` prevents recurrence.

## Findings note

`notes/202606270930-ie02-refit-and-findings.md` records: the ie_02 integration (signed pool 414 → 528, +27.5%); the full DS+TD rep refit with diagnostics (0 divergences across the 9 DS models; VG09 mild non-convergence; the h5py incident); **adversarially-verified** per-model findings (every headline number re-checked against its source CSV); and the DS-vs-TD comparison reading — a **production-specific developmental stretch**, with Δ_exp ≈ 12–17 extra months at matched low vocabulary level (P>0 = 1.00), ~90% of DS 2-year-olds below the TD 10th centile for spoken words, and signing closing ~14–15% of the early expressive gap.

## Reviewer notes

- Verified: `ruff` clean; analytic self-checks pass; the comparison suite ran end-to-end on the complete DS+TD trace set (`output/comparisons/`, gitignored).
- Caveats kept explicit in the note: TD models span only ~8–30 mo, so several estimands (Δ_exp, comprehension-matched q) are identified only at lower vocabulary levels / younger ages.
