### PR TITLE
Consolidate duplicated model-build scaffolding across the engines (#66)

### DIFF
--- a/src/vocab_growth/models/build_utils.py
+++ b/src/vocab_growth/models/build_utils.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Pure-NumPy build helpers shared across the model engines.
+
+These functions factor out blocks that were previously copy-and-pasted, byte for
+byte, into the ``build`` step of every engine (``common.py`` and its
+copy-and-extend siblings): age standardisation, plot/query grid construction,
+length-scale validation, and slope-anchor z-scoring.
+
+They are deliberately free of any ``pymc`` import. Every function performs only
+deterministic NumPy arithmetic and returns plain Python scalars / NumPy arrays
+that are subsequently fed into ``pm.Data(...)`` and the model trend. Because the
+operations (and their order) are identical to the inlined code they replace, the
+values handed to the PyMC graph are bit-identical, so the graph and the sampling
+RNG are unaffected. Graph-building helpers that create PyMC random variables live
+separately in :mod:`vocab_growth.models.gp_utils`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+def standardize_ages(X_obs: np.ndarray) -> tuple[float, float, np.ndarray]:
+    """Return ``(mean, std, X_obs_z)`` for the observed ages.
+
+    ``std`` uses ``ddof=1`` (sample standard deviation), matching the convention
+    every engine relies on for its z-scores. Raises ``ValueError`` if the
+    standard deviation is non-finite or non-positive (degenerate ages).
+
+    The age *median* is intentionally not computed here: it is reporting-only and
+    used by a single engine's build table, so it stays in the caller.
+    """
+    X_obs_mean = float(np.mean(X_obs))
+    X_obs_std = float(np.std(X_obs, ddof=1))
+
+    if not np.isfinite(X_obs_std) or X_obs_std <= 0:
+        raise ValueError("Age standard deviation must be positive.")
+
+    X_obs_z = (X_obs - X_obs_mean) / X_obs_std
+    return X_obs_mean, X_obs_std, X_obs_z
+
+
+@dataclass(frozen=True)
+class AgeGrids:
+    """Standardised age grids for observed, plot, and query points.
+
+    ``X_all_z`` is the vertical stack ``[obs, plot, query]`` (plus a single anchor
+    row when ``use_gp_anchor`` is requested). The ``i_*`` fields are
+    ``(start, stop)`` slice bounds into ``X_all_z``; ``i_anchor`` is the integer
+    index of the anchor row (or ``None`` when not anchored).
+    """
+
+    X_plot: np.ndarray
+    X_plot_z: np.ndarray
+    X_query: np.ndarray
+    X_query_z: np.ndarray
+    X_all_z: np.ndarray
+    n_plot: int
+    n_query: int
+    n_all: int
+    i_obs: tuple[int, int]
+    i_plot: tuple[int, int]
+    i_query: tuple[int, int]
+    i_anchor: int | None
+    anchor_age_months: float | None
+
+
+def construct_age_grids(
+    X_obs: np.ndarray,
+    X_obs_z: np.ndarray,
+    *,
+    X_obs_mean: float,
+    X_obs_std: float,
+    n_plot: int,
+    ages_query,
+    slope_anchors,
+    use_gp_anchor: bool = False,
+    gp_anchor_age_months: float | None = None,
+) -> AgeGrids:
+    """Build the plot/query grids and the stacked standardised grid ``X_all_z``.
+
+    ``X_obs`` is in original months (used for the ``linspace`` plot grid bounds);
+    ``X_obs_z`` is the already-standardised observed grid (used in the stack).
+
+    When ``use_gp_anchor`` is True a single anchor row is appended to ``X_all_z``
+    at ``gp_anchor_age_months`` (defaulting to the midpoint of ``slope_anchors``
+    when not given), matching the reference-age anchoring used by the random-
+    effects and joint engines.
+    """
+    X_plot = np.linspace(X_obs.min(), X_obs.max(), n_plot).reshape(-1, 1)
+    X_plot_z = (X_plot - X_obs_mean) / X_obs_std
+
+    X_query = np.array(ages_query).reshape(-1, 1)
+    X_query_z = (X_query - X_obs_mean) / X_obs_std
+
+    n = X_obs_z.shape[0]
+    n_plot_actual = X_plot_z.shape[0]
+    n_query = X_query_z.shape[0]
+
+    if use_gp_anchor:
+        if gp_anchor_age_months is not None:
+            anchor_age_months: float | None = float(gp_anchor_age_months)
+        else:
+            anchor_age_months = (
+                float(slope_anchors[0]) + float(slope_anchors[1])
+            ) / 2.0
+        X_anchor_z = (
+            np.array([[anchor_age_months]], dtype=float) - X_obs_mean
+        ) / X_obs_std
+        X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z, X_anchor_z])
+        i_anchor: int | None = n + n_plot_actual + n_query
+    else:
+        anchor_age_months = None
+        X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z])
+        i_anchor = None
+
+    n_all = X_all_z.shape[0]
+
+    return AgeGrids(
+        X_plot=X_plot,
+        X_plot_z=X_plot_z,
+        X_query=X_query,
+        X_query_z=X_query_z,
+        X_all_z=X_all_z,
+        n_plot=n_plot_actual,
+        n_query=n_query,
+        n_all=n_all,
+        i_obs=(0, n),
+        i_plot=(n, n + n_plot_actual),
+        i_query=(n + n_plot_actual, n + n_plot_actual + n_query),
+        i_anchor=i_anchor,
+        anchor_age_months=anchor_age_months,
+    )
+
+
+def validate_ell_bounds(ell_months_range) -> tuple[float, float]:
+    """Return ``(ell_low_months, ell_high_months)`` as floats after validation.
+
+    Raises ``ValueError`` if either bound is non-positive or if the range is not
+    strictly increasing — the two checks previously inlined in every engine.
+    """
+    ell_low_months = float(ell_months_range[0])
+    ell_high_months = float(ell_months_range[1])
+
+    if ell_low_months <= 0 or ell_high_months <= 0:
+        raise ValueError("Length-scale bounds must be positive (in months).")
+    if ell_high_months <= ell_low_months:
+        raise ValueError("ell_months_range must be (low, high) with high > low.")
+
+    return ell_low_months, ell_high_months
+
+
+def slope_anchor_logit_coeffs(
+    slope_anchors,
+    *,
+    X_obs_mean: float,
+    X_obs_std: float,
+) -> tuple[float, float]:
+    """Return the z-scored slope-anchor ages ``(slope_age_a_z, slope_age_b_z)``.
+
+    Only the pure z-scoring is shared. The logit-difference computation of the
+    slope/intercept coefficients operates on PyMC random variables and stays
+    inline in each engine's model context.
+    """
+    slope_age_a = float(slope_anchors[0])
+    slope_age_b = float(slope_anchors[1])
+    slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
+    slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
+    return slope_age_a_z, slope_age_b_z

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -40,8 +40,15 @@ import vocab_growth.environment as local_env
 import vocab_growth.plotting as plotting
 import vocab_growth.posterior_analysis as posterior_analysis
 import vocab_growth.reporting as vg_reporting
+from vocab_growth.models.build_utils import (
+    construct_age_grids,
+    slope_anchor_logit_coeffs,
+    standardize_ages,
+    validate_ell_bounds,
+)
 from vocab_growth.models.definitions import UnivariateModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
+from vocab_growth.models.gp_utils import make_kappa_of_z
 from vocab_growth.reporting import (
     config_table,
     console,
@@ -474,11 +481,7 @@ def build_model(context: ModelFitContext):
         raise ValueError("y_obs exceeds n_trials.")
 
     X_obs_median = float(np.median(context.model_data.X_obs))
-    X_obs_mean = float(np.mean(context.model_data.X_obs))
-    X_obs_std = float(np.std(context.model_data.X_obs, ddof=1))
-
-    if not np.isfinite(X_obs_std) or X_obs_std <= 0:
-        raise ValueError("Age standard deviation must be positive.")
+    X_obs_mean, X_obs_std, X_obs_z = standardize_ages(context.model_data.X_obs)
 
     key_value_table(
         "Build configuration",
@@ -510,36 +513,29 @@ def build_model(context: ModelFitContext):
         value_header="Distribution",
     )
 
-    # Predictor standardised (z-score)
-    X_obs_z = (context.model_data.X_obs - X_obs_mean) / X_obs_std
+    # Plot / query grids (standardised), stacked for 'free' predictions — see
+    # models.build_utils.construct_age_grids.
+    grids = construct_age_grids(
+        context.model_data.X_obs,
+        X_obs_z,
+        X_obs_mean=X_obs_mean,
+        X_obs_std=X_obs_std,
+        n_plot=context.model_config.n_plot,
+        ages_query=context.model_config.ages_query,
+        slope_anchors=context.model_config.slope_anchors,
+    )
+    X_plot = grids.X_plot
+    X_plot_z = grids.X_plot_z
+    X_query = grids.X_query
+    X_query_z = grids.X_query_z
+    X_all_z = grids.X_all_z
+    n_plot = grids.n_plot
+    n_query = grids.n_query
+    n_all = grids.n_all
 
-    # Plot grid
-    X_plot = np.linspace(
-        context.model_data.X_obs.min(),
-        context.model_data.X_obs.max(),
-        context.model_config.n_plot,
-    ).reshape(-1, 1)
-    X_plot_z = (X_plot - X_obs_mean) / X_obs_std
-
-    # Query grid
-    X_query = np.array(context.model_config.ages_query).reshape(-1, 1)
-    X_query_z = (X_query - X_obs_mean) / X_obs_std
-
-    # Stack for 'free' predictions (all standardised)
-    X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z])
-
-    n_plot = X_plot_z.shape[0]
-    n_query = X_query_z.shape[0]
-    n_all = X_all_z.shape[0]
-
-    ell_low_months = float(context.model_config.ell_months_range[0])
-    ell_high_months = float(context.model_config.ell_months_range[1])
-
-    if ell_low_months <= 0 or ell_high_months <= 0:
-        raise ValueError("Length-scale bounds must be positive (in months).")
-    if ell_high_months <= ell_low_months:
-        raise ValueError("ell_months_range must be (low, high) with high > low.")
-
+    ell_low_months, ell_high_months = validate_ell_bounds(
+        context.model_config.ell_months_range
+    )
     ell_low_z = ell_low_months / X_obs_std
     ell_high_z = ell_high_months / X_obs_std
     ell_range_z = (ell_low_z, ell_high_z)
