### PR TITLE
Switch model report templates to PNG figures

### DIFF
--- a/docs/models/vg01/index.qmd
+++ b/docs/models/vg01/index.qmd
@@ -45,35 +45,35 @@ For full details and discussion, please refer to the technical report.
 
 ### Lengthscale
 
-![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.svg){#fig-lengthscale .lightbox fig-align="left"}
+![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.png){#fig-lengthscale .lightbox fig-align="left"}
 
 ### Amplitude
 
-![Amplitude prior distribution `eta_dist`](eta_dist.svg){#fig-amplitude .lightbox fig-align="left"}
+![Amplitude prior distribution `eta_dist`](eta_dist.png){#fig-amplitude .lightbox fig-align="left"}
 
 ### Slope
 
 #### Low slope anchor (24 months)
 
-![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.svg){#fig-slope-low .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.png){#fig-slope-low .lightbox fig-align="left"}
 
 #### High slope anchor (84 months)
 
-![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.svg){#fig-slope-hi .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.png){#fig-slope-hi .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion
 
-![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.svg){#fig-kappa-min .lightbox fig-align="left"}
+![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.png){#fig-kappa-min .lightbox fig-align="left"}
 
-![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.svg){#fig-a-kappa .lightbox fig-align="left"}
+![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.png){#fig-a-kappa .lightbox fig-align="left"}
 
-![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.svg){#fig-b-kappa-mag .lightbox fig-align="left"}
+![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples
 
-![Prior sample trajectories](prior_samples.svg){#fig-prior-samples .lightbox fig-align="left"}
+![Prior sample trajectories](prior_samples.png){#fig-prior-samples .lightbox fig-align="left"}
 
 ### Prior predictions
 
@@ -126,7 +126,7 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Posterior predictions
 
@@ -143,34 +143,34 @@ posterior_summary
 
 The probability of observing a specific count of words spoken for selected ages.
 
-![posterior_predictive_pmf](posterior_predictive_pmf.svg){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
+![posterior_predictive_pmf](posterior_predictive_pmf.png){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
 
 ### Posterior predictive cumulative distribution function (CDF) for word counts, by age
 
 The cumulative sum of the PMF: the probability that the count of words spoken is less than or equal to a specified value for selected ages.
 
-![posterior_predictive_cdf](posterior_predictive_cdf.svg){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
+![posterior_predictive_cdf](posterior_predictive_cdf.png){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.svg){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
 
 ### Posterior predictive median trend with uncertainty intervals
 
-![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.svg){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.png){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
 
 Smoothed:
 
-![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.svg){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.png){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
 
 ### Estimated learning rate
 
 The posterior distribution of the estimated learning rate (estimated gain in spoken words per month) across age. The is the derivative of the conditional expectation of the count given the latent function $f$. The posterior uncertainty bands show how that estimated rate varies across posterior draws of $f$.
 
-![expected_learning_rate](expected_learning_rate.svg){#fig-expected-learning-rate .lightbox fig-align="left"}
+![expected_learning_rate](expected_learning_rate.png){#fig-expected-learning-rate .lightbox fig-align="left"}
 
 ### Posterior distribution for dispersion parameter $\kappa$
 
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean). The plot shows how the estimated dispersion parameter $\kappa$ changes with age, along with uncertainty intervals.
 
-![posterior_kappa](posterior_kappa.svg){#fig-posterior-kappa .lightbox fig-align="left"}
+![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}

--- a/docs/models/vg02/index.qmd
+++ b/docs/models/vg02/index.qmd
@@ -45,35 +45,35 @@ For full details and discussion, please refer to the technical report.
 
 ### Lengthscale
 
-![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.svg){#fig-lengthscale .lightbox fig-align="left"}
+![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.png){#fig-lengthscale .lightbox fig-align="left"}
 
 ### Amplitude
 
-![Amplitude prior distribution `eta_dist`](eta_dist.svg){#fig-amplitude .lightbox fig-align="left"}
+![Amplitude prior distribution `eta_dist`](eta_dist.png){#fig-amplitude .lightbox fig-align="left"}
 
 ### Slope
 
 #### Low slope anchor (24 months)
 
-![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.svg){#fig-slope-low .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.png){#fig-slope-low .lightbox fig-align="left"}
 
 #### High slope anchor (84 months)
 
-![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.svg){#fig-slope-hi .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.png){#fig-slope-hi .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion
 
-![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.svg){#fig-kappa-min .lightbox fig-align="left"}
+![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.png){#fig-kappa-min .lightbox fig-align="left"}
 
-![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.svg){#fig-a-kappa .lightbox fig-align="left"}
+![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.png){#fig-a-kappa .lightbox fig-align="left"}
 
-![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.svg){#fig-b-kappa-mag .lightbox fig-align="left"}
+![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples
 
-![Prior sample trajectories](prior_samples.svg){#fig-prior-samples .lightbox fig-align="left"}
+![Prior sample trajectories](prior_samples.png){#fig-prior-samples .lightbox fig-align="left"}
 
 ### Prior predictions
 
@@ -126,7 +126,7 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Posterior predictions
 
@@ -143,34 +143,34 @@ posterior_summary
 
 The probability of observing a specific count of words understood for selected ages.
 
-![posterior_predictive_pmf](posterior_predictive_pmf.svg){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
+![posterior_predictive_pmf](posterior_predictive_pmf.png){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
 
 ### Posterior predictive cumulative distribution function (CDF) for word counts, by age
 
 The cumulative sum of the PMF: the probability that the count of words understood is less than or equal to a specified value for selected ages.
 
-![posterior_predictive_cdf](posterior_predictive_cdf.svg){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
+![posterior_predictive_cdf](posterior_predictive_cdf.png){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.svg){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
 
 ### Posterior predictive median trend with uncertainty intervals
 
-![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.svg){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.png){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
 
 Smoothed:
 
-![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.svg){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.png){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
 
 ### Estimated learning rate
 
 The posterior distribution of the estimated learning rate (estimated gain in understood words per month) across age. The is the derivative of the conditional expectation of the count given the latent function $f$. The posterior uncertainty bands show how that estimated rate varies across posterior draws of $f$.
 
-![expected_learning_rate](expected_learning_rate.svg){#fig-expected-learning-rate .lightbox fig-align="left"}
+![expected_learning_rate](expected_learning_rate.png){#fig-expected-learning-rate .lightbox fig-align="left"}
 
 ### Posterior distribution for dispersion parameter $\kappa$
 
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean). The plot shows how the estimated dispersion parameter $\kappa$ changes with age, along with uncertainty intervals.
 
-![posterior_kappa](posterior_kappa.svg){#fig-posterior-kappa .lightbox fig-align="left"}
+![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}

--- a/docs/models/vg03/index.qmd
+++ b/docs/models/vg03/index.qmd
@@ -45,35 +45,35 @@ For full details and discussion, please refer to the technical report.
 
 ### Lengthscale
 
-![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.svg){#fig-lengthscale .lightbox fig-align="left"}
+![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.png){#fig-lengthscale .lightbox fig-align="left"}
 
 ### Amplitude
 
-![Amplitude prior distribution `eta_dist`](eta_dist.svg){#fig-amplitude .lightbox fig-align="left"}
+![Amplitude prior distribution `eta_dist`](eta_dist.png){#fig-amplitude .lightbox fig-align="left"}
 
 ### Slope
 
 #### Low slope anchor (12 months)
 
-![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.svg){#fig-slope-low .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.png){#fig-slope-low .lightbox fig-align="left"}
 
 #### High slope anchor (26 months)
 
-![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.svg){#fig-slope-hi .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.png){#fig-slope-hi .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion
 
-![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.svg){#fig-kappa-min .lightbox fig-align="left"}
+![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.png){#fig-kappa-min .lightbox fig-align="left"}
 
-![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.svg){#fig-a-kappa .lightbox fig-align="left"}
+![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.png){#fig-a-kappa .lightbox fig-align="left"}
 
-![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.svg){#fig-b-kappa-mag .lightbox fig-align="left"}
+![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples
 
-![Prior sample trajectories](prior_samples.svg){#fig-prior-samples .lightbox fig-align="left"}
+![Prior sample trajectories](prior_samples.png){#fig-prior-samples .lightbox fig-align="left"}
 
 ### Prior predictions
 
@@ -126,7 +126,7 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Posterior predictions
 
@@ -143,34 +143,34 @@ posterior_summary
 
 The probability of observing a specific count of words spoken for selected ages.
 
-![posterior_predictive_pmf](posterior_predictive_pmf.svg){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
+![posterior_predictive_pmf](posterior_predictive_pmf.png){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
 
 ### Posterior predictive cumulative distribution function (CDF) for word counts, by age
 
 The cumulative sum of the PMF: the probability that the count of words spoken is less than or equal to a specified value for selected ages.
 
-![posterior_predictive_cdf](posterior_predictive_cdf.svg){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
+![posterior_predictive_cdf](posterior_predictive_cdf.png){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.svg){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
 
 ### Posterior predictive median trend with uncertainty intervals
 
-![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.svg){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.png){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
 
 Smoothed:
 
-![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.svg){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.png){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
 
 ### Estimated learning rate
 
 The posterior distribution of the estimated learning rate (estimated gain in spoken words per month) across age. The is the derivative of the conditional expectation of the count given the latent function $f$. The posterior uncertainty bands show how that estimated rate varies across posterior draws of $f$.
 
-![expected_learning_rate](expected_learning_rate.svg){#fig-expected-learning-rate .lightbox fig-align="left"}
+![expected_learning_rate](expected_learning_rate.png){#fig-expected-learning-rate .lightbox fig-align="left"}
 
 ### Posterior distribution for dispersion parameter $\kappa$
 
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean). The plot shows how the estimated dispersion parameter $\kappa$ changes with age, along with uncertainty intervals.
 
-![posterior_kappa](posterior_kappa.svg){#fig-posterior-kappa .lightbox fig-align="left"}
+![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}

--- a/docs/models/vg04/index.qmd
+++ b/docs/models/vg04/index.qmd
@@ -45,35 +45,35 @@ For full details and discussion, please refer to the technical report.
 
 ### Lengthscale
 
-![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.svg){#fig-lengthscale .lightbox fig-align="left"}
+![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.png){#fig-lengthscale .lightbox fig-align="left"}
 
 ### Amplitude
 
-![Amplitude prior distribution `eta_dist`](eta_dist.svg){#fig-amplitude .lightbox fig-align="left"}
+![Amplitude prior distribution `eta_dist`](eta_dist.png){#fig-amplitude .lightbox fig-align="left"}
 
 ### Slope
 
 #### Low slope anchor (12 months)
 
-![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.svg){#fig-slope-low .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.png){#fig-slope-low .lightbox fig-align="left"}
 
 #### High slope anchor (26 months)
 
-![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.svg){#fig-slope-hi .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.png){#fig-slope-hi .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion
 
-![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.svg){#fig-kappa-min .lightbox fig-align="left"}
+![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.png){#fig-kappa-min .lightbox fig-align="left"}
 
-![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.svg){#fig-a-kappa .lightbox fig-align="left"}
+![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.png){#fig-a-kappa .lightbox fig-align="left"}
 
-![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.svg){#fig-b-kappa-mag .lightbox fig-align="left"}
+![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples
 
-![Prior sample trajectories](prior_samples.svg){#fig-prior-samples .lightbox fig-align="left"}
+![Prior sample trajectories](prior_samples.png){#fig-prior-samples .lightbox fig-align="left"}
 
 ### Prior predictions
 
@@ -126,7 +126,7 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Posterior predictions
 
@@ -143,34 +143,34 @@ posterior_summary
 
 The probability of observing a specific count of words understood for selected ages.
 
-![posterior_predictive_pmf](posterior_predictive_pmf.svg){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
+![posterior_predictive_pmf](posterior_predictive_pmf.png){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
 
 ### Posterior predictive cumulative distribution function (CDF) for word counts, by age
 
 The cumulative sum of the PMF: the probability that the count of words understood is less than or equal to a specified value for selected ages.
 
-![posterior_predictive_cdf](posterior_predictive_cdf.svg){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
+![posterior_predictive_cdf](posterior_predictive_cdf.png){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.svg){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
 
 ### Posterior predictive median trend with uncertainty intervals
 
-![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.svg){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.png){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
 
 Smoothed:
 
-![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.svg){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.png){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
 
 ### Estimated learning rate
 
 The posterior distribution of the estimated learning rate (estimated gain in understood words per month) across age. This is the derivative of the conditional expectation of the count given the latent function $f$. The posterior uncertainty bands show how that estimated rate varies across posterior draws of $f$.
 
-![expected_learning_rate](expected_learning_rate.svg){#fig-expected-learning-rate .lightbox fig-align="left"}
+![expected_learning_rate](expected_learning_rate.png){#fig-expected-learning-rate .lightbox fig-align="left"}
 
 ### Posterior distribution for dispersion parameter $\kappa$
 
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean). The plot shows how the estimated dispersion parameter $\kappa$ changes with age, along with uncertainty intervals.
 
-![posterior_kappa](posterior_kappa.svg){#fig-posterior-kappa .lightbox fig-align="left"}
+![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}

--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -45,53 +45,53 @@ For full details and discussion, please refer to the technical report.
 
 ### Understood trajectory
 
-![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.svg){#fig-ell-u .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.png){#fig-ell-u .lightbox fig-align="left"}
 
-![Amplitude prior `eta_u_dist`](eta_u_dist.svg){#fig-eta-u .lightbox fig-align="left"}
+![Amplitude prior `eta_u_dist`](eta_u_dist.png){#fig-eta-u .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.svg){#fig-slope-low-u .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.png){#fig-slope-low-u .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.svg){#fig-slope-hi-u .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.png){#fig-slope-hi-u .lightbox fig-align="left"}
 
 ### Production ratio
 
-![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.svg){#fig-ell-q .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
 
-![Amplitude prior `eta_q_dist`](eta_q_dist.svg){#fig-eta-q .lightbox fig-align="left"}
+![Amplitude prior `eta_q_dist`](eta_q_dist.png){#fig-eta-q .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.svg){#fig-slope-low-q .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.png){#fig-slope-low-q .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.svg){#fig-slope-hi-q .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.png){#fig-slope-hi-q .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- understood
 
-![`kappa_min_u_dist`](kappa_min_u_dist.svg){#fig-kappa-min-u .lightbox fig-align="left"}
+![`kappa_min_u_dist`](kappa_min_u_dist.png){#fig-kappa-min-u .lightbox fig-align="left"}
 
-![`a_kappa_u_dist`](a_kappa_u_dist.svg){#fig-a-kappa-u .lightbox fig-align="left"}
+![`a_kappa_u_dist`](a_kappa_u_dist.png){#fig-a-kappa-u .lightbox fig-align="left"}
 
-![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.svg){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.png){#fig-b-kappa-mag-u .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- spoken
 
-![`kappa_min_s_dist`](kappa_min_s_dist.svg){#fig-kappa-min-s .lightbox fig-align="left"}
+![`kappa_min_s_dist`](kappa_min_s_dist.png){#fig-kappa-min-s .lightbox fig-align="left"}
 
-![`a_kappa_s_dist`](a_kappa_s_dist.svg){#fig-a-kappa-s .lightbox fig-align="left"}
+![`a_kappa_s_dist`](a_kappa_s_dist.png){#fig-a-kappa-s .lightbox fig-align="left"}
 
-![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.svg){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples -- words understood
 
-![Prior sample trajectories (understood)](prior_samples_u.svg){#fig-prior-samples-u .lightbox fig-align="left"}
+![Prior sample trajectories (understood)](prior_samples_u.png){#fig-prior-samples-u .lightbox fig-align="left"}
 
 ### Prior samples -- words spoken
 
-![Prior sample trajectories (spoken)](prior_samples_s.svg){#fig-prior-samples-s .lightbox fig-align="left"}
+![Prior sample trajectories (spoken)](prior_samples_s.png){#fig-prior-samples-s .lightbox fig-align="left"}
 
 ### Prior samples -- production rate q(a)
 
-![Prior sample trajectories for production ratio q(a)](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
+![Prior sample trajectories for production ratio q(a)](prior_samples_q.png){#fig-prior-samples-q .lightbox fig-align="left"}
 
 ## Data
 
@@ -136,24 +136,24 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Joint trajectory
 
-![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
+![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.svg){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
 
 ## Production ratio
 
 The production ratio $q(a) = p_S(a) / p_U(a)$ represents the fraction of understood words that are spoken at each age.
 The posterior predictive figure below instead shows the ratio of posterior predictive spoken and understood counts, so it should be interpreted separately from $q(a)$.
 
-![Production rate q(a)](production_rate.svg){#fig-production-rate .lightbox fig-align="left"}
+![Production rate q(a)](production_rate.png){#fig-production-rate .lightbox fig-align="left"}
 
-![Production ratio by words understood](production_rate_by_understood.svg){#fig-production-rate-by-understood .lightbox fig-align="left"}
+![Production ratio by words understood](production_rate_by_understood.png){#fig-production-rate-by-understood .lightbox fig-align="left"}
 
-![Posterior predictive spoken/understood count ratio](production_rate_predictive.svg){#fig-production-rate-predictive .lightbox fig-align="left"}
+![Posterior predictive spoken/understood count ratio](production_rate_predictive.png){#fig-production-rate-predictive .lightbox fig-align="left"}
 
 ```{python}
 summary_q = pd.read_csv("posterior_summary_q.csv")
@@ -164,13 +164,13 @@ summary_q
 
 The expected difference in word counts between understanding and production.
 
-![Comprehension-production gap](comprehension_production_gap.svg){#fig-gap .lightbox fig-align="left"}
+![Comprehension-production gap](comprehension_production_gap.png){#fig-gap .lightbox fig-align="left"}
 
 ## Words understood vs words spoken
 
-![Expected words understood vs spoken](understood_vs_spoken.svg){#fig-understood-vs-spoken .lightbox fig-align="left"}
+![Expected words understood vs spoken](understood_vs_spoken.png){#fig-understood-vs-spoken .lightbox fig-align="left"}
 
-![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.svg){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
+![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.png){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
 
 ## Posterior predictions -- words understood
 
@@ -183,31 +183,31 @@ posterior_summary_u
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_u](posterior_predictive_pmf_u.svg){#fig-pmf-u .lightbox fig-align="left"}
+![posterior_predictive_pmf_u](posterior_predictive_pmf_u.png){#fig-pmf-u .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_u](posterior_predictive_cdf_u.svg){#fig-cdf-u .lightbox fig-align="left"}
+![posterior_predictive_cdf_u](posterior_predictive_cdf_u.png){#fig-cdf-u .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.svg){#fig-count-dist-u .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.svg){#fig-trend-u .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.png){#fig-trend-u .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.svg){#fig-trend-u-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.png){#fig-trend-u-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_u](expected_learning_rate_u.svg){#fig-rate-u .lightbox fig-align="left"}
+![expected_learning_rate_u](expected_learning_rate_u.png){#fig-rate-u .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- understood
 
-![posterior_kappa_u](posterior_kappa_u.svg){#fig-kappa-u .lightbox fig-align="left"}
+![posterior_kappa_u](posterior_kappa_u.png){#fig-kappa-u .lightbox fig-align="left"}
 
 ## Posterior predictions -- words spoken
 
@@ -220,28 +220,28 @@ posterior_summary_s
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_s](posterior_predictive_pmf_s.svg){#fig-pmf-s .lightbox fig-align="left"}
+![posterior_predictive_pmf_s](posterior_predictive_pmf_s.png){#fig-pmf-s .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_s](posterior_predictive_cdf_s.svg){#fig-cdf-s .lightbox fig-align="left"}
+![posterior_predictive_cdf_s](posterior_predictive_cdf_s.png){#fig-cdf-s .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.svg){#fig-count-dist-s .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.svg){#fig-trend-s .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.png){#fig-trend-s .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.svg){#fig-trend-s-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.png){#fig-trend-s-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_s](expected_learning_rate_s.svg){#fig-rate-s .lightbox fig-align="left"}
+![expected_learning_rate_s](expected_learning_rate_s.png){#fig-rate-s .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- spoken
 
-![posterior_kappa_s](posterior_kappa_s.svg){#fig-kappa-s .lightbox fig-align="left"}
+![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}

--- a/docs/models/vg06/index.qmd
+++ b/docs/models/vg06/index.qmd
@@ -45,53 +45,53 @@ For full details and discussion, please refer to the technical report.
 
 ### Understood trajectory
 
-![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.svg){#fig-ell-u .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.png){#fig-ell-u .lightbox fig-align="left"}
 
-![Amplitude prior `eta_u_dist`](eta_u_dist.svg){#fig-eta-u .lightbox fig-align="left"}
+![Amplitude prior `eta_u_dist`](eta_u_dist.png){#fig-eta-u .lightbox fig-align="left"}
 
-![Low slope anchor (12 months) `p_slope_low_u_dist`](p_slope_low_u_dist.svg){#fig-slope-low-u .lightbox fig-align="left"}
+![Low slope anchor (12 months) `p_slope_low_u_dist`](p_slope_low_u_dist.png){#fig-slope-low-u .lightbox fig-align="left"}
 
-![High slope anchor (26 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.svg){#fig-slope-hi-u .lightbox fig-align="left"}
+![High slope anchor (26 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.png){#fig-slope-hi-u .lightbox fig-align="left"}
 
 ### Production ratio
 
-![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.svg){#fig-ell-q .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
 
-![Amplitude prior `eta_q_dist`](eta_q_dist.svg){#fig-eta-q .lightbox fig-align="left"}
+![Amplitude prior `eta_q_dist`](eta_q_dist.png){#fig-eta-q .lightbox fig-align="left"}
 
-![Low slope anchor (12 months) `p_slope_low_q_dist`](p_slope_low_q_dist.svg){#fig-slope-low-q .lightbox fig-align="left"}
+![Low slope anchor (12 months) `p_slope_low_q_dist`](p_slope_low_q_dist.png){#fig-slope-low-q .lightbox fig-align="left"}
 
-![High slope anchor (26 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.svg){#fig-slope-hi-q .lightbox fig-align="left"}
+![High slope anchor (26 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.png){#fig-slope-hi-q .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- understood
 
-![`kappa_min_u_dist`](kappa_min_u_dist.svg){#fig-kappa-min-u .lightbox fig-align="left"}
+![`kappa_min_u_dist`](kappa_min_u_dist.png){#fig-kappa-min-u .lightbox fig-align="left"}
 
-![`a_kappa_u_dist`](a_kappa_u_dist.svg){#fig-a-kappa-u .lightbox fig-align="left"}
+![`a_kappa_u_dist`](a_kappa_u_dist.png){#fig-a-kappa-u .lightbox fig-align="left"}
 
-![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.svg){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.png){#fig-b-kappa-mag-u .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- spoken
 
-![`kappa_min_s_dist`](kappa_min_s_dist.svg){#fig-kappa-min-s .lightbox fig-align="left"}
+![`kappa_min_s_dist`](kappa_min_s_dist.png){#fig-kappa-min-s .lightbox fig-align="left"}
 
-![`a_kappa_s_dist`](a_kappa_s_dist.svg){#fig-a-kappa-s .lightbox fig-align="left"}
+![`a_kappa_s_dist`](a_kappa_s_dist.png){#fig-a-kappa-s .lightbox fig-align="left"}
 
-![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.svg){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples -- words understood
 
-![Prior sample trajectories (understood)](prior_samples_u.svg){#fig-prior-samples-u .lightbox fig-align="left"}
+![Prior sample trajectories (understood)](prior_samples_u.png){#fig-prior-samples-u .lightbox fig-align="left"}
 
 ### Prior samples -- words spoken
 
-![Prior sample trajectories (spoken)](prior_samples_s.svg){#fig-prior-samples-s .lightbox fig-align="left"}
+![Prior sample trajectories (spoken)](prior_samples_s.png){#fig-prior-samples-s .lightbox fig-align="left"}
 
 ### Prior samples -- production rate q(a)
 
-![Prior sample trajectories for production ratio q(a)](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
+![Prior sample trajectories for production ratio q(a)](prior_samples_q.png){#fig-prior-samples-q .lightbox fig-align="left"}
 
 ## Data
 
@@ -136,24 +136,24 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Joint trajectory
 
-![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
+![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.svg){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
 
 ## Production ratio
 
 The production ratio $q(a) = p_S(a) / p_U(a)$ represents the fraction of understood words that are spoken at each age.
 The posterior predictive figure below instead shows the ratio of posterior predictive spoken and understood word counts, so it should not be interpreted as the same quantity as $q(a)$.
 
-![Production rate q(a)](production_rate.svg){#fig-production-rate .lightbox fig-align="left"}
+![Production rate q(a)](production_rate.png){#fig-production-rate .lightbox fig-align="left"}
 
-![Production ratio by words understood](production_rate_by_understood.svg){#fig-production-rate-by-understood .lightbox fig-align="left"}
+![Production ratio by words understood](production_rate_by_understood.png){#fig-production-rate-by-understood .lightbox fig-align="left"}
 
-![Posterior predictive spoken/understood count ratio](production_rate_predictive.svg){#fig-production-rate-predictive .lightbox fig-align="left"}
+![Posterior predictive spoken/understood count ratio](production_rate_predictive.png){#fig-production-rate-predictive .lightbox fig-align="left"}
 
 ```{python}
 summary_q = pd.read_csv("posterior_summary_q.csv")
@@ -164,13 +164,13 @@ summary_q
 
 The expected difference in word counts between understanding and production.
 
-![Comprehension-production gap](comprehension_production_gap.svg){#fig-gap .lightbox fig-align="left"}
+![Comprehension-production gap](comprehension_production_gap.png){#fig-gap .lightbox fig-align="left"}
 
 ## Words understood vs words spoken
 
-![Expected words understood vs spoken](understood_vs_spoken.svg){#fig-understood-vs-spoken .lightbox fig-align="left"}
+![Expected words understood vs spoken](understood_vs_spoken.png){#fig-understood-vs-spoken .lightbox fig-align="left"}
 
-![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.svg){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
+![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.png){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
 
 ## Posterior predictions -- words understood
 
@@ -183,31 +183,31 @@ posterior_summary_u
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_u](posterior_predictive_pmf_u.svg){#fig-pmf-u .lightbox fig-align="left"}
+![posterior_predictive_pmf_u](posterior_predictive_pmf_u.png){#fig-pmf-u .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_u](posterior_predictive_cdf_u.svg){#fig-cdf-u .lightbox fig-align="left"}
+![posterior_predictive_cdf_u](posterior_predictive_cdf_u.png){#fig-cdf-u .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.svg){#fig-count-dist-u .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.svg){#fig-trend-u .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.png){#fig-trend-u .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.svg){#fig-trend-u-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.png){#fig-trend-u-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_u](expected_learning_rate_u.svg){#fig-rate-u .lightbox fig-align="left"}
+![expected_learning_rate_u](expected_learning_rate_u.png){#fig-rate-u .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- understood
 
-![posterior_kappa_u](posterior_kappa_u.svg){#fig-kappa-u .lightbox fig-align="left"}
+![posterior_kappa_u](posterior_kappa_u.png){#fig-kappa-u .lightbox fig-align="left"}
 
 ## Posterior predictions -- words spoken
 
@@ -220,28 +220,28 @@ posterior_summary_s
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_s](posterior_predictive_pmf_s.svg){#fig-pmf-s .lightbox fig-align="left"}
+![posterior_predictive_pmf_s](posterior_predictive_pmf_s.png){#fig-pmf-s .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_s](posterior_predictive_cdf_s.svg){#fig-cdf-s .lightbox fig-align="left"}
+![posterior_predictive_cdf_s](posterior_predictive_cdf_s.png){#fig-cdf-s .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.svg){#fig-count-dist-s .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.svg){#fig-trend-s .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.png){#fig-trend-s .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.svg){#fig-trend-s-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.png){#fig-trend-s-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_s](expected_learning_rate_s.svg){#fig-rate-s .lightbox fig-align="left"}
+![expected_learning_rate_s](expected_learning_rate_s.png){#fig-rate-s .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- spoken
 
-![posterior_kappa_s](posterior_kappa_s.svg){#fig-kappa-s .lightbox fig-align="left"}
+![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}

--- a/docs/models/vg07/index.qmd
+++ b/docs/models/vg07/index.qmd
@@ -50,53 +50,53 @@ For full details and discussion, please refer to the technical report.
 
 ### Understood trajectory
 
-![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.svg){#fig-ell-u .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.png){#fig-ell-u .lightbox fig-align="left"}
 
-![Amplitude prior `eta_u_dist`](eta_u_dist.svg){#fig-eta-u .lightbox fig-align="left"}
+![Amplitude prior `eta_u_dist`](eta_u_dist.png){#fig-eta-u .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.svg){#fig-slope-low-u .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.png){#fig-slope-low-u .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.svg){#fig-slope-hi-u .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.png){#fig-slope-hi-u .lightbox fig-align="left"}
 
 ### Production ratio
 
-![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.svg){#fig-ell-q .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
 
-![Amplitude prior `eta_q_dist`](eta_q_dist.svg){#fig-eta-q .lightbox fig-align="left"}
+![Amplitude prior `eta_q_dist`](eta_q_dist.png){#fig-eta-q .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.svg){#fig-slope-low-q .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.png){#fig-slope-low-q .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.svg){#fig-slope-hi-q .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.png){#fig-slope-hi-q .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- understood
 
-![`kappa_min_u_dist`](kappa_min_u_dist.svg){#fig-kappa-min-u .lightbox fig-align="left"}
+![`kappa_min_u_dist`](kappa_min_u_dist.png){#fig-kappa-min-u .lightbox fig-align="left"}
 
-![`a_kappa_u_dist`](a_kappa_u_dist.svg){#fig-a-kappa-u .lightbox fig-align="left"}
+![`a_kappa_u_dist`](a_kappa_u_dist.png){#fig-a-kappa-u .lightbox fig-align="left"}
 
-![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.svg){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.png){#fig-b-kappa-mag-u .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- spoken
 
-![`kappa_min_s_dist`](kappa_min_s_dist.svg){#fig-kappa-min-s .lightbox fig-align="left"}
+![`kappa_min_s_dist`](kappa_min_s_dist.png){#fig-kappa-min-s .lightbox fig-align="left"}
 
-![`a_kappa_s_dist`](a_kappa_s_dist.svg){#fig-a-kappa-s .lightbox fig-align="left"}
+![`a_kappa_s_dist`](a_kappa_s_dist.png){#fig-a-kappa-s .lightbox fig-align="left"}
 
-![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.svg){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples -- words understood
 
-![Prior sample trajectories (understood)](prior_samples_u.svg){#fig-prior-samples-u .lightbox fig-align="left"}
+![Prior sample trajectories (understood)](prior_samples_u.png){#fig-prior-samples-u .lightbox fig-align="left"}
 
 ### Prior samples -- words spoken
 
-![Prior sample trajectories (spoken)](prior_samples_s.svg){#fig-prior-samples-s .lightbox fig-align="left"}
+![Prior sample trajectories (spoken)](prior_samples_s.png){#fig-prior-samples-s .lightbox fig-align="left"}
 
 ### Prior samples -- production rate q(a)
 
-![Prior sample trajectories for production ratio q(a)](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
+![Prior sample trajectories for production ratio q(a)](prior_samples_q.png){#fig-prior-samples-q .lightbox fig-align="left"}
 
 ## Data
 
@@ -141,24 +141,24 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Joint trajectory
 
-![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
+![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.svg){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
 
 ## Production ratio
 
 The production ratio $q(a) = p_S(a) / p_U(a)$ represents the fraction of understood words that are spoken at each age.
 The posterior predictive figure below instead shows the ratio of posterior predictive spoken and understood counts, so it should be interpreted separately from $q(a)$.
 
-![Production rate q(a)](production_rate.svg){#fig-production-rate .lightbox fig-align="left"}
+![Production rate q(a)](production_rate.png){#fig-production-rate .lightbox fig-align="left"}
 
-![Production ratio by words understood](production_rate_by_understood.svg){#fig-production-rate-by-understood .lightbox fig-align="left"}
+![Production ratio by words understood](production_rate_by_understood.png){#fig-production-rate-by-understood .lightbox fig-align="left"}
 
-![Posterior predictive spoken/understood count ratio](production_rate_predictive.svg){#fig-production-rate-predictive .lightbox fig-align="left"}
+![Posterior predictive spoken/understood count ratio](production_rate_predictive.png){#fig-production-rate-predictive .lightbox fig-align="left"}
 
 ```{python}
 summary_q = pd.read_csv("posterior_summary_q.csv")
@@ -169,13 +169,13 @@ summary_q
 
 The expected difference in word counts between understanding and production.
 
-![Comprehension-production gap](comprehension_production_gap.svg){#fig-gap .lightbox fig-align="left"}
+![Comprehension-production gap](comprehension_production_gap.png){#fig-gap .lightbox fig-align="left"}
 
 ## Words understood vs words spoken
 
-![Expected words understood vs spoken](understood_vs_spoken.svg){#fig-understood-vs-spoken .lightbox fig-align="left"}
+![Expected words understood vs spoken](understood_vs_spoken.png){#fig-understood-vs-spoken .lightbox fig-align="left"}
 
-![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.svg){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
+![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.png){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
 
 ## Posterior predictions -- words understood
 
@@ -188,31 +188,31 @@ posterior_summary_u
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_u](posterior_predictive_pmf_u.svg){#fig-pmf-u .lightbox fig-align="left"}
+![posterior_predictive_pmf_u](posterior_predictive_pmf_u.png){#fig-pmf-u .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_u](posterior_predictive_cdf_u.svg){#fig-cdf-u .lightbox fig-align="left"}
+![posterior_predictive_cdf_u](posterior_predictive_cdf_u.png){#fig-cdf-u .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.svg){#fig-count-dist-u .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.svg){#fig-trend-u .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.png){#fig-trend-u .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.svg){#fig-trend-u-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.png){#fig-trend-u-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_u](expected_learning_rate_u.svg){#fig-rate-u .lightbox fig-align="left"}
+![expected_learning_rate_u](expected_learning_rate_u.png){#fig-rate-u .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- understood
 
-![posterior_kappa_u](posterior_kappa_u.svg){#fig-kappa-u .lightbox fig-align="left"}
+![posterior_kappa_u](posterior_kappa_u.png){#fig-kappa-u .lightbox fig-align="left"}
 
 ## Posterior predictions -- words spoken
 
@@ -225,28 +225,28 @@ posterior_summary_s
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_s](posterior_predictive_pmf_s.svg){#fig-pmf-s .lightbox fig-align="left"}
+![posterior_predictive_pmf_s](posterior_predictive_pmf_s.png){#fig-pmf-s .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_s](posterior_predictive_cdf_s.svg){#fig-cdf-s .lightbox fig-align="left"}
+![posterior_predictive_cdf_s](posterior_predictive_cdf_s.png){#fig-cdf-s .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.svg){#fig-count-dist-s .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.svg){#fig-trend-s .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.png){#fig-trend-s .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.svg){#fig-trend-s-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.png){#fig-trend-s-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_s](expected_learning_rate_s.svg){#fig-rate-s .lightbox fig-align="left"}
+![expected_learning_rate_s](expected_learning_rate_s.png){#fig-rate-s .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- spoken
 
-![posterior_kappa_s](posterior_kappa_s.svg){#fig-kappa-s .lightbox fig-align="left"}
+![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}

--- a/docs/models/vg08/index.qmd
+++ b/docs/models/vg08/index.qmd
@@ -52,53 +52,53 @@ For full details and discussion, please refer to the technical report.
 
 ### Understood trajectory
 
-![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.svg){#fig-ell-u .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.png){#fig-ell-u .lightbox fig-align="left"}
 
-![Amplitude prior `eta_u_dist`](eta_u_dist.svg){#fig-eta-u .lightbox fig-align="left"}
+![Amplitude prior `eta_u_dist`](eta_u_dist.png){#fig-eta-u .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.svg){#fig-slope-low-u .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.png){#fig-slope-low-u .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.svg){#fig-slope-hi-u .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.png){#fig-slope-hi-u .lightbox fig-align="left"}
 
 ### Production ratio
 
-![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.svg){#fig-ell-q .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
 
-![Amplitude prior `eta_q_dist`](eta_q_dist.svg){#fig-eta-q .lightbox fig-align="left"}
+![Amplitude prior `eta_q_dist`](eta_q_dist.png){#fig-eta-q .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.svg){#fig-slope-low-q .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.png){#fig-slope-low-q .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.svg){#fig-slope-hi-q .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.png){#fig-slope-hi-q .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- understood
 
-![`kappa_min_u_dist`](kappa_min_u_dist.svg){#fig-kappa-min-u .lightbox fig-align="left"}
+![`kappa_min_u_dist`](kappa_min_u_dist.png){#fig-kappa-min-u .lightbox fig-align="left"}
 
-![`a_kappa_u_dist`](a_kappa_u_dist.svg){#fig-a-kappa-u .lightbox fig-align="left"}
+![`a_kappa_u_dist`](a_kappa_u_dist.png){#fig-a-kappa-u .lightbox fig-align="left"}
 
-![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.svg){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.png){#fig-b-kappa-mag-u .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- spoken
 
-![`kappa_min_s_dist`](kappa_min_s_dist.svg){#fig-kappa-min-s .lightbox fig-align="left"}
+![`kappa_min_s_dist`](kappa_min_s_dist.png){#fig-kappa-min-s .lightbox fig-align="left"}
 
-![`a_kappa_s_dist`](a_kappa_s_dist.svg){#fig-a-kappa-s .lightbox fig-align="left"}
+![`a_kappa_s_dist`](a_kappa_s_dist.png){#fig-a-kappa-s .lightbox fig-align="left"}
 
-![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.svg){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples -- words understood
 
-![Prior sample trajectories (understood)](prior_samples_u.svg){#fig-prior-samples-u .lightbox fig-align="left"}
+![Prior sample trajectories (understood)](prior_samples_u.png){#fig-prior-samples-u .lightbox fig-align="left"}
 
 ### Prior samples -- words spoken
 
-![Prior sample trajectories (spoken)](prior_samples_s.svg){#fig-prior-samples-s .lightbox fig-align="left"}
+![Prior sample trajectories (spoken)](prior_samples_s.png){#fig-prior-samples-s .lightbox fig-align="left"}
 
 ### Prior samples -- production rate q(a)
 
-![Prior sample trajectories for production ratio q(a)](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
+![Prior sample trajectories for production ratio q(a)](prior_samples_q.png){#fig-prior-samples-q .lightbox fig-align="left"}
 
 ## Data
 
@@ -143,24 +143,24 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Joint trajectory
 
-![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
+![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.svg){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
 
 ## Production ratio
 
 The production ratio $q(a) = p_S(a) / p_U(a)$ represents the fraction of understood words that are spoken at each age.
 The posterior predictive figure below instead shows the ratio of posterior predictive spoken and understood counts, so it should be interpreted separately from $q(a)$.
 
-![Production rate q(a)](production_rate.svg){#fig-production-rate .lightbox fig-align="left"}
+![Production rate q(a)](production_rate.png){#fig-production-rate .lightbox fig-align="left"}
 
-![Production ratio by words understood](production_rate_by_understood.svg){#fig-production-rate-by-understood .lightbox fig-align="left"}
+![Production ratio by words understood](production_rate_by_understood.png){#fig-production-rate-by-understood .lightbox fig-align="left"}
 
-![Posterior predictive spoken/understood count ratio](production_rate_predictive.svg){#fig-production-rate-predictive .lightbox fig-align="left"}
+![Posterior predictive spoken/understood count ratio](production_rate_predictive.png){#fig-production-rate-predictive .lightbox fig-align="left"}
 
 ```{python}
 summary_q = pd.read_csv("posterior_summary_q.csv")
@@ -171,13 +171,13 @@ summary_q
 
 The expected difference in word counts between understanding and production.
 
-![Comprehension-production gap](comprehension_production_gap.svg){#fig-gap .lightbox fig-align="left"}
+![Comprehension-production gap](comprehension_production_gap.png){#fig-gap .lightbox fig-align="left"}
 
 ## Words understood vs words spoken
 
-![Expected words understood vs spoken](understood_vs_spoken.svg){#fig-understood-vs-spoken .lightbox fig-align="left"}
+![Expected words understood vs spoken](understood_vs_spoken.png){#fig-understood-vs-spoken .lightbox fig-align="left"}
 
-![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.svg){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
+![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.png){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
 
 ## Posterior predictions -- words understood
 
@@ -202,31 +202,31 @@ posterior_summary_u
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_u](posterior_predictive_pmf_u.svg){#fig-pmf-u .lightbox fig-align="left"}
+![posterior_predictive_pmf_u](posterior_predictive_pmf_u.png){#fig-pmf-u .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_u](posterior_predictive_cdf_u.svg){#fig-cdf-u .lightbox fig-align="left"}
+![posterior_predictive_cdf_u](posterior_predictive_cdf_u.png){#fig-cdf-u .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.svg){#fig-count-dist-u .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.svg){#fig-trend-u .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.png){#fig-trend-u .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.svg){#fig-trend-u-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.png){#fig-trend-u-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_u](expected_learning_rate_u.svg){#fig-rate-u .lightbox fig-align="left"}
+![expected_learning_rate_u](expected_learning_rate_u.png){#fig-rate-u .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- understood
 
-![posterior_kappa_u](posterior_kappa_u.svg){#fig-kappa-u .lightbox fig-align="left"}
+![posterior_kappa_u](posterior_kappa_u.png){#fig-kappa-u .lightbox fig-align="left"}
 
 ## Posterior predictions -- words spoken
 
@@ -239,28 +239,28 @@ posterior_summary_s
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_s](posterior_predictive_pmf_s.svg){#fig-pmf-s .lightbox fig-align="left"}
+![posterior_predictive_pmf_s](posterior_predictive_pmf_s.png){#fig-pmf-s .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_s](posterior_predictive_cdf_s.svg){#fig-cdf-s .lightbox fig-align="left"}
+![posterior_predictive_cdf_s](posterior_predictive_cdf_s.png){#fig-cdf-s .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.svg){#fig-count-dist-s .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.svg){#fig-trend-s .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.png){#fig-trend-s .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.svg){#fig-trend-s-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.png){#fig-trend-s-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_s](expected_learning_rate_s.svg){#fig-rate-s .lightbox fig-align="left"}
+![expected_learning_rate_s](expected_learning_rate_s.png){#fig-rate-s .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- spoken
 
-![posterior_kappa_s](posterior_kappa_s.svg){#fig-kappa-s .lightbox fig-align="left"}
+![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -50,53 +50,53 @@ For full details and discussion, please refer to the technical report.
 
 ### Understood trajectory
 
-![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.svg){#fig-ell-u .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.png){#fig-ell-u .lightbox fig-align="left"}
 
-![Amplitude prior `eta_u_dist`](eta_u_dist.svg){#fig-eta-u .lightbox fig-align="left"}
+![Amplitude prior `eta_u_dist`](eta_u_dist.png){#fig-eta-u .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.svg){#fig-slope-low-u .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.png){#fig-slope-low-u .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.svg){#fig-slope-hi-u .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.png){#fig-slope-hi-u .lightbox fig-align="left"}
 
 ### Production ratio
 
-![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.svg){#fig-ell-q .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
 
-![Amplitude prior `eta_q_dist`](eta_q_dist.svg){#fig-eta-q .lightbox fig-align="left"}
+![Amplitude prior `eta_q_dist`](eta_q_dist.png){#fig-eta-q .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.svg){#fig-slope-low-q .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.png){#fig-slope-low-q .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.svg){#fig-slope-hi-q .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.png){#fig-slope-hi-q .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- understood
 
-![`kappa_min_u_dist`](kappa_min_u_dist.svg){#fig-kappa-min-u .lightbox fig-align="left"}
+![`kappa_min_u_dist`](kappa_min_u_dist.png){#fig-kappa-min-u .lightbox fig-align="left"}
 
-![`a_kappa_u_dist`](a_kappa_u_dist.svg){#fig-a-kappa-u .lightbox fig-align="left"}
+![`a_kappa_u_dist`](a_kappa_u_dist.png){#fig-a-kappa-u .lightbox fig-align="left"}
 
-![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.svg){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.png){#fig-b-kappa-mag-u .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- spoken
 
-![`kappa_min_s_dist`](kappa_min_s_dist.svg){#fig-kappa-min-s .lightbox fig-align="left"}
+![`kappa_min_s_dist`](kappa_min_s_dist.png){#fig-kappa-min-s .lightbox fig-align="left"}
 
-![`a_kappa_s_dist`](a_kappa_s_dist.svg){#fig-a-kappa-s .lightbox fig-align="left"}
+![`a_kappa_s_dist`](a_kappa_s_dist.png){#fig-a-kappa-s .lightbox fig-align="left"}
 
-![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.svg){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples -- words understood
 
-![Prior sample trajectories (understood)](prior_samples_u.svg){#fig-prior-samples-u .lightbox fig-align="left"}
+![Prior sample trajectories (understood)](prior_samples_u.png){#fig-prior-samples-u .lightbox fig-align="left"}
 
 ### Prior samples -- words spoken
 
-![Prior sample trajectories (spoken)](prior_samples_s.svg){#fig-prior-samples-s .lightbox fig-align="left"}
+![Prior sample trajectories (spoken)](prior_samples_s.png){#fig-prior-samples-s .lightbox fig-align="left"}
 
 ### Prior samples -- production rate q(a)
 
-![Prior sample trajectories for production ratio q(a)](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
+![Prior sample trajectories for production ratio q(a)](prior_samples_q.png){#fig-prior-samples-q .lightbox fig-align="left"}
 
 ## Data
 
@@ -141,24 +141,24 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Joint trajectory
 
-![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
+![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.svg){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
 
 ## Production ratio
 
 The production ratio $q(a) = p_S(a) / p_U(a)$ represents the fraction of understood words that are spoken at each age.
 The posterior predictive figure below instead shows the ratio of posterior predictive spoken and understood counts, so it should be interpreted separately from $q(a)$.
 
-![Production rate q(a)](production_rate.svg){#fig-production-rate .lightbox fig-align="left"}
+![Production rate q(a)](production_rate.png){#fig-production-rate .lightbox fig-align="left"}
 
-![Production ratio by words understood](production_rate_by_understood.svg){#fig-production-rate-by-understood .lightbox fig-align="left"}
+![Production ratio by words understood](production_rate_by_understood.png){#fig-production-rate-by-understood .lightbox fig-align="left"}
 
-![Posterior predictive spoken/understood count ratio](production_rate_predictive.svg){#fig-production-rate-predictive .lightbox fig-align="left"}
+![Posterior predictive spoken/understood count ratio](production_rate_predictive.png){#fig-production-rate-predictive .lightbox fig-align="left"}
 
 ```{python}
 summary_q = pd.read_csv("posterior_summary_q.csv")
@@ -169,13 +169,13 @@ summary_q
 
 The expected difference in word counts between understanding and production.
 
-![Comprehension-production gap](comprehension_production_gap.svg){#fig-gap .lightbox fig-align="left"}
+![Comprehension-production gap](comprehension_production_gap.png){#fig-gap .lightbox fig-align="left"}
 
 ## Words understood vs words spoken
 
-![Expected words understood vs spoken](understood_vs_spoken.svg){#fig-understood-vs-spoken .lightbox fig-align="left"}
+![Expected words understood vs spoken](understood_vs_spoken.png){#fig-understood-vs-spoken .lightbox fig-align="left"}
 
-![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.svg){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
+![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.png){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
 
 ## Posterior predictions -- words understood
 
@@ -202,31 +202,31 @@ posterior_summary_u
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_u](posterior_predictive_pmf_u.svg){#fig-pmf-u .lightbox fig-align="left"}
+![posterior_predictive_pmf_u](posterior_predictive_pmf_u.png){#fig-pmf-u .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_u](posterior_predictive_cdf_u.svg){#fig-cdf-u .lightbox fig-align="left"}
+![posterior_predictive_cdf_u](posterior_predictive_cdf_u.png){#fig-cdf-u .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.svg){#fig-count-dist-u .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.svg){#fig-trend-u .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.png){#fig-trend-u .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.svg){#fig-trend-u-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.png){#fig-trend-u-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_u](expected_learning_rate_u.svg){#fig-rate-u .lightbox fig-align="left"}
+![expected_learning_rate_u](expected_learning_rate_u.png){#fig-rate-u .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- understood
 
-![posterior_kappa_u](posterior_kappa_u.svg){#fig-kappa-u .lightbox fig-align="left"}
+![posterior_kappa_u](posterior_kappa_u.png){#fig-kappa-u .lightbox fig-align="left"}
 
 ## Posterior predictions -- words spoken
 
@@ -239,28 +239,28 @@ posterior_summary_s
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_s](posterior_predictive_pmf_s.svg){#fig-pmf-s .lightbox fig-align="left"}
+![posterior_predictive_pmf_s](posterior_predictive_pmf_s.png){#fig-pmf-s .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_s](posterior_predictive_cdf_s.svg){#fig-cdf-s .lightbox fig-align="left"}
+![posterior_predictive_cdf_s](posterior_predictive_cdf_s.png){#fig-cdf-s .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.svg){#fig-count-dist-s .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.svg){#fig-trend-s .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.png){#fig-trend-s .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.svg){#fig-trend-s-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.png){#fig-trend-s-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_s](expected_learning_rate_s.svg){#fig-rate-s .lightbox fig-align="left"}
+![expected_learning_rate_s](expected_learning_rate_s.png){#fig-rate-s .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- spoken
 
-![posterior_kappa_s](posterior_kappa_s.svg){#fig-kappa-s .lightbox fig-align="left"}
+![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -57,53 +57,53 @@ For full details and discussion, please refer to the technical report.
 
 ### Understood trajectory
 
-![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.svg){#fig-ell-u .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.png){#fig-ell-u .lightbox fig-align="left"}
 
-![Amplitude prior `eta_u_dist`](eta_u_dist.svg){#fig-eta-u .lightbox fig-align="left"}
+![Amplitude prior `eta_u_dist`](eta_u_dist.png){#fig-eta-u .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.svg){#fig-slope-low-u .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.png){#fig-slope-low-u .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.svg){#fig-slope-hi-u .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.png){#fig-slope-hi-u .lightbox fig-align="left"}
 
 ### Production ratio
 
-![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.svg){#fig-ell-q .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
 
-![Amplitude prior `eta_q_dist`](eta_q_dist.svg){#fig-eta-q .lightbox fig-align="left"}
+![Amplitude prior `eta_q_dist`](eta_q_dist.png){#fig-eta-q .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.svg){#fig-slope-low-q .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.png){#fig-slope-low-q .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.svg){#fig-slope-hi-q .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.png){#fig-slope-hi-q .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- understood
 
-![`kappa_min_u_dist`](kappa_min_u_dist.svg){#fig-kappa-min-u .lightbox fig-align="left"}
+![`kappa_min_u_dist`](kappa_min_u_dist.png){#fig-kappa-min-u .lightbox fig-align="left"}
 
-![`a_kappa_u_dist`](a_kappa_u_dist.svg){#fig-a-kappa-u .lightbox fig-align="left"}
+![`a_kappa_u_dist`](a_kappa_u_dist.png){#fig-a-kappa-u .lightbox fig-align="left"}
 
-![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.svg){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.png){#fig-b-kappa-mag-u .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- spoken
 
-![`kappa_min_s_dist`](kappa_min_s_dist.svg){#fig-kappa-min-s .lightbox fig-align="left"}
+![`kappa_min_s_dist`](kappa_min_s_dist.png){#fig-kappa-min-s .lightbox fig-align="left"}
 
-![`a_kappa_s_dist`](a_kappa_s_dist.svg){#fig-a-kappa-s .lightbox fig-align="left"}
+![`a_kappa_s_dist`](a_kappa_s_dist.png){#fig-a-kappa-s .lightbox fig-align="left"}
 
-![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.svg){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples -- words understood
 
-![Prior sample trajectories (understood)](prior_samples_u.svg){#fig-prior-samples-u .lightbox fig-align="left"}
+![Prior sample trajectories (understood)](prior_samples_u.png){#fig-prior-samples-u .lightbox fig-align="left"}
 
 ### Prior samples -- words spoken
 
-![Prior sample trajectories (spoken)](prior_samples_s.svg){#fig-prior-samples-s .lightbox fig-align="left"}
+![Prior sample trajectories (spoken)](prior_samples_s.png){#fig-prior-samples-s .lightbox fig-align="left"}
 
 ### Prior samples -- production rate q(a)
 
-![Prior sample trajectories for production ratio q(a)](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
+![Prior sample trajectories for production ratio q(a)](prior_samples_q.png){#fig-prior-samples-q .lightbox fig-align="left"}
 
 ## Data
 
@@ -148,24 +148,24 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Joint trajectory
 
-![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
+![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.svg){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
 
 ## Production ratio
 
 The production ratio $q(a) = p_S(a) / p_U(a)$ represents the fraction of understood words that are spoken at each age.
 The posterior predictive figure below instead shows the ratio of posterior predictive spoken and understood counts, so it should be interpreted separately from $q(a)$.
 
-![Production rate q(a)](production_rate.svg){#fig-production-rate .lightbox fig-align="left"}
+![Production rate q(a)](production_rate.png){#fig-production-rate .lightbox fig-align="left"}
 
-![Production ratio by words understood](production_rate_by_understood.svg){#fig-production-rate-by-understood .lightbox fig-align="left"}
+![Production ratio by words understood](production_rate_by_understood.png){#fig-production-rate-by-understood .lightbox fig-align="left"}
 
-![Posterior predictive spoken/understood count ratio](production_rate_predictive.svg){#fig-production-rate-predictive .lightbox fig-align="left"}
+![Posterior predictive spoken/understood count ratio](production_rate_predictive.png){#fig-production-rate-predictive .lightbox fig-align="left"}
 
 ```{python}
 summary_q = pd.read_csv("posterior_summary_q.csv")
@@ -176,13 +176,13 @@ summary_q
 
 The expected difference in word counts between understanding and production.
 
-![Comprehension-production gap](comprehension_production_gap.svg){#fig-gap .lightbox fig-align="left"}
+![Comprehension-production gap](comprehension_production_gap.png){#fig-gap .lightbox fig-align="left"}
 
 ## Words understood vs words spoken
 
-![Expected words understood vs spoken](understood_vs_spoken.svg){#fig-understood-vs-spoken .lightbox fig-align="left"}
+![Expected words understood vs spoken](understood_vs_spoken.png){#fig-understood-vs-spoken .lightbox fig-align="left"}
 
-![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.svg){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
+![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.png){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
 
 ## Posterior predictions -- words understood
 
@@ -209,31 +209,31 @@ posterior_summary_u
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_u](posterior_predictive_pmf_u.svg){#fig-pmf-u .lightbox fig-align="left"}
+![posterior_predictive_pmf_u](posterior_predictive_pmf_u.png){#fig-pmf-u .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_u](posterior_predictive_cdf_u.svg){#fig-cdf-u .lightbox fig-align="left"}
+![posterior_predictive_cdf_u](posterior_predictive_cdf_u.png){#fig-cdf-u .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.svg){#fig-count-dist-u .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.svg){#fig-trend-u .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.png){#fig-trend-u .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.svg){#fig-trend-u-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.png){#fig-trend-u-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_u](expected_learning_rate_u.svg){#fig-rate-u .lightbox fig-align="left"}
+![expected_learning_rate_u](expected_learning_rate_u.png){#fig-rate-u .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- understood
 
-![posterior_kappa_u](posterior_kappa_u.svg){#fig-kappa-u .lightbox fig-align="left"}
+![posterior_kappa_u](posterior_kappa_u.png){#fig-kappa-u .lightbox fig-align="left"}
 
 ## Posterior predictions -- words spoken
 
@@ -246,28 +246,28 @@ posterior_summary_s
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_s](posterior_predictive_pmf_s.svg){#fig-pmf-s .lightbox fig-align="left"}
+![posterior_predictive_pmf_s](posterior_predictive_pmf_s.png){#fig-pmf-s .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_s](posterior_predictive_cdf_s.svg){#fig-cdf-s .lightbox fig-align="left"}
+![posterior_predictive_cdf_s](posterior_predictive_cdf_s.png){#fig-cdf-s .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.svg){#fig-count-dist-s .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.svg){#fig-trend-s .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.png){#fig-trend-s .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.svg){#fig-trend-s-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.png){#fig-trend-s-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_s](expected_learning_rate_s.svg){#fig-rate-s .lightbox fig-align="left"}
+![expected_learning_rate_s](expected_learning_rate_s.png){#fig-rate-s .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- spoken
 
-![posterior_kappa_s](posterior_kappa_s.svg){#fig-kappa-s .lightbox fig-align="left"}
+![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}

--- a/docs/models/vg11/index.qmd
+++ b/docs/models/vg11/index.qmd
@@ -45,35 +45,35 @@ For full details and discussion, please refer to the technical report.
 
 ### Lengthscale
 
-![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.svg){#fig-lengthscale .lightbox fig-align="left"}
+![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.png){#fig-lengthscale .lightbox fig-align="left"}
 
 ### Amplitude
 
-![Amplitude prior distribution `eta_dist`](eta_dist.svg){#fig-amplitude .lightbox fig-align="left"}
+![Amplitude prior distribution `eta_dist`](eta_dist.png){#fig-amplitude .lightbox fig-align="left"}
 
 ### Slope
 
 #### Low slope anchor (12 months)
 
-![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.svg){#fig-slope-low .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.png){#fig-slope-low .lightbox fig-align="left"}
 
 #### High slope anchor (26 months)
 
-![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.svg){#fig-slope-hi .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.png){#fig-slope-hi .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion
 
-![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.svg){#fig-kappa-min .lightbox fig-align="left"}
+![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.png){#fig-kappa-min .lightbox fig-align="left"}
 
-![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.svg){#fig-a-kappa .lightbox fig-align="left"}
+![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.png){#fig-a-kappa .lightbox fig-align="left"}
 
-![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.svg){#fig-b-kappa-mag .lightbox fig-align="left"}
+![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples
 
-![Prior sample trajectories](prior_samples.svg){#fig-prior-samples .lightbox fig-align="left"}
+![Prior sample trajectories](prior_samples.png){#fig-prior-samples .lightbox fig-align="left"}
 
 ### Prior predictions
 
@@ -131,7 +131,7 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Posterior predictions
 
@@ -148,34 +148,34 @@ posterior_summary
 
 The probability of observing a specific count of words spoken for selected ages.
 
-![posterior_predictive_pmf](posterior_predictive_pmf.svg){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
+![posterior_predictive_pmf](posterior_predictive_pmf.png){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
 
 ### Posterior predictive cumulative distribution function (CDF) for word counts, by age
 
 The cumulative sum of the PMF: the probability that the count of words spoken is less than or equal to a specified value for selected ages.
 
-![posterior_predictive_cdf](posterior_predictive_cdf.svg){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
+![posterior_predictive_cdf](posterior_predictive_cdf.png){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.svg){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
 
 ### Posterior predictive median trend with uncertainty intervals
 
-![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.svg){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.png){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
 
 Smoothed:
 
-![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.svg){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.png){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
 
 ### Estimated learning rate
 
 The posterior distribution of the estimated learning rate (estimated gain in spoken words per month) across age.
 
-![expected_learning_rate](expected_learning_rate.svg){#fig-expected-learning-rate .lightbox fig-align="left"}
+![expected_learning_rate](expected_learning_rate.png){#fig-expected-learning-rate .lightbox fig-align="left"}
 
 ### Posterior distribution for dispersion parameter $\kappa$
 
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean).
 
-![posterior_kappa](posterior_kappa.svg){#fig-posterior-kappa .lightbox fig-align="left"}
+![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}

--- a/docs/models/vg12/index.qmd
+++ b/docs/models/vg12/index.qmd
@@ -45,35 +45,35 @@ For full details and discussion, please refer to the technical report.
 
 ### Lengthscale
 
-![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.svg){#fig-lengthscale .lightbox fig-align="left"}
+![Lengthscale prior distribution `ell_unit_dist`](ell_unit_dist.png){#fig-lengthscale .lightbox fig-align="left"}
 
 ### Amplitude
 
-![Amplitude prior distribution `eta_dist`](eta_dist.svg){#fig-amplitude .lightbox fig-align="left"}
+![Amplitude prior distribution `eta_dist`](eta_dist.png){#fig-amplitude .lightbox fig-align="left"}
 
 ### Slope
 
 #### Low slope anchor (12 months)
 
-![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.svg){#fig-slope-low .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_low_dist`](p_slope_low_dist.png){#fig-slope-low .lightbox fig-align="left"}
 
 #### High slope anchor (26 months)
 
-![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.svg){#fig-slope-hi .lightbox fig-align="left"}
+![Slope prior distribution `p_slope_hi_dist`](p_slope_hi_dist.png){#fig-slope-hi .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion
 
-![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.svg){#fig-kappa-min .lightbox fig-align="left"}
+![Dispersion prior distribution `kappa_min_dist`](kappa_min_dist.png){#fig-kappa-min .lightbox fig-align="left"}
 
-![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.svg){#fig-a-kappa .lightbox fig-align="left"}
+![Dispersion prior distribution `a_kappa_dist`](a_kappa_dist.png){#fig-a-kappa .lightbox fig-align="left"}
 
-![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.svg){#fig-b-kappa-mag .lightbox fig-align="left"}
+![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples
 
-![Prior sample trajectories](prior_samples.svg){#fig-prior-samples .lightbox fig-align="left"}
+![Prior sample trajectories](prior_samples.png){#fig-prior-samples .lightbox fig-align="left"}
 
 ### Prior predictions
 
@@ -131,7 +131,7 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Posterior predictions
 
@@ -148,34 +148,34 @@ posterior_summary
 
 The probability of observing a specific count of words understood for selected ages.
 
-![posterior_predictive_pmf](posterior_predictive_pmf.svg){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
+![posterior_predictive_pmf](posterior_predictive_pmf.png){#fig-posterior-predictive-pmf .lightbox fig-align="left"}
 
 ### Posterior predictive cumulative distribution function (CDF) for word counts, by age
 
 The cumulative sum of the PMF: the probability that the count of words understood is less than or equal to a specified value for selected ages.
 
-![posterior_predictive_cdf](posterior_predictive_cdf.svg){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
+![posterior_predictive_cdf](posterior_predictive_cdf.png){#fig-posterior-predictive-cdf .lightbox fig-align="left"}
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.svg){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
 
 ### Posterior predictive median trend with uncertainty intervals
 
-![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.svg){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend](plot_posterior_predictive_median_trend.png){#fig-posterior-predictive-median-trend .lightbox fig-align="left"}
 
 Smoothed:
 
-![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.svg){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
+![plot_posterior_predictive_median_trend_smoothed](plot_posterior_predictive_median_trend_smoothed.png){#fig-posterior-predictive-median-trend-smoothed .lightbox fig-align="left"}
 
 ### Estimated learning rate
 
 The posterior distribution of the estimated learning rate (estimated gain in understood words per month) across age.
 
-![expected_learning_rate](expected_learning_rate.svg){#fig-expected-learning-rate .lightbox fig-align="left"}
+![expected_learning_rate](expected_learning_rate.png){#fig-expected-learning-rate .lightbox fig-align="left"}
 
 ### Posterior distribution for dispersion parameter $\kappa$
 
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean).
 
-![posterior_kappa](posterior_kappa.svg){#fig-posterior-kappa .lightbox fig-align="left"}
+![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}

--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -84,7 +84,7 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Posterior predictions
 
@@ -97,12 +97,12 @@ posterior_summary_u
 
 ### Joint trajectory
 
-![joint_trajectory](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
+![joint_trajectory](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
 ### Production ratio $q$
 
-![production_ratio](production_ratio.svg){#fig-production-ratio .lightbox fig-align="left"}
+![production_ratio](production_rate.png){#fig-production-ratio .lightbox fig-align="left"}
 
 ### Comprehension–production gap
 
-![comprehension_production_gap](comprehension_production_gap.svg){#fig-gap .lightbox fig-align="left"}
+![comprehension_production_gap](comprehension_production_gap.png){#fig-gap .lightbox fig-align="left"}

--- a/docs/models/vg14/index.qmd
+++ b/docs/models/vg14/index.qmd
@@ -67,79 +67,79 @@ For full details and discussion, please refer to the technical report.
 
 ### Understood trajectory
 
-![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.svg){#fig-ell-u .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.png){#fig-ell-u .lightbox fig-align="left"}
 
-![Amplitude prior `eta_u_dist`](eta_u_dist.svg){#fig-eta-u .lightbox fig-align="left"}
+![Amplitude prior `eta_u_dist`](eta_u_dist.png){#fig-eta-u .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.svg){#fig-slope-low-u .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.png){#fig-slope-low-u .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.svg){#fig-slope-hi-u .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.png){#fig-slope-hi-u .lightbox fig-align="left"}
 
 ### Production ratio (spoken)
 
-![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.svg){#fig-ell-q .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
 
-![Amplitude prior `eta_q_dist`](eta_q_dist.svg){#fig-eta-q .lightbox fig-align="left"}
+![Amplitude prior `eta_q_dist`](eta_q_dist.png){#fig-eta-q .lightbox fig-align="left"}
 
-![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.svg){#fig-slope-low-q .lightbox fig-align="left"}
+![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.png){#fig-slope-low-q .lightbox fig-align="left"}
 
-![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.svg){#fig-slope-hi-q .lightbox fig-align="left"}
+![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.png){#fig-slope-hi-q .lightbox fig-align="left"}
 
 ### Signed ratio
 
 The empirical signed fraction of understood words is a **hump** — near zero below ~24 months, rising to a peak in the preschool years, then receding as words move into speech — not a monotone trend. The signed-ratio mean trend is **intercept-only** (no age slope): this structurally prevents a free slope from extrapolating the ratio below the data floor (< ~18 months), so the level no longer needs a tight prior. A single weakly-informative intercept (`intercept_sign`, logit scale) lets the data set the signed level and old-age tail, while the GP — given a **looser amplitude** (`eta_sign`) and a **shorter lengthscale** than the spoken ratio — carries the rise-then-fall shape.
 
-![Lengthscale prior `ell_unit_sign_dist`](ell_unit_sign_dist.svg){#fig-ell-sign .lightbox fig-align="left"}
+![Lengthscale prior `ell_unit_sign_dist`](ell_unit_sign_dist.png){#fig-ell-sign .lightbox fig-align="left"}
 
-![Amplitude prior `eta_sign_dist`](eta_sign_dist.svg){#fig-eta-sign .lightbox fig-align="left"}
+![Amplitude prior `eta_sign_dist`](eta_sign_dist.png){#fig-eta-sign .lightbox fig-align="left"}
 
-![Signed-ratio mean intercept prior `intercept_sign_dist` (logit scale, intercept-only mean)](intercept_sign_dist.svg){#fig-intercept-sign .lightbox fig-align="left"}
+![Signed-ratio mean intercept prior `intercept_sign_dist` (logit scale, intercept-only mean)](intercept_sign_dist.png){#fig-intercept-sign .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- understood
 
-![`kappa_min_u_dist`](kappa_min_u_dist.svg){#fig-kappa-min-u .lightbox fig-align="left"}
+![`kappa_min_u_dist`](kappa_min_u_dist.png){#fig-kappa-min-u .lightbox fig-align="left"}
 
-![`a_kappa_u_dist`](a_kappa_u_dist.svg){#fig-a-kappa-u .lightbox fig-align="left"}
+![`a_kappa_u_dist`](a_kappa_u_dist.png){#fig-a-kappa-u .lightbox fig-align="left"}
 
-![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.svg){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.png){#fig-b-kappa-mag-u .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- spoken
 
-![`kappa_min_s_dist`](kappa_min_s_dist.svg){#fig-kappa-min-s .lightbox fig-align="left"}
+![`kappa_min_s_dist`](kappa_min_s_dist.png){#fig-kappa-min-s .lightbox fig-align="left"}
 
-![`a_kappa_s_dist`](a_kappa_s_dist.svg){#fig-a-kappa-s .lightbox fig-align="left"}
+![`a_kappa_s_dist`](a_kappa_s_dist.png){#fig-a-kappa-s .lightbox fig-align="left"}
 
-![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.svg){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ### Dispersion / overdispersion -- signed
 
-![`kappa_min_sign_dist`](kappa_min_sign_dist.svg){#fig-kappa-min-sign .lightbox fig-align="left"}
+![`kappa_min_sign_dist`](kappa_min_sign_dist.png){#fig-kappa-min-sign .lightbox fig-align="left"}
 
-![`a_kappa_sign_dist`](a_kappa_sign_dist.svg){#fig-a-kappa-sign .lightbox fig-align="left"}
+![`a_kappa_sign_dist`](a_kappa_sign_dist.png){#fig-a-kappa-sign .lightbox fig-align="left"}
 
-![`b_kappa_mag_sign_dist`](b_kappa_mag_sign_dist.svg){#fig-b-kappa-mag-sign .lightbox fig-align="left"}
+![`b_kappa_mag_sign_dist`](b_kappa_mag_sign_dist.png){#fig-b-kappa-mag-sign .lightbox fig-align="left"}
 
 ## Prior predictive checks
 
 ### Prior samples -- words understood
 
-![Prior sample trajectories (understood)](prior_samples_u.svg){#fig-prior-samples-u .lightbox fig-align="left"}
+![Prior sample trajectories (understood)](prior_samples_u.png){#fig-prior-samples-u .lightbox fig-align="left"}
 
 ### Prior samples -- words spoken
 
-![Prior sample trajectories (spoken)](prior_samples_s.svg){#fig-prior-samples-s .lightbox fig-align="left"}
+![Prior sample trajectories (spoken)](prior_samples_s.png){#fig-prior-samples-s .lightbox fig-align="left"}
 
 ### Prior samples -- words signed
 
-![Prior sample trajectories (signed)](prior_samples_sign.svg){#fig-prior-samples-sign .lightbox fig-align="left"}
+![Prior sample trajectories (signed)](prior_samples_sign.png){#fig-prior-samples-sign .lightbox fig-align="left"}
 
 ### Prior samples -- production rate q(a)
 
-![Prior sample trajectories for production ratio q(a)](prior_samples_q.svg){#fig-prior-samples-q .lightbox fig-align="left"}
+![Prior sample trajectories for production ratio q(a)](prior_samples_q.png){#fig-prior-samples-q .lightbox fig-align="left"}
 
 ### Prior samples -- signed rate r(a)
 
-![Prior sample trajectories for signed ratio r(a)](prior_samples_r.svg){#fig-prior-samples-r .lightbox fig-align="left"}
+![Prior sample trajectories for signed ratio r(a)](prior_samples_r.png){#fig-prior-samples-r .lightbox fig-align="left"}
 
 ## Data
 
@@ -184,17 +184,17 @@ _style_diagnostics(diagnostics)
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
-![pair_plot](pair_plot.svg){#fig-pair .lightbox fig-align="left"}
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
 ## Joint trajectory
 
-![Joint posterior predictive trajectory for words understood, spoken and signed](joint_trajectory.svg){#fig-joint-trajectory .lightbox fig-align="left"}
+![Joint posterior predictive trajectory for words understood, spoken and signed](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
 ## Total expressive vocabulary
 
 The expected vocabulary by modality, including the derived total-expressive quantity $p_\text{any}(a)$. As noted above, $p_\text{any}$ assumes signing and speaking are conditionally independent given age, so it is an **upper bound** on the true total expressive vocabulary (the sign–speech association is positive).
 
-![Expected vocabulary by modality (understood, spoken, signed, total expressive)](modality_trajectories.svg){#fig-modality .lightbox fig-align="left"}
+![Expected vocabulary by modality (understood, spoken, signed, total expressive)](modality_trajectories.png){#fig-modality .lightbox fig-align="left"}
 
 ```{python}
 summary_p_any = pd.read_csv("posterior_summary_p_any.csv")
@@ -205,7 +205,7 @@ summary_p_any
 
 `uk_02` is the only source that records each understood word as sign-only, sign+speech, speech-only, or understood-only, so we can test the independence assumption directly. Building the independence union $1-(1-r)(1-q)$ from `uk_02`'s **own** observed sign and speech fractions gives 0.608, versus the **observed** union of 0.571 over 20–56 months — independence over-states the total by ~3.7 percentage points (the dashed line above the observed points), because signing and speaking are positively associated. VG14's own $p_\text{any} / p_U$ (the band) lands closer to the observed union (~1.2 pp above) only because the model's in-window signed ratio is lower than `uk_02`'s, partly cancelling the bias. Both gaps are recorded in `p_any_validation_gap.csv`. VG15 will identify the association directly.
 
-![p_any (independence upper bound) vs uk_02 observed union](p_any_validation.svg){#fig-p-any-validation .lightbox fig-align="left"}
+![p_any (independence upper bound) vs uk_02 observed union](p_any_validation.png){#fig-p-any-validation .lightbox fig-align="left"}
 
 ```{python}
 p_any_gap = pd.read_csv("p_any_validation_gap.csv")
@@ -216,7 +216,7 @@ p_any_gap
 
 The production ratio $q(a) = p_S(a) / p_U(a)$ represents the fraction of understood words that are spoken at each age.
 
-![Production rate q(a)](production_rate.svg){#fig-production-rate .lightbox fig-align="left"}
+![Production rate q(a)](production_rate.png){#fig-production-rate .lightbox fig-align="left"}
 
 ```{python}
 summary_q = pd.read_csv("posterior_summary_q.csv")
@@ -233,7 +233,7 @@ The fitted curve peaks at ~24–30 months and then declines, but **the peak age 
 
 :::
 
-![Signed rate r(a)](signed_rate.svg){#fig-signed-rate .lightbox fig-align="left"}
+![Signed rate r(a)](signed_rate.png){#fig-signed-rate .lightbox fig-align="left"}
 
 ```{python}
 summary_r = pd.read_csv("posterior_summary_r.csv")
@@ -244,13 +244,13 @@ summary_r
 
 The signed ratio $r(a)$ against the spoken ratio $q(a)$ on a single axis. The robust result is the **crossover at ~39 months**: early on a larger share of understood words is signed than spoken, and by the late preschool years the rising spoken fraction overtakes the signed fraction — the sign-to-speech hand-off. (As above, the exact signed peak and the post-peak decline are study-confounded and should not be read as a precise developmental month; ages outside the ~18–54-month signing-data window are shaded as extrapolation.)
 
-![Signed ratio r(a) vs production ratio q(a)](sign_speech_crossover.svg){#fig-crossover .lightbox fig-align="left"}
+![Signed ratio r(a) vs production ratio q(a)](sign_speech_crossover.png){#fig-crossover .lightbox fig-align="left"}
 
 ## Comprehension-production gap
 
 The expected difference in word counts between understanding and speaking.
 
-![Comprehension-production gap](comprehension_production_gap.svg){#fig-gap .lightbox fig-align="left"}
+![Comprehension-production gap](comprehension_production_gap.png){#fig-gap .lightbox fig-align="left"}
 
 ## Posterior predictions -- words understood
 
@@ -263,31 +263,31 @@ posterior_summary_u
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_u](posterior_predictive_pmf_u.svg){#fig-pmf-u .lightbox fig-align="left"}
+![posterior_predictive_pmf_u](posterior_predictive_pmf_u.png){#fig-pmf-u .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_u](posterior_predictive_cdf_u.svg){#fig-cdf-u .lightbox fig-align="left"}
+![posterior_predictive_cdf_u](posterior_predictive_cdf_u.png){#fig-cdf-u .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.svg){#fig-count-dist-u .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.svg){#fig-trend-u .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.png){#fig-trend-u .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.svg){#fig-trend-u-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.png){#fig-trend-u-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_u](expected_learning_rate_u.svg){#fig-rate-u .lightbox fig-align="left"}
+![expected_learning_rate_u](expected_learning_rate_u.png){#fig-rate-u .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- understood
 
-![posterior_kappa_u](posterior_kappa_u.svg){#fig-kappa-u .lightbox fig-align="left"}
+![posterior_kappa_u](posterior_kappa_u.png){#fig-kappa-u .lightbox fig-align="left"}
 
 ## Posterior predictions -- words spoken
 
@@ -300,31 +300,31 @@ posterior_summary_s
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_s](posterior_predictive_pmf_s.svg){#fig-pmf-s .lightbox fig-align="left"}
+![posterior_predictive_pmf_s](posterior_predictive_pmf_s.png){#fig-pmf-s .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_s](posterior_predictive_cdf_s.svg){#fig-cdf-s .lightbox fig-align="left"}
+![posterior_predictive_cdf_s](posterior_predictive_cdf_s.png){#fig-cdf-s .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.svg){#fig-count-dist-s .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.svg){#fig-trend-s .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.png){#fig-trend-s .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.svg){#fig-trend-s-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.png){#fig-trend-s-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_s](expected_learning_rate_s.svg){#fig-rate-s .lightbox fig-align="left"}
+![expected_learning_rate_s](expected_learning_rate_s.png){#fig-rate-s .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- spoken
 
-![posterior_kappa_s](posterior_kappa_s.svg){#fig-kappa-s .lightbox fig-align="left"}
+![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}
 
 ## Posterior predictions -- words signed
 
@@ -337,28 +337,28 @@ posterior_summary_sign
 
 ### Posterior predictive PMF
 
-![posterior_predictive_pmf_sign](posterior_predictive_pmf_sign.svg){#fig-pmf-sign .lightbox fig-align="left"}
+![posterior_predictive_pmf_sign](posterior_predictive_pmf_sign.png){#fig-pmf-sign .lightbox fig-align="left"}
 
 ### Posterior predictive CDF
 
-![posterior_predictive_cdf_sign](posterior_predictive_cdf_sign.svg){#fig-cdf-sign .lightbox fig-align="left"}
+![posterior_predictive_cdf_sign](posterior_predictive_cdf_sign.png){#fig-cdf-sign .lightbox fig-align="left"}
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_sign](posterior_predictive_count_distributions_sign.svg){#fig-count-dist-sign .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_sign](posterior_predictive_count_distributions_sign.png){#fig-count-dist-sign .lightbox fig-align="left"}
 
 ### Median trend
 
-![posterior_predictive_median_trend_sign](posterior_predictive_median_trend_sign.svg){#fig-trend-sign .lightbox fig-align="left"}
+![posterior_predictive_median_trend_sign](posterior_predictive_median_trend_sign.png){#fig-trend-sign .lightbox fig-align="left"}
 
 Smoothed:
 
-![posterior_predictive_median_trend_sign_smoothed](posterior_predictive_median_trend_sign_smoothed.svg){#fig-trend-sign-smooth .lightbox fig-align="left"}
+![posterior_predictive_median_trend_sign_smoothed](posterior_predictive_median_trend_sign_smoothed.png){#fig-trend-sign-smooth .lightbox fig-align="left"}
 
 ### Learning rate
 
-![expected_learning_rate_sign](expected_learning_rate_sign.svg){#fig-rate-sign .lightbox fig-align="left"}
+![expected_learning_rate_sign](expected_learning_rate_sign.png){#fig-rate-sign .lightbox fig-align="left"}
 
 ### Dispersion $\kappa$ -- signed
 
-![posterior_kappa_sign](posterior_kappa_sign.svg){#fig-kappa-sign .lightbox fig-align="left"}
+![posterior_kappa_sign](posterior_kappa_sign.png){#fig-kappa-sign .lightbox fig-align="left"}

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -75,21 +75,21 @@ The association $\psi$ is identified by the ~60 uk_02 rows with the four-cell cr
 
 ### Trajectories (understood / spoken-ratio / signed-ratio)
 
-![`p_slope_low_u_dist`](p_slope_low_u_dist.svg){.lightbox fig-align="left" width=380}
-![`eta_u_dist`](eta_u_dist.svg){.lightbox fig-align="left" width=380}
-![`intercept_sign_dist` (signed mean is intercept-only)](intercept_sign_dist.svg){.lightbox fig-align="left" width=380}
-![`eta_sign_dist`](eta_sign_dist.svg){.lightbox fig-align="left" width=380}
+![`p_slope_low_u_dist`](p_slope_low_u_dist.png){.lightbox fig-align="left" width=380}
+![`eta_u_dist`](eta_u_dist.png){.lightbox fig-align="left" width=380}
+![`intercept_sign_dist` (signed mean is intercept-only)](intercept_sign_dist.png){.lightbox fig-align="left" width=380}
+![`eta_sign_dist`](eta_sign_dist.png){.lightbox fig-align="left" width=380}
 
 ### Association and concentration
 
-![Plackett log odds-ratio prior `log_psi_dist`](log_psi_dist.svg){#fig-log-psi .lightbox fig-align="left" width=380}
-![Dirichlet-Multinomial log-concentration prior `log_conc_dist`](log_conc_dist.svg){#fig-log-conc .lightbox fig-align="left" width=380}
+![Plackett log odds-ratio prior `log_psi_dist`](log_psi_dist.png){#fig-log-psi .lightbox fig-align="left" width=380}
+![Dirichlet-Multinomial log-concentration prior `log_conc_dist`](log_conc_dist.png){#fig-log-conc .lightbox fig-align="left" width=380}
 
 ## Prior predictive checks
 
-![Prior r(a) = P(sign | understood)](prior_samples_r.svg){#fig-prior-r .lightbox fig-align="left"}
+![Prior r(a) = P(sign | understood)](prior_samples_r.png){#fig-prior-r .lightbox fig-align="left"}
 
-![Prior q(a) = P(speak | understood)](prior_samples_q.svg){#fig-prior-q .lightbox fig-align="left"}
+![Prior q(a) = P(speak | understood)](prior_samples_q.png){#fig-prior-q .lightbox fig-align="left"}
 
 ## Data
 
@@ -113,7 +113,7 @@ diagnostics
 
 The posterior of the sign-speech odds ratio $\psi$, with the independence reference $\psi = 1$.
 
-![Association psi posterior](psi_posterior.svg){#fig-psi .lightbox fig-align="left"}
+![Association psi posterior](psi_posterior.png){#fig-psi .lightbox fig-align="left"}
 
 ```{python}
 summary_psi = pd.read_csv("posterior_summary_psi.csv")
@@ -124,13 +124,13 @@ summary_psi
 
 The four mutually-exclusive states of an understood word (sign-only, sign+speech, speak-only, neither) as fractions of understood vocabulary over age — words migrating from sign into speech.
 
-![Four-cell composition trajectory](four_cell_composition.svg){#fig-composition .lightbox fig-align="left"}
+![Four-cell composition trajectory](four_cell_composition.png){#fig-composition .lightbox fig-align="left"}
 
 ## Total expressive vocabulary (data-identified)
 
 The data-identified $p_\text{any}$ against VG14's independence upper bound. With $\psi > 1$ the identified total sits below the bound (the gap is the association VG14 ignored).
 
-![Data-identified p_any vs independence bound](p_any_identified_vs_bound.svg){#fig-p-any .lightbox fig-align="left"}
+![Data-identified p_any vs independence bound](p_any_identified_vs_bound.png){#fig-p-any .lightbox fig-align="left"}
 
 ```{python}
 summary_p_any = pd.read_csv("posterior_summary_p_any.csv")
@@ -141,7 +141,7 @@ summary_p_any
 
 The population sign and speak ratios with study composition absorbed by the random intercepts. Compare the signed peak/recede with VG14, where it was study-confounded.
 
-![Signed vs spoken ratio](signed_vs_spoken_rate.svg){#fig-rates .lightbox fig-align="left"}
+![Signed vs spoken ratio](signed_vs_spoken_rate.png){#fig-rates .lightbox fig-align="left"}
 
 ```{python}
 summary_r = pd.read_csv("posterior_summary_r.csv")
@@ -152,4 +152,4 @@ summary_r
 
 Observed vs predicted totals for the four within-understood cells (uk_02), checking the Dirichlet-Multinomial fit that identifies $\psi$.
 
-![uk_02 four-cell PPC](uk02_cell_ppc.svg){#fig-ppc .lightbox fig-align="left"}
+![uk_02 four-cell PPC](uk02_cell_ppc.png){#fig-ppc .lightbox fig-align="left"}

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -5,6 +5,7 @@ import mimetypes
 import os
 import time
 import uuid
+from collections.abc import Callable
 from urllib.parse import urlparse
 
 from azure.identity import DefaultAzureCredential
@@ -19,14 +20,27 @@ from vocab_growth.reporting import (
 
 
 def upload_to_blob_storage(
-    output_dir: str, model_label: str, *, include_traces: bool = False
-) -> None:
+    output_dir: str,
+    model_label: str,
+    *,
+    include_traces: bool = False,
+    skip: Callable[[str], bool] | None = None,
+) -> str:
     """Upload model output directory to Azure Blob Storage.
 
     Parameters
     ----------
     include_traces : bool
         If True, include NetCDF trace files (.nc). Excluded by default due to size.
+    skip : callable, optional
+        Predicate called with each file's POSIX-style path relative to
+        ``output_dir``; return True to skip uploading that file. Use to exclude
+        unreferenced artifacts (e.g. heavy SVG figures superseded by PNGs).
+
+    Returns
+    -------
+    str
+        The public URL of the uploaded ``index.html`` report.
     """
     container_url = os.environ.get("DSERESEARCH_BLOB_CONTAINER_URL")
     if not container_url:
@@ -69,12 +83,16 @@ def upload_to_blob_storage(
     started = time.perf_counter()
     for root, _dirs, files in os.walk(output_dir):
         for filename in files:
+            local_path = os.path.join(root, filename)
+            relative_path = os.path.relpath(local_path, output_dir).replace("\\", "/")
+
             if not include_traces and filename.endswith(".nc"):
                 skipped += 1
                 continue
+            if skip is not None and skip(relative_path):
+                skipped += 1
+                continue
 
-            local_path = os.path.join(root, filename)
-            relative_path = os.path.relpath(local_path, output_dir).replace("\\", "/")
             blob_name = f"{blob_prefix}/{relative_path}"
 
             content_type, _ = mimetypes.guess_type(filename)
@@ -91,12 +109,15 @@ def upload_to_blob_storage(
                 )
             uploaded += 1
 
+    report_url = f"{account_url}/{container_name}/{blob_prefix}/index.html"
     key_value_table(
         f"Upload complete — {model_label}",
         [
             ("Files uploaded", uploaded),
-            ("Files skipped (.nc)", skipped),
+            ("Files skipped", skipped),
             ("Bytes uploaded", f"{bytes_sent / 1_000_000:.1f} MB"),
             ("Elapsed", format_duration(time.perf_counter() - started)),
+            ("Report URL", report_url),
         ],
     )
+    return report_url


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

Switch the per-model report templates to reference PNG figures instead of SVG. Dense matplotlib SVGs (many elements — trajectory/posterior bands, scatter of every data point, pair plots) made the published HTML model reports slow to browse.

## Changes

- **`docs/models/vgNN/index.qmd` (×15):** all figure references `.svg → .png` (422 refs). PNGs are already generated alongside the SVGs at fit time, so no plotting/generation changes are needed.
- **`gp_model_graph` kept as SVG** — a small graphviz DAG (not a many-element plot) and the only figure with no PNG sibling on disk.
- **VG13:** fixed a pre-existing broken reference (`production_ratio` → `production_rate`) that showed a missing-image icon in the published report.
- **`src/vocab_growth/storage.py`:** `upload_to_blob_storage` gains an optional `skip(rel_path) -> bool` predicate and now returns the published `index.html` URL. Backward compatible — existing callers ignore the return value and don't pass `skip`.

## Verification

- Every PNG referenced by the 15 templates exists on disk in all output dirs.
- VG01 smoke render embeds 20 PNGs + 1 SVG (the DAG).
- `ruff` clean; `cspell` 0 issues; `prettier --check` clean.
- All 15 reports were re-rendered and re-published (PNG-based), excluding the now-unused figure SVGs (~315 MB vs ~1.3 GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)