@@ -549,10 +545,11 @@ def build_model(context: ModelFitContext):
         ell_range_z,
     )
 
-    slope_age_a = float(context.model_config.slope_anchors[0])
-    slope_age_b = float(context.model_config.slope_anchors[1])
-    slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
-    slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
+    slope_age_a_z, slope_age_b_z = slope_anchor_logit_coeffs(
+        context.model_config.slope_anchors,
+        X_obs_mean=X_obs_mean,
+        X_obs_std=X_obs_std,
+    )
 
     key_value_table(
         "Derived quantities",
@@ -675,8 +672,7 @@ def build_model(context: ModelFitContext):
         b_kappa = pm.Deterministic("b_kappa", -b_kappa_mag)
 
         # function to compute kappa as a function of age (z)
-        def kappa_of_z(z):
-            return kappa_min + pm.math.exp(a_kappa + b_kappa * z)
+        kappa_of_z = make_kappa_of_z(kappa_min, a_kappa, b_kappa)
 
         # compute kappa for the observed data points, and use that in the likelihood
         kappa_obs = pm.Deterministic("kappa_obs", kappa_of_z(z_obs), dims="obs_id")

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -41,6 +41,12 @@ import vocab_growth.environment as local_env
 import vocab_growth.plotting as plotting
 import vocab_growth.posterior_analysis as posterior_analysis
 import vocab_growth.reporting as vg_reporting
+from vocab_growth.models.build_utils import (
+    construct_age_grids,
+    slope_anchor_logit_coeffs,
+    standardize_ages,
+    validate_ell_bounds,
+)
 from vocab_growth.models.common import (
     PACKAGE_LIST,
     BaseModelConfiguration,
@@ -53,7 +59,18 @@ from vocab_growth.models.common import (
 )
 from vocab_growth.models.definitions import BivariateModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
-from vocab_growth.plotting import _save_csv
+from vocab_growth.models.gp_utils import make_kappa_of_z
+from vocab_growth.plotting import (
+    _save_csv,
+    plot_comprehension_production_gap,
+    plot_production_rate,
+)
+from vocab_growth.posterior_analysis import (
+    extract_posterior as _extract_posterior,
+)
+from vocab_growth.posterior_analysis import (
+    extract_posterior_predictive as _extract_posterior_predictive,
+)
 from vocab_growth.reporting import (
     config_table,
     console,
@@ -377,11 +394,7 @@ def build_model(context: BivariateContext):
         raise ValueError("y_s exceeds n_trials.")
 
     # Standardise ages
-    X_obs_mean = float(np.mean(X_obs))
-    X_obs_std = float(np.std(X_obs, ddof=1))
-
-    if not np.isfinite(X_obs_std) or X_obs_std <= 0:
-        raise ValueError("Age standard deviation must be positive.")
+    X_obs_mean, X_obs_std, X_obs_z = standardize_ages(X_obs)
 
     key_value_table(
         "Build configuration",
@@ -398,32 +411,26 @@ def build_model(context: BivariateContext):
         ],
     )
 
-    X_obs_z = (X_obs - X_obs_mean) / X_obs_std
-
-    # Plot grid
-    X_plot = np.linspace(X_obs.min(), X_obs.max(), config.n_plot).reshape(-1, 1)
-    X_plot_z = (X_plot - X_obs_mean) / X_obs_std
-
-    # Query grid
-    X_query = np.array(config.ages_query).reshape(-1, 1)
-    X_query_z = (X_query - X_obs_mean) / X_obs_std
-
-    # Stack all
-    X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z])
-
-    n_plot = X_plot_z.shape[0]
-    n_query = X_query_z.shape[0]
-    n_all = X_all_z.shape[0]
+    # Plot / query grids (standardised), stacked for 'free' predictions — see
+    # models.build_utils.construct_age_grids.
+    grids = construct_age_grids(
+        X_obs,
+        X_obs_z,
+        X_obs_mean=X_obs_mean,
+        X_obs_std=X_obs_std,
+        n_plot=config.n_plot,
+        ages_query=config.ages_query,
+        slope_anchors=config.slope_anchors,
+    )
+    X_plot = grids.X_plot
+    X_query = grids.X_query
+    X_all_z = grids.X_all_z
+    n_plot = grids.n_plot
+    n_query = grids.n_query
+    n_all = grids.n_all
 
     # Length-scale bounds
-    ell_low_months = float(config.ell_months_range[0])
-    ell_high_months = float(config.ell_months_range[1])
-
-    if ell_low_months <= 0 or ell_high_months <= 0:
-        raise ValueError("Length-scale bounds must be positive (in months).")
-    if ell_high_months <= ell_low_months:
-        raise ValueError("ell_months_range must be (low, high) with high > low.")
-
+    ell_low_months, ell_high_months = validate_ell_bounds(config.ell_months_range)
     ell_low_z = ell_low_months / X_obs_std
     ell_high_z = ell_high_months / X_obs_std
     ell_range_z = (ell_low_z, ell_high_z)
@@ -431,10 +438,9 @@ def build_model(context: BivariateContext):
     L, M = get_hsgp_hyperparams(X_obs_z, ell_range_z)
 
     # Slope anchors
-    slope_age_a = float(config.slope_anchors[0])
-    slope_age_b = float(config.slope_anchors[1])
-    slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
-    slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
+    slope_age_a_z, slope_age_b_z = slope_anchor_logit_coeffs(
+        config.slope_anchors, X_obs_mean=X_obs_mean, X_obs_std=X_obs_std
+    )
 
     key_value_table(
         "Derived quantities",
@@ -614,8 +620,7 @@ def build_model(context: BivariateContext):
         b_kappa_mag_u = config.b_kappa_mag_u_dist.to_pymc("b_kappa_mag_u")
         b_kappa_u = pm.Deterministic("b_kappa_u", -b_kappa_mag_u)
 
-        def kappa_u_of_z(z):
-            return kappa_min_u + pm.math.exp(a_kappa_u + b_kappa_u * z)
+        kappa_u_of_z = make_kappa_of_z(kappa_min_u, a_kappa_u, b_kappa_u)
 
         kappa_u_obs = pm.Deterministic(
             "kappa_u_obs", kappa_u_of_z(z_obs), dims="obs_id"
@@ -632,8 +637,7 @@ def build_model(context: BivariateContext):
         b_kappa_mag_s = config.b_kappa_mag_s_dist.to_pymc("b_kappa_mag_s")
         b_kappa_s = pm.Deterministic("b_kappa_s", -b_kappa_mag_s)
 
-        def kappa_s_of_z(z):
-            return kappa_min_s + pm.math.exp(a_kappa_s + b_kappa_s * z)
+        kappa_s_of_z = make_kappa_of_z(kappa_min_s, a_kappa_s, b_kappa_s)
 
         kappa_s_obs = pm.Deterministic(
             "kappa_s_obs", kappa_s_of_z(z_obs), dims="obs_id"
@@ -687,27 +691,6 @@ def build_model(context: BivariateContext):
 # ============================================================
 # Sample extraction
 # ============================================================
-
-
-def _extract_posterior(trace, name, dim_name):
-    """Extract posterior samples, stacking chains and draws."""
-    return np.array(
-        trace.posterior[name]
-        .stack(sample=("chain", "draw"))
-        .transpose(dim_name, "sample")
-        .values
-    )
-
-
-def _extract_posterior_predictive(trace, name, dim_name):
-    """Extract posterior predictive samples, stacking chains and draws."""
-    return np.array(
-        trace.posterior_predictive[name]
-        .stack(sample=("chain", "draw"))
-        .transpose(dim_name, "sample")
-        .values,
-        dtype=int,
-    )
 
 
 def extract_model_samples(trace: xr.DataTree) -> BivariateModelSamples:
@@ -1316,69 +1299,6 @@ def plot_understood_spoken_trajectory_hdi(
     return fig
 
 
-def plot_production_rate(
-    samples: BivariateModelSamples,
-    hdi_prob: float = 0.90,
-    output_dir: str | None = None,
-    filename: str | None = None,
-):
-    """Plot the posterior of the production ratio q(a) = p_S(a) / p_U(a) over age."""
-    X_plot = samples.X_plot
-    q_plot = samples.q_plot
-
-    q_median = np.median(q_plot, axis=1)
-    q_hdi = az.hdi(q_plot, prob=hdi_prob)
-    q_hdi_75 = az.hdi(q_plot, prob=0.75)
-    q_hdi_50 = az.hdi(q_plot, prob=0.50)
-
-    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-
-    ax.fill_between(
-        X_plot,
-        q_hdi[:, 0],
-        q_hdi[:, 1],
-        alpha=0.20,
-        label=f"{int(hdi_prob * 100)}% HDI",
-    )
-    ax.fill_between(
-        X_plot,
-        q_hdi_75[:, 0],
-        q_hdi_75[:, 1],
-        alpha=0.25,
-        label="75% HDI",
-    )
-    ax.fill_between(
-        X_plot,
-        q_hdi_50[:, 0],
-        q_hdi_50[:, 1],
-        alpha=0.30,
-        label="50% HDI",
-    )
-    ax.plot(X_plot, q_median, lw=3, label="Median q(a)")
-
-    ax.set_xlabel("Age (months)")
-    ax.set_ylabel("q(a) = p_S(a) / p_U(a)")
-    ax.set_ylim(0, 1)
-    ax.legend(loc="upper left", frameon=True)
-    ax.set_title("Production ratio q(a)")
-
-    if output_dir is not None and filename is not None:
-        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
-        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
-        _save_csv(pd.DataFrame({
-            "age_months": X_plot,
-            "q_median": q_median,
-            "hdi_lo": q_hdi[:, 0],
-            "hdi_hi": q_hdi[:, 1],
-            "hdi75_lo": q_hdi_75[:, 0],
-            "hdi75_hi": q_hdi_75[:, 1],
-            "hdi50_lo": q_hdi_50[:, 0],
-            "hdi50_hi": q_hdi_50[:, 1],
-        }), output_dir, filename)
-
-    return fig
-
-
 def plot_production_rate_by_understood(
     samples: BivariateModelSamples,
     n_trials: int,
@@ -1510,59 +1430,6 @@ def plot_production_rate_predictive(
             "hdi75_hi": ratio_hdi_75[:, 1],
             "hdi50_lo": ratio_hdi_50[:, 0],
             "hdi50_hi": ratio_hdi_50[:, 1],
-        }), output_dir, filename)
-
-    return fig
-
-
-def plot_comprehension_production_gap(
-    samples: BivariateModelSamples,
-    n_trials: int,
-    hdi_prob: float = 0.90,
-    output_dir: str | None = None,
-    filename: str | None = None,
-):
-    """Plot the posterior of the comprehension-production gap (p_U - p_S) over age."""
-    X_plot = samples.X_plot
-    gap = (samples.p_u_plot - samples.p_s_plot) * n_trials  # in word count units
-
-    gap_median = np.median(gap, axis=1)
-    gap_hdi = az.hdi(gap, prob=hdi_prob)
-    gap_hdi_50 = az.hdi(gap, prob=0.50)
-
-    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-
-    ax.fill_between(
-        X_plot,
-        gap_hdi[:, 0],
-        gap_hdi[:, 1],
-        alpha=0.20,
-        label=f"{int(hdi_prob * 100)}% HDI",
-    )
-    ax.fill_between(
-        X_plot,
-        gap_hdi_50[:, 0],
-        gap_hdi_50[:, 1],
-        alpha=0.30,
-        label="50% HDI",
-    )
-    ax.plot(X_plot, gap_median, lw=3, label="Median gap")
-
-    ax.set_xlabel("Age (months)")
-    ax.set_ylabel("E[understood] - E[spoken] (words)")
-    ax.legend(loc="upper left", frameon=True)
-    ax.set_title("Comprehension-production gap")
-
-    if output_dir is not None and filename is not None:
-        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
-        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
-        _save_csv(pd.DataFrame({
-            "age_months": X_plot,
-            "gap_median": gap_median,
-            "hdi_lo": gap_hdi[:, 0],
-            "hdi_hi": gap_hdi[:, 1],
-            "hdi50_lo": gap_hdi_50[:, 0],
-            "hdi50_hi": gap_hdi_50[:, 1],
         }), output_dir, filename)
 
     return fig

--- a/src/vocab_growth/models/common_bivariate_re.py
+++ b/src/vocab_growth/models/common_bivariate_re.py
@@ -39,6 +39,12 @@ import pymc as pm
 import vocab_growth.data_utils as vocab_data_utils
 import vocab_growth.environment as local_env
 import vocab_growth.reporting as vg_reporting
+from vocab_growth.models.build_utils import (
+    construct_age_grids,
+    slope_anchor_logit_coeffs,
+    standardize_ages,
+    validate_ell_bounds,
+)
 from vocab_growth.models.common import (
     PACKAGE_LIST,
     ModelFitContext,
@@ -57,6 +63,7 @@ from vocab_growth.models.common_bivariate import (
     sample_posterior_predictive,
 )
 from vocab_growth.models.definitions import BivariateModelDefinition
+from vocab_growth.models.gp_utils import make_kappa_of_z
 from vocab_growth.reporting import (
     console,
     dataframe_table,
@@ -250,11 +257,7 @@ def build_model_re(
         raise ValueError("y_s exceeds n_trials.")
 
     # Standardise ages
-    X_obs_mean = float(np.mean(X_obs))
-    X_obs_std = float(np.std(X_obs, ddof=1))
-
-    if not np.isfinite(X_obs_std) or X_obs_std <= 0:
-        raise ValueError("Age standard deviation must be positive.")
+    X_obs_mean, X_obs_std, X_obs_z = standardize_ages(X_obs)
 
     build_cfg: list[tuple[str, object]] = [
         ("Total observations", n),
@@ -276,48 +279,33 @@ def build_model_re(
     )
     key_value_table("Build configuration", build_cfg)
 
-    X_obs_z = (X_obs - X_obs_mean) / X_obs_std
-
-    # Plot grid
-    X_plot = np.linspace(X_obs.min(), X_obs.max(), config.n_plot).reshape(-1, 1)
-    X_plot_z = (X_plot - X_obs_mean) / X_obs_std
-
-    # Query grid
-    X_query = np.array(config.ages_query).reshape(-1, 1)
-    X_query_z = (X_query - X_obs_mean) / X_obs_std
-
-    # Optional anchor point (Option D: per-draw zero of the GP at a reference age)
+    # Plot / query grids (standardised), with the optional reference-age anchor
+    # row — see models.build_utils.construct_age_grids.
     anchor_g_u = bool(definition.anchor_g_u_at_ref)
     anchor_g_q = bool(definition.anchor_g_q_at_ref)
     use_gp_anchor = anchor_g_u or anchor_g_q
-    if use_gp_anchor:
-        if definition.gp_anchor_age_months is not None:
-            anchor_age_months = float(definition.gp_anchor_age_months)
-        else:
-            anchor_age_months = (
-                float(config.slope_anchors[0]) + float(config.slope_anchors[1])
-            ) / 2.0
-        X_anchor = np.array([[anchor_age_months]], dtype=float)
-        X_anchor_z = (X_anchor - X_obs_mean) / X_obs_std
-        X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z, X_anchor_z])
-    else:
-        anchor_age_months = None
-        X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z])
-
-    n_plot = X_plot_z.shape[0]
-    n_query = X_query_z.shape[0]
-    n_all = X_all_z.shape[0]
-    i_anchor = (n + n_plot + n_query) if use_gp_anchor else None
+    grids = construct_age_grids(
+        X_obs,
+        X_obs_z,
+        X_obs_mean=X_obs_mean,
+        X_obs_std=X_obs_std,
+        n_plot=config.n_plot,
+        ages_query=config.ages_query,
+        slope_anchors=config.slope_anchors,
+        use_gp_anchor=use_gp_anchor,
+        gp_anchor_age_months=definition.gp_anchor_age_months,
+    )
+    X_plot = grids.X_plot
+    X_query = grids.X_query
+    X_all_z = grids.X_all_z
+    n_plot = grids.n_plot
+    n_query = grids.n_query
+    n_all = grids.n_all
+    i_anchor = grids.i_anchor
+    anchor_age_months = grids.anchor_age_months
 
     # Length-scale bounds
-    ell_low_months = float(config.ell_months_range[0])
-    ell_high_months = float(config.ell_months_range[1])
-
-    if ell_low_months <= 0 or ell_high_months <= 0:
-        raise ValueError("Length-scale bounds must be positive (in months).")
-    if ell_high_months <= ell_low_months:
-        raise ValueError("ell_months_range must be (low, high) with high > low.")
-
+    ell_low_months, ell_high_months = validate_ell_bounds(config.ell_months_range)
     ell_low_z = ell_low_months / X_obs_std
     ell_high_z = ell_high_months / X_obs_std
     ell_range_z = (ell_low_z, ell_high_z)
@@ -325,10 +313,9 @@ def build_model_re(
     L, M = get_hsgp_hyperparams(X_obs_z, ell_range_z)
 
     # Slope anchors
-    slope_age_a = float(config.slope_anchors[0])
-    slope_age_b = float(config.slope_anchors[1])
-    slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
-    slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
+    slope_age_a_z, slope_age_b_z = slope_anchor_logit_coeffs(
+        config.slope_anchors, X_obs_mean=X_obs_mean, X_obs_std=X_obs_std
+    )
 
     derived_rows: list[tuple[str, object]] = [
         ("HSGP basis size (m)", M),
@@ -602,8 +589,7 @@ def build_model_re(
         b_kappa_mag_u = config.b_kappa_mag_u_dist.to_pymc("b_kappa_mag_u")
         b_kappa_u = pm.Deterministic("b_kappa_u", -b_kappa_mag_u)
 
-        def kappa_u_of_z(z):
-            return kappa_min_u + pm.math.exp(a_kappa_u + b_kappa_u * z)
+        kappa_u_of_z = make_kappa_of_z(kappa_min_u, a_kappa_u, b_kappa_u)
 
         kappa_u_obs = pm.Deterministic(
             "kappa_u_obs", kappa_u_of_z(z_obs), dims="obs_id"
@@ -620,8 +606,7 @@ def build_model_re(
         b_kappa_mag_s = config.b_kappa_mag_s_dist.to_pymc("b_kappa_mag_s")
         b_kappa_s = pm.Deterministic("b_kappa_s", -b_kappa_mag_s)
 
-        def kappa_s_of_z(z):
-            return kappa_min_s + pm.math.exp(a_kappa_s + b_kappa_s * z)
+        kappa_s_of_z = make_kappa_of_z(kappa_min_s, a_kappa_s, b_kappa_s)
 
         kappa_s_obs = pm.Deterministic(
             "kappa_s_obs", kappa_s_of_z(z_obs), dims="obs_id"

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -66,6 +66,12 @@ from preliz.distributions.distributions import Continuous
 import vocab_growth.data_utils as vocab_data_utils
 import vocab_growth.environment as local_env
 import vocab_growth.reporting as vg_reporting
+from vocab_growth.models.build_utils import (
+    construct_age_grids,
+    slope_anchor_logit_coeffs,
+    standardize_ages,
+    validate_ell_bounds,
+)
 from vocab_growth.models.common import (
     PACKAGE_LIST,
     BaseModelConfiguration,
@@ -78,7 +84,9 @@ from vocab_growth.models.common import (
 )
 from vocab_growth.models.definitions import JointModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
+from vocab_growth.models.gp_utils import make_kappa_of_z
 from vocab_growth.plotting import _save_csv, plot_prior_samples_ratio
+from vocab_growth.posterior_analysis import extract_posterior as _extract
 from vocab_growth.reporting import (
     config_table,
     console,
@@ -543,48 +551,44 @@ def build_model(context: JointContext, definition: JointModelDefinition):
 
     X_obs = np.asarray(df["age"], dtype=float).reshape(-1, 1)
     n = len(X_obs)
-    X_mean = float(np.mean(X_obs))
-    X_std = float(np.std(X_obs, ddof=1))
+    X_mean, X_std, X_obs_z = standardize_ages(X_obs)
 
-    X_obs_z = (X_obs - X_mean) / X_std
-    X_plot = np.linspace(X_obs.min(), X_obs.max(), config.n_plot).reshape(-1, 1)
-    X_plot_z = (X_plot - X_mean) / X_std
-    X_query = np.array(config.ages_query).reshape(-1, 1)
-    X_query_z = (X_query - X_mean) / X_std
-    n_plot = X_plot_z.shape[0]
-    n_query = X_query_z.shape[0]
-
-    # Option D — per-draw GP anchor at a reference age. Append one extra grid row
-    # (the reference age) so each anchored GP can be centred to pass through zero
-    # there for every draw, removing the GP<->intercept level redundancy.
+    # Plot / query grids (standardised), with the optional Option-D reference-age
+    # anchor row — see models.build_utils.construct_age_grids. Option D centres
+    # each anchored GP to pass through zero at the reference age for every draw,
+    # removing the GP<->intercept level redundancy.
     anchor_g_u = bool(definition.anchor_g_u_at_ref)
     anchor_g_q = bool(definition.anchor_g_q_at_ref)
     anchor_g_sign = bool(definition.anchor_g_sign_at_ref)
     use_gp_anchor = anchor_g_u or anchor_g_q or anchor_g_sign
-    if use_gp_anchor:
-        if definition.gp_anchor_age_months is not None:
-            anchor_age_months = float(definition.gp_anchor_age_months)
-        else:
-            anchor_age_months = (
-                float(config.slope_anchors[0]) + float(config.slope_anchors[1])
-            ) / 2.0
-        X_anchor_z = (np.array([[anchor_age_months]], dtype=float) - X_mean) / X_std
-        X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z, X_anchor_z])
-        i_anchor = n + n_plot + n_query
-    else:
-        anchor_age_months = None
-        X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z])
-        i_anchor = None
-    n_all = X_all_z.shape[0]
+    grids = construct_age_grids(
+        X_obs,
+        X_obs_z,
+        X_obs_mean=X_mean,
+        X_obs_std=X_std,
+        n_plot=config.n_plot,
+        ages_query=config.ages_query,
+        slope_anchors=config.slope_anchors,
+        use_gp_anchor=use_gp_anchor,
+        gp_anchor_age_months=definition.gp_anchor_age_months,
+    )
+    X_plot = grids.X_plot
+    X_query = grids.X_query
+    X_all_z = grids.X_all_z
+    n_plot = grids.n_plot
+    n_query = grids.n_query
+    n_all = grids.n_all
+    i_anchor = grids.i_anchor
+    anchor_age_months = grids.anchor_age_months
 
-    ell_low_z = float(config.ell_months_range[0]) / X_std
-    ell_high_z = float(config.ell_months_range[1]) / X_std
+    ell_low_months, ell_high_months = validate_ell_bounds(config.ell_months_range)
+    ell_low_z = ell_low_months / X_std
+    ell_high_z = ell_high_months / X_std
     L, M = get_hsgp_hyperparams(X_obs_z, (ell_low_z, ell_high_z))
 
-    sa = float(config.slope_anchors[0])
-    sb = float(config.slope_anchors[1])
-    sa_z = (sa - X_mean) / X_std
-    sb_z = (sb - X_mean) / X_std
+    sa_z, sb_z = slope_anchor_logit_coeffs(
+        config.slope_anchors, X_obs_mean=X_mean, X_obs_std=X_std
+    )
 
     build_cfg: list[tuple[str, object]] = [
         ("Total observations", n),
@@ -776,7 +780,7 @@ def build_model(context: JointContext, definition: JointModelDefinition):
             a = a_d.to_pymc(f"a_kappa_{suffix}")
             bmag = bmag_d.to_pymc(f"b_kappa_mag_{suffix}")
             b = pm.Deterministic(f"b_kappa_{suffix}", -bmag)
-            return lambda z: kmin + pm.math.exp(a + b * z)
+            return make_kappa_of_z(kmin, a, b)
 
         kappa_u_of_z = kappa_fn(config.kappa_min_u_dist, config.a_kappa_u_dist, config.b_kappa_mag_u_dist, "u")
         kappa_s_of_z = kappa_fn(config.kappa_min_s_dist, config.a_kappa_s_dist, config.b_kappa_mag_s_dist, "s")
@@ -903,10 +907,6 @@ def diagnostics(context: JointContext):
     az.plot_energy(context.trace, figure_kwargs={"figsize": plot_styles.FIGSIZE_XL})
     plt.savefig(os.path.join(context.reporting.output_dir, "energy_plot.png"), dpi=300)
     plt.close()
-
-
-def _extract(trace, name, dim):
-    return np.array(trace.posterior[name].stack(sample=("chain", "draw")).transpose(dim, "sample").values)
 
 
 def sample_posterior_predictive(context: JointContext, definition=None):

--- a/src/vocab_growth/models/common_trivariate.py
+++ b/src/vocab_growth/models/common_trivariate.py
@@ -54,6 +54,12 @@ import vocab_growth.environment as local_env
 import vocab_growth.plotting as plotting
 import vocab_growth.posterior_analysis as posterior_analysis
 import vocab_growth.reporting as vg_reporting
+from vocab_growth.models.build_utils import (
+    construct_age_grids,
+    slope_anchor_logit_coeffs,
+    standardize_ages,
+    validate_ell_bounds,
+)
 from vocab_growth.models.common import (
     PACKAGE_LIST,
     BaseModelConfiguration,
@@ -66,7 +72,18 @@ from vocab_growth.models.common import (
 )
 from vocab_growth.models.definitions import TrivariateModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
-from vocab_growth.plotting import _save_csv
+from vocab_growth.models.gp_utils import make_kappa_of_z
+from vocab_growth.plotting import (
+    _save_csv,
+    plot_comprehension_production_gap,
+    plot_production_rate,
+)
+from vocab_growth.posterior_analysis import (
+    extract_posterior as _extract_posterior,
+)
+from vocab_growth.posterior_analysis import (
+    extract_posterior_predictive as _extract_posterior_predictive,
+)
 from vocab_growth.reporting import (
     config_table,
     console,
@@ -493,11 +510,7 @@ def build_model(context: TrivariateContext):
         raise ValueError("y_sign exceeds n_trials.")
 
     # Standardise ages
-    X_obs_mean = float(np.mean(X_obs))
-    X_obs_std = float(np.std(X_obs, ddof=1))
-
-    if not np.isfinite(X_obs_std) or X_obs_std <= 0:
-        raise ValueError("Age standard deviation must be positive.")
+    X_obs_mean, X_obs_std, X_obs_z = standardize_ages(X_obs)
 
     key_value_table(
         "Build configuration",
@@ -515,32 +528,26 @@ def build_model(context: TrivariateContext):
         ],
     )
 
-    X_obs_z = (X_obs - X_obs_mean) / X_obs_std
-
-    # Plot grid
-    X_plot = np.linspace(X_obs.min(), X_obs.max(), config.n_plot).reshape(-1, 1)
-    X_plot_z = (X_plot - X_obs_mean) / X_obs_std
-
-    # Query grid
-    X_query = np.array(config.ages_query).reshape(-1, 1)
-    X_query_z = (X_query - X_obs_mean) / X_obs_std
-
-    # Stack all
-    X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z])
-
-    n_plot = X_plot_z.shape[0]
-    n_query = X_query_z.shape[0]
-    n_all = X_all_z.shape[0]
+    # Plot / query grids (standardised), stacked for 'free' predictions — see
+    # models.build_utils.construct_age_grids.
+    grids = construct_age_grids(
+        X_obs,
+        X_obs_z,
+        X_obs_mean=X_obs_mean,
+        X_obs_std=X_obs_std,
+        n_plot=config.n_plot,
+        ages_query=config.ages_query,
+        slope_anchors=config.slope_anchors,
+    )
+    X_plot = grids.X_plot
+    X_query = grids.X_query
+    X_all_z = grids.X_all_z
+    n_plot = grids.n_plot
+    n_query = grids.n_query
+    n_all = grids.n_all
 
     # Length-scale bounds
-    ell_low_months = float(config.ell_months_range[0])
-    ell_high_months = float(config.ell_months_range[1])
-
-    if ell_low_months <= 0 or ell_high_months <= 0:
-        raise ValueError("Length-scale bounds must be positive (in months).")
-    if ell_high_months <= ell_low_months:
-        raise ValueError("ell_months_range must be (low, high) with high > low.")
-
+    ell_low_months, ell_high_months = validate_ell_bounds(config.ell_months_range)
     ell_low_z = ell_low_months / X_obs_std
     ell_high_z = ell_high_months / X_obs_std
     ell_range_z = (ell_low_z, ell_high_z)
@@ -548,10 +555,9 @@ def build_model(context: TrivariateContext):
     L, M = get_hsgp_hyperparams(X_obs_z, ell_range_z)
 
     # Slope anchors
-    slope_age_a = float(config.slope_anchors[0])
-    slope_age_b = float(config.slope_anchors[1])
-    slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
-    slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
+    slope_age_a_z, slope_age_b_z = slope_anchor_logit_coeffs(
+        config.slope_anchors, X_obs_mean=X_obs_mean, X_obs_std=X_obs_std
+    )
 
     key_value_table(
         "Derived quantities",
@@ -810,8 +816,7 @@ def build_model(context: TrivariateContext):
         b_kappa_mag_u = config.b_kappa_mag_u_dist.to_pymc("b_kappa_mag_u")
         b_kappa_u = pm.Deterministic("b_kappa_u", -b_kappa_mag_u)
 
-        def kappa_u_of_z(z):
-            return kappa_min_u + pm.math.exp(a_kappa_u + b_kappa_u * z)
+        kappa_u_of_z = make_kappa_of_z(kappa_min_u, a_kappa_u, b_kappa_u)
 
         kappa_u_obs = pm.Deterministic(
             "kappa_u_obs", kappa_u_of_z(z_obs), dims="obs_id"
@@ -828,8 +833,7 @@ def build_model(context: TrivariateContext):
         b_kappa_mag_s = config.b_kappa_mag_s_dist.to_pymc("b_kappa_mag_s")
         b_kappa_s = pm.Deterministic("b_kappa_s", -b_kappa_mag_s)
 
-        def kappa_s_of_z(z):
-            return kappa_min_s + pm.math.exp(a_kappa_s + b_kappa_s * z)
+        kappa_s_of_z = make_kappa_of_z(kappa_min_s, a_kappa_s, b_kappa_s)
 
         kappa_s_obs = pm.Deterministic(
             "kappa_s_obs", kappa_s_of_z(z_obs), dims="obs_id"
@@ -846,8 +850,9 @@ def build_model(context: TrivariateContext):
         b_kappa_mag_sign = config.b_kappa_mag_sign_dist.to_pymc("b_kappa_mag_sign")
         b_kappa_sign = pm.Deterministic("b_kappa_sign", -b_kappa_mag_sign)
 
-        def kappa_sign_of_z(z):
-            return kappa_min_sign + pm.math.exp(a_kappa_sign + b_kappa_sign * z)
+        kappa_sign_of_z = make_kappa_of_z(
+            kappa_min_sign, a_kappa_sign, b_kappa_sign
+        )
 
         kappa_sign_obs = pm.Deterministic(
             "kappa_sign_obs", kappa_sign_of_z(z_obs), dims="obs_id"
@@ -920,27 +925,6 @@ def build_model(context: TrivariateContext):
 # ============================================================
 # Sample extraction
 # ============================================================
-
-
-def _extract_posterior(trace, name, dim_name):
-    """Extract posterior samples, stacking chains and draws."""
-    return np.array(
-        trace.posterior[name]
-        .stack(sample=("chain", "draw"))
-        .transpose(dim_name, "sample")
-        .values
-    )
-
-
-def _extract_posterior_predictive(trace, name, dim_name):
-    """Extract posterior predictive samples, stacking chains and draws."""
-    return np.array(
-        trace.posterior_predictive[name]
-        .stack(sample=("chain", "draw"))
-        .transpose(dim_name, "sample")
-        .values,
-        dtype=int,
-    )
 
 
 def extract_model_samples(trace: xr.DataTree) -> TrivariateModelSamples:
@@ -1800,112 +1784,6 @@ def plot_modality_trajectories(
                     "any_median": E_any,
                     "any_hdi_lo": any_hdi[:, 0],
                     "any_hdi_hi": any_hdi[:, 1],
-                }
-            ),
-            output_dir,
-            filename,
-        )
-
-    return fig
-
-
-def plot_production_rate(
-    samples: TrivariateModelSamples,
-    hdi_prob: float = 0.90,
-    output_dir: str | None = None,
-    filename: str | None = None,
-):
-    """Plot the posterior of the production ratio q(a) = p_S(a) / p_U(a) over age."""
-    X_plot = samples.X_plot
-    q_plot = samples.q_plot
-
-    q_median = np.median(q_plot, axis=1)
-    q_hdi = az.hdi(q_plot, prob=hdi_prob)
-    q_hdi_75 = az.hdi(q_plot, prob=0.75)
-    q_hdi_50 = az.hdi(q_plot, prob=0.50)
-
-    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-
-    ax.fill_between(
-        X_plot, q_hdi[:, 0], q_hdi[:, 1], alpha=0.20, label=f"{int(hdi_prob * 100)}% HDI"
-    )
-    ax.fill_between(X_plot, q_hdi_75[:, 0], q_hdi_75[:, 1], alpha=0.25, label="75% HDI")
-    ax.fill_between(X_plot, q_hdi_50[:, 0], q_hdi_50[:, 1], alpha=0.30, label="50% HDI")
-    ax.plot(X_plot, q_median, lw=3, label="Median q(a)")
-
-    ax.set_xlabel("Age (months)")
-    ax.set_ylabel("q(a) = p_S(a) / p_U(a)")
-    ax.set_ylim(0, 1)
-    ax.legend(loc="upper left", frameon=True)
-    ax.set_title("Production ratio q(a)")
-
-    if output_dir is not None and filename is not None:
-        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
-        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
-        _save_csv(
-            pd.DataFrame(
-                {
-                    "age_months": X_plot,
-                    "q_median": q_median,
-                    "hdi_lo": q_hdi[:, 0],
-                    "hdi_hi": q_hdi[:, 1],
-                    "hdi75_lo": q_hdi_75[:, 0],
-                    "hdi75_hi": q_hdi_75[:, 1],
-                    "hdi50_lo": q_hdi_50[:, 0],
-                    "hdi50_hi": q_hdi_50[:, 1],
-                }
-            ),
-            output_dir,
-            filename,
-        )
-
-    return fig
-
-
-def plot_comprehension_production_gap(
-    samples: TrivariateModelSamples,
-    n_trials: int,
-    hdi_prob: float = 0.90,
-    output_dir: str | None = None,
-    filename: str | None = None,
-):
-    """Plot the posterior of the comprehension-production gap (p_U - p_S) over age."""
-    X_plot = samples.X_plot
-    gap = (samples.p_u_plot - samples.p_s_plot) * n_trials  # in word count units
-
-    gap_median = np.median(gap, axis=1)
-    gap_hdi = az.hdi(gap, prob=hdi_prob)
-    gap_hdi_50 = az.hdi(gap, prob=0.50)
-
-    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
-
-    ax.fill_between(
-        X_plot,
-        gap_hdi[:, 0],
-        gap_hdi[:, 1],
-        alpha=0.20,
-        label=f"{int(hdi_prob * 100)}% HDI",
-    )
-    ax.fill_between(X_plot, gap_hdi_50[:, 0], gap_hdi_50[:, 1], alpha=0.30, label="50% HDI")
-    ax.plot(X_plot, gap_median, lw=3, label="Median gap")
-
-    ax.set_xlabel("Age (months)")
-    ax.set_ylabel("E[understood] - E[spoken] (words)")
-    ax.legend(loc="upper left", frameon=True)
-    ax.set_title("Comprehension-production gap")
-
-    if output_dir is not None and filename is not None:
-        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
-        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
-        _save_csv(
-            pd.DataFrame(
-                {
-                    "age_months": X_plot,
-                    "gap_median": gap_median,
-                    "hdi_lo": gap_hdi[:, 0],
-                    "hdi_hi": gap_hdi[:, 1],
-                    "hdi50_lo": gap_hdi_50[:, 0],
-                    "hdi50_hi": gap_hdi_50[:, 1],
                 }
             ),
             output_dir,

--- a/src/vocab_growth/models/common_univariate_re.py
+++ b/src/vocab_growth/models/common_univariate_re.py
@@ -35,6 +35,12 @@ import pymc as pm
 import vocab_growth.data_utils as vocab_data_utils
 import vocab_growth.environment as local_env
 import vocab_growth.reporting as vg_reporting
+from vocab_growth.models.build_utils import (
+    construct_age_grids,
+    slope_anchor_logit_coeffs,
+    standardize_ages,
+    validate_ell_bounds,
+)
 from vocab_growth.models.common import (
     PACKAGE_LIST,
     ModelFitContext,
@@ -50,6 +56,7 @@ from vocab_growth.models.common import (
     sample_posterior_predictive,
 )
 from vocab_growth.models.definitions import UnivariateModelDefinition
+from vocab_growth.models.gp_utils import make_kappa_of_z
 from vocab_growth.reporting import (
     console,
     dataframe_table,
@@ -191,11 +198,7 @@ def build_univariate_re_model(
         raise ValueError("y_obs exceeds n_trials.")
 
     # Standardise ages
-    X_obs_mean = float(np.mean(X_obs))
-    X_obs_std = float(np.std(X_obs, ddof=1))
-
-    if not np.isfinite(X_obs_std) or X_obs_std <= 0:
-        raise ValueError("Age standard deviation must be positive.")
+    X_obs_mean, X_obs_std, X_obs_z = standardize_ages(X_obs)
 
     key_value_table(
         "Build configuration",
@@ -213,45 +216,31 @@ def build_univariate_re_model(
         ],
     )
 
-    X_obs_z = (X_obs - X_obs_mean) / X_obs_std
-
-    # Plot and query grids
-    X_plot = np.linspace(X_obs.min(), X_obs.max(), config.n_plot).reshape(-1, 1)
-    X_plot_z = (X_plot - X_obs_mean) / X_obs_std
-
-    X_query = np.array(config.ages_query).reshape(-1, 1)
-    X_query_z = (X_query - X_obs_mean) / X_obs_std
-
-    # Optional GP anchor point
+    # Plot / query grids (standardised), with the optional reference-age anchor
+    # row — see models.build_utils.construct_age_grids.
     anchor_g = bool(definition.anchor_g_at_ref)
-    if anchor_g:
-        if definition.gp_anchor_age_months is not None:
-            anchor_age_months = float(definition.gp_anchor_age_months)
-        else:
-            anchor_age_months = (
-                float(config.slope_anchors[0]) + float(config.slope_anchors[1])
-            ) / 2.0
-        X_anchor = np.array([[anchor_age_months]], dtype=float)
-        X_anchor_z = (X_anchor - X_obs_mean) / X_obs_std
-        X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z, X_anchor_z])
-    else:
-        anchor_age_months = None
-        X_all_z = np.vstack([X_obs_z, X_plot_z, X_query_z])
-
-    n_plot = X_plot_z.shape[0]
-    n_query = X_query_z.shape[0]
-    n_all = X_all_z.shape[0]
-    i_anchor = (n + n_plot + n_query) if anchor_g else None
+    grids = construct_age_grids(
+        X_obs,
+        X_obs_z,
+        X_obs_mean=X_obs_mean,
+        X_obs_std=X_obs_std,
+        n_plot=config.n_plot,
+        ages_query=config.ages_query,
+        slope_anchors=config.slope_anchors,
+        use_gp_anchor=anchor_g,
+        gp_anchor_age_months=definition.gp_anchor_age_months,
+    )
+    X_plot = grids.X_plot
+    X_query = grids.X_query
+    X_all_z = grids.X_all_z
+    n_plot = grids.n_plot
+    n_query = grids.n_query
+    n_all = grids.n_all
+    i_anchor = grids.i_anchor
+    anchor_age_months = grids.anchor_age_months
 
     # Length-scale bounds
-    ell_low_months = float(config.ell_months_range[0])
-    ell_high_months = float(config.ell_months_range[1])
-
-    if ell_low_months <= 0 or ell_high_months <= 0:
-        raise ValueError("Length-scale bounds must be positive (in months).")
-    if ell_high_months <= ell_low_months:
-        raise ValueError("ell_months_range must be (low, high) with high > low.")
-
+    ell_low_months, ell_high_months = validate_ell_bounds(config.ell_months_range)
     ell_low_z = ell_low_months / X_obs_std
     ell_high_z = ell_high_months / X_obs_std
     ell_range_z = (ell_low_z, ell_high_z)
@@ -259,10 +248,9 @@ def build_univariate_re_model(
     L, M = get_hsgp_hyperparams(X_obs_z, ell_range_z)
 
     # Slope anchors
-    slope_age_a = float(config.slope_anchors[0])
-    slope_age_b = float(config.slope_anchors[1])
-    slope_age_a_z = (slope_age_a - X_obs_mean) / X_obs_std
-    slope_age_b_z = (slope_age_b - X_obs_mean) / X_obs_std
+    slope_age_a_z, slope_age_b_z = slope_anchor_logit_coeffs(
+        config.slope_anchors, X_obs_mean=X_obs_mean, X_obs_std=X_obs_std
+    )
 
     derived_rows: list[tuple[str, object]] = [
         ("HSGP basis size (m)", M),
@@ -390,8 +378,7 @@ def build_univariate_re_model(
         b_kappa_mag = config.b_kappa_mag_dist.to_pymc("b_kappa_mag")
         b_kappa = pm.Deterministic("b_kappa", -b_kappa_mag)
 
-        def kappa_of_z(z):
-            return kappa_min + pm.math.exp(a_kappa + b_kappa * z)
+        kappa_of_z = make_kappa_of_z(kappa_min, a_kappa, b_kappa)
 
         kappa_obs = pm.Deterministic(
             "kappa_obs", kappa_of_z(X_all_z_data[i_obs0:i_obs1, 0]), dims="obs_id"

--- a/src/vocab_growth/models/gp_utils.py
+++ b/src/vocab_growth/models/gp_utils.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""PyMC-graph build helpers shared across the model engines.
+
+This module holds helpers that emit PyMC ops (as opposed to the pure-NumPy
+helpers in :mod:`vocab_growth.models.build_utils`). It is deliberately kept
+separate so the pure module stays ``pymc``-free.
+
+Currently it provides only :func:`make_kappa_of_z`, the age-varying dispersion
+closure factory. The factory takes random variables the caller has already
+created (in the caller's own order) and returns a closure whose body is
+byte-identical to the ``kappa_of_z`` closures previously inlined in every engine,
+so it moves no random-variable creation and cannot change the model graph.
+
+The trend + HSGP construction (``trend_and_gp`` / ``intercept_and_gp``), which is
+still duplicated across the engines, is intended to be consolidated here in a
+follow-up; it is excluded from the current change because it moves the sole
+RNG-bearing call (``hsgp.prior()``) and requires empirical fit-equivalence proof.
+"""
+
+from __future__ import annotations
+
+import pymc as pm
+
+
+def make_kappa_of_z(kappa_min, a_kappa, b_kappa):
+    """Return the age-varying dispersion closure ``z -> kappa_min + exp(a + b z)``.
+
+    ``kappa_min``, ``a_kappa`` and ``b_kappa`` are PyMC variables the caller has
+    already created (including any ``b_kappa = -b_kappa_mag`` deterministic). The
+    returned closure is evaluated later at the standardised ages, emitting the
+    same ops the inlined closures did.
+    """
+
+    def kappa_of_z(z):
+        return kappa_min + pm.math.exp(a_kappa + b_kappa * z)
+
+    return kappa_of_z

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import os
+from typing import Protocol
 
 import arviz as az
 import dse_research_utils.plot.predictive as plot_predictive
@@ -979,3 +980,145 @@ def plot_posterior_kappa(
         _save_csv(df_kappa_plot, output_dir, filename)
 
     return fig, df_kappa_plot, df_kappa_query
+
+
+class _RatioGapSamples(Protocol):
+    """Structural type for the two joint-trajectory plots below.
+
+    Both ``BivariateModelSamples`` and ``TrivariateModelSamples`` satisfy this;
+    declaring it here (instead of importing those dataclasses) keeps ``plotting``
+    free of an import cycle with the engine modules.
+    """
+
+    X_plot: np.ndarray
+    q_plot: np.ndarray
+    p_u_plot: np.ndarray
+    p_s_plot: np.ndarray
+
+
+def plot_production_rate(
+    samples: _RatioGapSamples,
+    hdi_prob: float = 0.90,
+    output_dir: str | None = None,
+    filename: str | None = None,
+) -> Figure:
+    """Plot the posterior of the production ratio q(a) = p_S(a) / p_U(a) over age."""
+    X_plot = samples.X_plot
+    q_plot = samples.q_plot
+
+    q_median = np.median(q_plot, axis=1)
+    q_hdi = az.hdi(q_plot, prob=hdi_prob)
+    q_hdi_75 = az.hdi(q_plot, prob=0.75)
+    q_hdi_50 = az.hdi(q_plot, prob=0.50)
+
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+
+    ax.fill_between(
+        X_plot,
+        q_hdi[:, 0],
+        q_hdi[:, 1],
+        alpha=0.20,
+        label=f"{int(hdi_prob * 100)}% HDI",
+    )
+    ax.fill_between(
+        X_plot,
+        q_hdi_75[:, 0],
+        q_hdi_75[:, 1],
+        alpha=0.25,
+        label="75% HDI",
+    )
+    ax.fill_between(
+        X_plot,
+        q_hdi_50[:, 0],
+        q_hdi_50[:, 1],
+        alpha=0.30,
+        label="50% HDI",
+    )
+    ax.plot(X_plot, q_median, lw=3, label="Median q(a)")
+
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel("q(a) = p_S(a) / p_U(a)")
+    ax.set_ylim(0, 1)
+    ax.legend(loc="upper left", frameon=True)
+    ax.set_title("Production ratio q(a)")
+
+    if output_dir is not None and filename is not None:
+        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
+        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
+        _save_csv(
+            pd.DataFrame(
+                {
+                    "age_months": X_plot,
+                    "q_median": q_median,
+                    "hdi_lo": q_hdi[:, 0],
+                    "hdi_hi": q_hdi[:, 1],
+                    "hdi75_lo": q_hdi_75[:, 0],
+                    "hdi75_hi": q_hdi_75[:, 1],
+                    "hdi50_lo": q_hdi_50[:, 0],
+                    "hdi50_hi": q_hdi_50[:, 1],
+                }
+            ),
+            output_dir,
+            filename,
+        )
+
+    return fig
+
+
+def plot_comprehension_production_gap(
+    samples: _RatioGapSamples,
+    n_trials: int,
+    hdi_prob: float = 0.90,
+    output_dir: str | None = None,
+    filename: str | None = None,
+) -> Figure:
+    """Plot the posterior of the comprehension-production gap (p_U - p_S) over age."""
+    X_plot = samples.X_plot
+    gap = (samples.p_u_plot - samples.p_s_plot) * n_trials  # in word count units
+
+    gap_median = np.median(gap, axis=1)
+    gap_hdi = az.hdi(gap, prob=hdi_prob)
+    gap_hdi_50 = az.hdi(gap, prob=0.50)
+
+    fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
+
+    ax.fill_between(
+        X_plot,
+        gap_hdi[:, 0],
+        gap_hdi[:, 1],
+        alpha=0.20,
+        label=f"{int(hdi_prob * 100)}% HDI",
+    )
+    ax.fill_between(
+        X_plot,
+        gap_hdi_50[:, 0],
+        gap_hdi_50[:, 1],
+        alpha=0.30,
+        label="50% HDI",
+    )
+    ax.plot(X_plot, gap_median, lw=3, label="Median gap")
+
+    ax.set_xlabel("Age (months)")
+    ax.set_ylabel("E[understood] - E[spoken] (words)")
+    ax.legend(loc="upper left", frameon=True)
+    ax.set_title("Comprehension-production gap")
+
+    if output_dir is not None and filename is not None:
+        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300)
+        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
+        _save_csv(
+            pd.DataFrame(
+                {
+                    "age_months": X_plot,
+                    "gap_median": gap_median,
+                    "hdi_lo": gap_hdi[:, 0],
+                    "hdi_hi": gap_hdi[:, 1],
+                    "hdi50_lo": gap_hdi_50[:, 0],
+                    "hdi50_hi": gap_hdi_50[:, 1],
+                }
+            ),
+            output_dir,
+            filename,
+        )
+
+    return fig

--- a/src/vocab_growth/posterior_analysis.py
+++ b/src/vocab_growth/posterior_analysis.py
@@ -8,6 +8,35 @@ import numpy as np
 import pandas as pd
 
 
+def extract_posterior(trace, name, dim):
+    """Extract posterior samples for ``name``, stacking chains and draws.
+
+    Returns an array shaped ``(len(dim), n_chain * n_draw)``. Shared by the
+    multivariate engines, which previously each defined an identical private copy.
+    """
+    return np.array(
+        trace.posterior[name]
+        .stack(sample=("chain", "draw"))
+        .transpose(dim, "sample")
+        .values
+    )
+
+
+def extract_posterior_predictive(trace, name, dim):
+    """Extract posterior-predictive samples for ``name`` as integer counts.
+
+    As :func:`extract_posterior`, but reads from ``posterior_predictive`` and
+    casts to ``int`` (the predictive draws are word counts).
+    """
+    return np.array(
+        trace.posterior_predictive[name]
+        .stack(sample=("chain", "draw"))
+        .transpose(dim, "sample")
+        .values,
+        dtype=int,
+    )
+
+
 def posterior_summary_table(
     X_query: np.ndarray,
     p_query: np.ndarray,

--- a/tests/test_build_utils.py
+++ b/tests/test_build_utils.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Unit tests for the pure-NumPy build helpers in ``models.build_utils``.
+
+These pin the exact formulas hoisted out of the engines so that any transcription
+drift (e.g. a ``ddof=0`` regression in the age z-scores) is caught immediately.
+"""
+
+import numpy as np
+import pytest
+
+from vocab_growth.models.build_utils import (
+    construct_age_grids,
+    slope_anchor_logit_coeffs,
+    standardize_ages,
+    validate_ell_bounds,
+)
+
+# --- standardize_ages -------------------------------------------------------
+
+
+def test_standardize_ages_known_values():
+    X = np.array([[10.0], [20.0], [30.0]])
+    mean, std, X_z = standardize_ages(X)
+    assert np.isclose(mean, 20.0)
+    assert np.isclose(std, 10.0)  # ddof=1 sample std
+    np.testing.assert_allclose(X_z, [[-1.0], [0.0], [1.0]])
+
+
+def test_standardize_ages_uses_ddof1():
+    X = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    _, std, _ = standardize_ages(X)
+    assert np.isclose(std, np.std(X, ddof=1))
+    assert not np.isclose(std, np.std(X, ddof=0))
+
+
+def test_standardize_ages_affine_inverse():
+    rng = np.random.default_rng(0)
+    X = rng.normal(30.0, 8.0, size=(50, 1))
+    mean, std, X_z = standardize_ages(X)
+    np.testing.assert_allclose(X_z * std + mean, X)
+    assert np.isclose(X_z.mean(), 0.0, atol=1e-12)
+
+
+def test_standardize_ages_degenerate_raises():
+    with pytest.raises(ValueError):
+        standardize_ages(np.array([[5.0], [5.0], [5.0]]))
+
+
+def test_standardize_ages_nan_raises():
+    with pytest.raises(ValueError):
+        standardize_ages(np.array([[5.0], [np.nan], [7.0]]))
+
+
+# --- validate_ell_bounds ----------------------------------------------------
+
+
+def test_validate_ell_bounds_ok():
+    assert validate_ell_bounds((6, 18)) == (6.0, 18.0)
+
+
+def test_validate_ell_bounds_nonpositive_raises():
+    with pytest.raises(ValueError):
+        validate_ell_bounds((0, 18))
+    with pytest.raises(ValueError):
+        validate_ell_bounds((-1, 18))
+
+
+def test_validate_ell_bounds_non_increasing_raises():
+    with pytest.raises(ValueError):
+        validate_ell_bounds((18, 6))
+    with pytest.raises(ValueError):
+        validate_ell_bounds((6, 6))
+
+
+# --- slope_anchor_logit_coeffs ----------------------------------------------
+
+
+def test_slope_anchor_logit_coeffs():
+    a_z, b_z = slope_anchor_logit_coeffs((24, 84), X_obs_mean=30.0, X_obs_std=12.0)
+    assert np.isclose(a_z, (24 - 30) / 12)
+    assert np.isclose(b_z, (84 - 30) / 12)
+
+
+# --- construct_age_grids ----------------------------------------------------
+
+N_PLOT = 100
+AGES_QUERY = [12, 24, 36]
+SLOPE_ANCHORS = (24, 84)
+
+
+def _grids(*, use_gp_anchor=False, gp_anchor_age_months=None):
+    X = np.linspace(8.0, 60.0, 40).reshape(-1, 1)
+    mean, std, X_z = standardize_ages(X)
+    grids = construct_age_grids(
+        X,
+        X_z,
+        X_obs_mean=mean,
+        X_obs_std=std,
+        n_plot=N_PLOT,
+        ages_query=AGES_QUERY,
+        slope_anchors=SLOPE_ANCHORS,
+        use_gp_anchor=use_gp_anchor,
+        gp_anchor_age_months=gp_anchor_age_months,
+    )
+    return X, mean, std, grids
+
+
+def test_construct_age_grids_shapes_no_anchor():
+    X, _, _, g = _grids()
+    n = X.shape[0]
+    assert g.X_plot.shape == (N_PLOT, 1)
+    assert g.n_plot == N_PLOT
+    assert g.n_query == len(AGES_QUERY)
+    assert g.X_all_z.shape == (n + N_PLOT + len(AGES_QUERY), 1)
+    assert g.n_all == n + N_PLOT + len(AGES_QUERY)
+    assert g.i_anchor is None
+    assert g.anchor_age_months is None
+
+
+def test_construct_age_grids_plot_endpoints():
+    X, _, _, g = _grids()
+    assert np.isclose(g.X_plot[0, 0], X.min())
+    assert np.isclose(g.X_plot[-1, 0], X.max())
+
+
+def test_construct_age_grids_index_tuples():
+    X, _, _, g = _grids()
+    n = X.shape[0]
+    assert g.i_obs == (0, n)
+    assert g.i_plot == (n, n + N_PLOT)
+    assert g.i_query == (n + N_PLOT, n + N_PLOT + len(AGES_QUERY))
+
+
+def test_construct_age_grids_blocks_are_zscored():
+    X, mean, std, g = _grids()
+    n = X.shape[0]
+    np.testing.assert_allclose(g.X_all_z[n : n + N_PLOT], (g.X_plot - mean) / std)
+    np.testing.assert_allclose(
+        g.X_all_z[n + N_PLOT : n + N_PLOT + len(AGES_QUERY)],
+        (g.X_query - mean) / std,
+    )
+
+
+def test_construct_age_grids_anchor_default_midpoint():
+    X, mean, std, g = _grids(use_gp_anchor=True)
+    n = X.shape[0]
+    assert g.anchor_age_months == 54.0  # midpoint of (24, 84)
+    assert g.i_anchor == n + N_PLOT + len(AGES_QUERY)
+    assert g.X_all_z.shape == (n + N_PLOT + len(AGES_QUERY) + 1, 1)
+    np.testing.assert_allclose(g.X_all_z[g.i_anchor, 0], (54.0 - mean) / std)
+
+
+def test_construct_age_grids_anchor_explicit_age():
+    X, mean, std, g = _grids(use_gp_anchor=True, gp_anchor_age_months=19.0)
+    assert g.anchor_age_months == 19.0
+    np.testing.assert_allclose(g.X_all_z[g.i_anchor, 0], (19.0 - mean) / std)

--- a/tests/test_gp_utils.py
+++ b/tests/test_gp_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Unit tests for the kappa dispersion-closure factory in ``models.gp_utils``.
+
+The factory returns the closure ``z -> kappa_min + exp(a_kappa + b_kappa * z)``;
+these tests pin that closed form. Evaluating with constant inputs is sufficient
+(and matches the per-engine usage, where the same expression is built from random
+variables the caller has already created).
+"""
+
+import numpy as np
+
+from vocab_growth.models.gp_utils import make_kappa_of_z
+
+
+def test_make_kappa_of_z_at_zero():
+    f = make_kappa_of_z(2.0, 0.5, -0.3)
+    # at z = 0: kappa_min + exp(a_kappa)
+    assert np.isclose(float(f(0.0).eval()), 2.0 + np.exp(0.5))
+
+
+def test_make_kappa_of_z_closed_form():
+    kappa_min, a_kappa, b_kappa, z = 1.5, 0.2, -0.4, 0.7
+    f = make_kappa_of_z(kappa_min, a_kappa, b_kappa)
+    expected = kappa_min + np.exp(a_kappa + b_kappa * z)
+    assert np.isclose(float(f(z).eval()), expected)
+
+
+def test_make_kappa_of_z_monotone_for_negative_b():
+    f = make_kappa_of_z(1.0, 0.0, -0.5)
+    lo = float(f(-1.0).eval())
+    hi = float(f(1.0).eval())
+    # negative b_kappa => kappa decreases as standardised age increases
+    assert lo > hi

--- a/tests/test_plotting_helpers.py
+++ b/tests/test_plotting_helpers.py
@@ -1,10 +1,48 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import os
+import types
+
 import numpy as np
 import pytest
+from matplotlib.figure import Figure
 
-from vocab_growth.plotting import _maybe_savgol, _resolve_savgol_window_length
+from vocab_growth.plotting import (
+    _maybe_savgol,
+    _resolve_savgol_window_length,
+    plot_comprehension_production_gap,
+    plot_production_rate,
+)
+
+
+def _ratio_gap_samples(n_plot: int = 20, n_draws: int = 50):
+    """Duck-typed stand-in for Bivariate/Trivariate model samples."""
+    rng = np.random.default_rng(0)
+    return types.SimpleNamespace(
+        X_plot=np.linspace(8.0, 36.0, n_plot),
+        q_plot=rng.uniform(0.0, 1.0, size=(n_plot, n_draws)),
+        p_u_plot=rng.uniform(0.3, 0.6, size=(n_plot, n_draws)),
+        p_s_plot=rng.uniform(0.0, 0.3, size=(n_plot, n_draws)),
+    )
+
+
+def test_plot_production_rate_returns_figure_and_writes_files(tmp_path):
+    fig = plot_production_rate(
+        _ratio_gap_samples(), output_dir=str(tmp_path), filename="prod"
+    )
+    assert isinstance(fig, Figure)
+    for ext in ("png", "svg", "csv"):
+        assert os.path.exists(os.path.join(str(tmp_path), f"prod.{ext}"))
+
+
+def test_plot_comprehension_production_gap_returns_figure_and_writes_files(tmp_path):
+    fig = plot_comprehension_production_gap(
+        _ratio_gap_samples(), n_trials=800, output_dir=str(tmp_path), filename="gap"
+    )
+    assert isinstance(fig, Figure)
+    for ext in ("png", "svg", "csv"):
+        assert os.path.exists(os.path.join(str(tmp_path), f"gap.{ext}"))
 
 
 @pytest.mark.parametrize("n", [5, 7, 15, 21, 100])

--- a/tests/test_posterior_analysis.py
+++ b/tests/test_posterior_analysis.py
@@ -1,9 +1,51 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import numpy as np
+import types
 
-from vocab_growth.posterior_analysis import posterior_summary_table
+import numpy as np
+import xarray as xr
+
+from vocab_growth.posterior_analysis import (
+    extract_posterior,
+    extract_posterior_predictive,
+    posterior_summary_table,
+)
+
+
+def _fake_trace(group: str, name: str, values: np.ndarray):
+    """Minimal stand-in for an InferenceData with one (chain, draw, plot_id) var."""
+    n_chain, n_draw, n_plot = values.shape
+    ds = xr.Dataset(
+        {name: (("chain", "draw", "plot_id"), values)},
+        coords={
+            "chain": np.arange(n_chain),
+            "draw": np.arange(n_draw),
+            "plot_id": np.arange(n_plot),
+        },
+    )
+    return types.SimpleNamespace(**{group: ds})
+
+
+def test_extract_posterior_shape_and_order():
+    values = np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4)
+    trace = _fake_trace("posterior", "f", values)
+    out = extract_posterior(trace, "f", "plot_id")
+    # (n_plot_id, n_chain * n_draw); sample axis iterates chain-outer, draw-inner
+    assert out.shape == (4, 6)
+    np.testing.assert_array_equal(out, values.transpose(2, 0, 1).reshape(4, 6))
+
+
+def test_extract_posterior_predictive_is_integer():
+    values = np.arange(2 * 3 * 4, dtype=float).reshape(2, 3, 4) + 0.5
+    trace = _fake_trace("posterior_predictive", "y", values)
+    out = extract_posterior_predictive(trace, "y", "plot_id")
+    assert out.shape == (4, 6)
+    assert np.issubdtype(out.dtype, np.integer)
+    # float 0.5+ values are truncated toward zero by the int cast
+    np.testing.assert_array_equal(
+        out, values.transpose(2, 0, 1).reshape(4, 6).astype(int)
+    )
 
 N_SAMPLES = 2000
 EXPECTED_COLUMNS = {


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

Addresses #66 — the **graph-identical, zero-RNG-risk tier** of the consolidation. The riskier trend + HSGP builder unification is deferred to #86.

## What

Hoists copy-and-pasted model-build scaffolding out of the six engine modules (`common.py`, `common_univariate_re.py`, `common_bivariate.py`, `common_bivariate_re.py`, `common_trivariate.py`, `common_joint_modality.py`) into shared helpers:

| Consolidation | Was duplicated in | Now in |
| --- | --- | --- |
| `standardize_ages`, `construct_age_grids`, `validate_ell_bounds`, `slope_anchor_logit_coeffs` | all 6 engines | **new `models/build_utils.py`** (pure NumPy, no `pymc`) |
| `make_kappa_of_z` (the `kappa_of_z` closure) | 9 sites across 6 engines | **new `models/gp_utils.py`** |
| `extract_posterior` / `extract_posterior_predictive` | bivariate / trivariate / joint (byte-identical) | `posterior_analysis.py` |
| `plot_production_rate` / `plot_comprehension_production_gap` | bivariate + trivariate | `plotting.py` |

Net: the engines shrink ~520 lines, and a single fix to any of these blocks now lives in one place (the maintainability cost flagged in #66 and seen in #64).

## Why it's safe (no-op on sampled values)

- the extraction and plotting helpers are pure post-processing;
- the `build_utils` helpers are deterministic NumPy producing bit-identical inputs to `pm.Data`;
- `make_kappa_of_z` moves **no** random-variable creation — the caller still creates the RVs in the same order, and the returned closure body is byte-identical to the inlined ones.

Two incidental, strictly-safe tightenings: the joint engine now runs the same `ell`-bounds and age-std validation the other five engines already had (bit-identical for any valid config).

## Verification

`ruff check src/ scripts/ tests/` ✓ · `pytest` ✓ (63 tests; new unit tests cover every pure helper, the kappa factory, and the extraction/plotting helpers).

**Fit equivalence within Monte-Carlo error** (the criterion in #66) — one model per engine re-fit on `--config dev`, diffing `diagnostics.csv` + every `posterior_summary*.csv` against a pre-refactor baseline:

| Model (engine) | max z on posterior means | max \|Δr̂\| | largest raw Δ |
| --- | --- | --- | --- |
| VG01 (common) | 1.41 | 0.022 | `ess_tail` |
| VG05 (bivariate) | 2.00 | 0.011 | `ess_tail` |
| VG10 (bivariate_re) | 1.98 | 0.055 | `ess_bulk` |
| VG11 (univariate_re) | 2.12 | 0.015 | `ess_tail` |
| VG14 (trivariate) | 1.94 | 0.019 | `ess_tail` |
| VG15 (joint) | 2.48 | 0.092 | `ess_bulk` |

`z = |Δmean| / sqrt(mcse_a² + mcse_b²)`. Every posterior mean agrees within **≤2.5 MCSE**, r̂ is unchanged, and the large raw deltas are confined to `ess_*` (expected — effective sample size is the noisiest diagnostic at `dev` draw counts).

These fits are **not** bit-reproducible across process runs (nutpie's gradient BLAS is non-deterministic and NUTS amplifies it), so exact CSV equality isn't the bar. A **same-code refit control** confirms it — re-running the *identical* refactored code twice gives the same spread as original-vs-refactored:

| Model | original ↔ refactored (z) | refit ↔ refit, same code (z) |
| --- | --- | --- |
| VG05 | 2.00 | 1.53 |
| VG14 | 1.94 | 2.30 |

i.e. the original↔refactored differences are MCMC run-to-run noise, not the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
