### PR TITLE
[codex] Fix VG15 totals and subject RE summaries

### DIFF
--- a/docs/models/vg08/index.qmd
+++ b/docs/models/vg08/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -186,10 +190,12 @@ The expected difference in word counts between understanding and production.
 The count distributions, PMF/CDF, median-trend plots and the `Y_*`
 and `P(Y<=k)` columns in the summary tables below integrate over a
 freshly-sampled subject random intercept drawn from
-`Normal(0, τ^{subj}_U)`. This is the correct predictive distribution
-for an unseen DS child. The latent probability columns (`p_median`,
-`Ey_median` etc.) describe the population-mean conditional
-probability and are unchanged.
+`Normal(0, τ^{subj}_U)`. This is the predictive distribution for an
+unseen DS child. The historical `p_*` and `Ey_*` columns retain their
+population-level meaning; the explicit `p_population_*` /
+`Ey_population_*` columns repeat that estimand, and the
+`p_subject_marginal_*` / `Ey_subject_marginal_*` columns report the
+matching new-child probability and expected-count estimand.
 
 :::
 

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -182,14 +186,14 @@ The expected difference in word counts between understanding and production.
 ::: {.callout-note title="Subject-marginalised posterior predictive"}
 
 The count distributions, PMF/CDF, median-trend plots and the `Y_*`
-and `P(Y<=k)` columns in the summary tables below have been
-post-processed to integrate over the subject random-effect priors
-(`τ^{subj}_U ≈ 0.84`, `τ^{subj}_q ≈ 1.20`). This is the correct
-predictive distribution to compare with an unseen DS child's
-expected vocabulary counts. The latent probability columns
-(`p_median`, `Ey_median` etc.) are unchanged from the
-population-level estimates because those describe the latent mean,
-not the predictive spread.
+and `P(Y<=k)` columns in the summary tables below integrate over the
+subject random-effect priors (`τ^{subj}_U ≈ 0.84`,
+`τ^{subj}_q ≈ 1.20`). This is the predictive distribution for an
+unseen DS child. The historical `p_*` and `Ey_*` columns retain their
+population-level meaning; the explicit `p_population_*` /
+`Ey_population_*` columns repeat that estimand, and the
+`p_subject_marginal_*` / `Ey_subject_marginal_*` columns report the
+matching new-child probability and expected-count estimand.
 
 :::
 

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -189,14 +193,13 @@ The expected difference in word counts between understanding and production.
 ::: {.callout-note title="Subject-marginalised posterior predictive"}
 
 The count distributions, PMF/CDF, median-trend plots and the `Y_*`
-and `P(Y<=k)` columns in the summary tables below have been
-post-processed to integrate over the subject random-effect priors
-(`τ^{subj}_U`, `τ^{subj}_q`). This is the correct
-predictive distribution to compare with an unseen DS child's
-expected vocabulary counts. The latent probability columns
-(`p_median`, `Ey_median` etc.) are unchanged from the
-population-level estimates because those describe the latent mean,
-not the predictive spread.
+and `P(Y<=k)` columns in the summary tables below integrate over the
+subject random-effect priors (`τ^{subj}_U`, `τ^{subj}_q`). This is the
+predictive distribution for an unseen DS child. The historical `p_*`
+and `Ey_*` columns retain their population-level meaning; the explicit
+`p_population_*` / `Ey_population_*` columns repeat that estimand, and
+the `p_subject_marginal_*` / `Ey_subject_marginal_*` columns report
+the matching new-child probability and expected-count estimand.
 
 :::
 

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -61,7 +65,7 @@ The association $\psi$ is deliberately kept **decoupled** from the subject rando
 
 - **understood** (all DS studies): $\text{BetaBinomial}(800, p_U, \kappa_U)$.
 - **spoken / signed marginals** (uk_01/04/05/06 + uk_02 marginal-only rows): $\text{BetaBinomial}(800, p_U q, \kappa_S)$ and $\text{BetaBinomial}(800, p_U r, \kappa_\text{sign})$.
-- **uk_02 four cells** (the only cross-tab source): $\text{DirichletMultinomial}(\text{total}, \text{conc}\cdot[\pi_\text{neither}, \pi_\text{sign-only}, \pi_\text{speak-only}, \pi_\text{both}])$. **This is what identifies $\psi$.**
+- **uk_02 four cells** (the only cross-tab source): $\text{DirichletMultinomial}(\text{total}, \text{conc}\cdot[\pi_\text{neither}, \pi_\text{sign-only}, \pi_\text{speak-only}, \pi_\text{both}])$. For rows with complete four-cell data, `total` is the four-cell sum and is also used as the understood count for that assessment occasion, so the marginal understood likelihood and the four-cell likelihood share one authoritative total. **This is what identifies $\psi$.**
 
 ::: {.callout-important title="psi rests almost entirely on uk_02 — descriptive / exploratory"}
 

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -26,6 +26,8 @@ MODEL_CONFIGS = {
     "vg11": ("VG11", "age-spoken-td-re"),
     "vg12": ("VG12", "age-understood-td-re"),
     "vg13": ("VG13", "age-understood-spoken-td-re-young"),
+    "vg14": ("VG14", "age-understood-spoken-signed-ds"),
+    "vg15": ("VG15", "age-joint-signspeech-ds"),
 }
 
 if __name__ == "__main__":
@@ -35,7 +37,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "model",
         type=str,
-        help="Model id (vg01–vg13) or 'all'.",
+        help="Model id (vg01–vg15) or 'all'.",
     )
     parser.add_argument(
         "--include-traces",

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -143,6 +143,7 @@ class BivariateModelSamples:
     p_u_obs: np.ndarray
     p_u_plot: np.ndarray
     p_u_query: np.ndarray
+    p_u_query_subject_marginal: np.ndarray
     y_u_obs: np.ndarray
     y_u_plot: np.ndarray
     y_u_query: np.ndarray
@@ -164,6 +165,7 @@ class BivariateModelSamples:
     p_s_obs: np.ndarray
     p_s_plot: np.ndarray
     p_s_query: np.ndarray
+    p_s_query_subject_marginal: np.ndarray
     y_s_obs: np.ndarray
     y_s_plot: np.ndarray
     y_s_query: np.ndarray
@@ -759,6 +761,12 @@ def extract_model_samples(trace: xr.DataTree) -> BivariateModelSamples:
     y_u_query = _extract_posterior_predictive(trace, "y_u_query", "query_id")
     y_s_plot = _extract_posterior_predictive(trace, "y_s_plot", "plot_id")
     y_s_query = _extract_posterior_predictive(trace, "y_s_query", "query_id")
+    p_u_query_subject_marginal = posterior_analysis.extract_posterior_predictive_float(
+        trace, "p_u_query_subject_marginal", "query_id"
+    )
+    p_s_query_subject_marginal = posterior_analysis.extract_posterior_predictive_float(
+        trace, "p_s_query_subject_marginal", "query_id"
+    )
 
     # Constant data
     X_obs = np.array(trace.constant_data["X_obs"].values)
@@ -783,6 +791,7 @@ def extract_model_samples(trace: xr.DataTree) -> BivariateModelSamples:
         p_u_obs=p_u_obs,
         p_u_plot=p_u_plot,
         p_u_query=p_u_query,
+        p_u_query_subject_marginal=p_u_query_subject_marginal,
         y_u_obs=y_u_obs,
         y_u_plot=y_u_plot,
         y_u_query=y_u_query,
@@ -800,6 +809,7 @@ def extract_model_samples(trace: xr.DataTree) -> BivariateModelSamples:
         p_s_obs=p_s_obs,
         p_s_plot=p_s_plot,
         p_s_query=p_s_query,
+        p_s_query_subject_marginal=p_s_query_subject_marginal,
         y_s_obs=y_s_obs,
         y_s_plot=y_s_plot,
         y_s_query=y_s_query,
@@ -1063,6 +1073,13 @@ def sample_posterior_predictive(context: BivariateContext, definition=None):
             p_s_plot = p_u_plot * q_plot
             p_s_query = p_u_query * q_query
 
+        pm.Deterministic(
+            "p_u_query_subject_marginal", p_u_query, dims=("query_id",)
+        )
+        pm.Deterministic(
+            "p_s_query_subject_marginal", p_s_query, dims=("query_id",)
+        )
+
         # Understood — plot
         p_u_plot_clip = pm.math.clip(p_u_plot, EPSILON, 1 - EPSILON)
         pm.BetaBinomial(
@@ -1105,9 +1122,11 @@ def sample_posterior_predictive(context: BivariateContext, definition=None):
             var_names=[
                 "y_u_plot",
                 "y_u_query",
+                "p_u_query_subject_marginal",
                 "y_u_obs",
                 "y_s_plot",
                 "y_s_query",
+                "p_s_query_subject_marginal",
                 "y_s_obs",
             ],
             extend_inferencedata=True,
@@ -1128,6 +1147,9 @@ def posterior_summary(context: BivariateContext):
     samples = context.model_samples
     n_trials = context.model_data.n_trials
     hdi_prob = context.reporting.hdi
+    has_subject_re = any(
+        name in context.model_variables for name in ("tau_subj_u", "tau_subj_q")
+    )
 
     # Understood summary
     summary_u = posterior_analysis.posterior_summary_table(
@@ -1137,6 +1159,14 @@ def posterior_summary(context: BivariateContext):
         n_trials=n_trials,
         hdi_prob=hdi_prob,
     )
+    if has_subject_re:
+        summary_u = posterior_analysis.add_probability_estimand_columns(
+            summary_u,
+            samples.p_u_query,
+            samples.p_u_query_subject_marginal,
+            n_trials=n_trials,
+            hdi_prob=hdi_prob,
+        )
     dataframe_table(
         summary_u, title="Posterior summary — words understood", show_index=False
     )
@@ -1154,6 +1184,14 @@ def posterior_summary(context: BivariateContext):
         n_trials=n_trials,
         hdi_prob=hdi_prob,
     )
+    if has_subject_re:
+        summary_s = posterior_analysis.add_probability_estimand_columns(
+            summary_s,
+            samples.p_s_query,
+            samples.p_s_query_subject_marginal,
+            n_trials=n_trials,
+            hdi_prob=hdi_prob,
+        )
     dataframe_table(
         summary_s, title="Posterior summary — words spoken", show_index=False
     )

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -204,8 +204,11 @@ def _load_uk02_four_cell():
     all four cell counts recorded, whose signed and spoken margins reconcile
     with the cross-tab cells (signed == signed_only + signed_spoken,
     spoken == spoken_only + signed_spoken) and whose four cells sum to a
-    positive total; they identify psi. The rest are marginal-only uk_02 rows
-    (no usable cross-tab).
+    positive total; they identify psi. For these rows the four-cell sum is
+    treated as the authoritative understood total, so a small mismatch between
+    the raw comprehension column and the cross-tab partition does not make the
+    U likelihood and the Dirichlet-Multinomial likelihood disagree. The rest are
+    marginal-only uk_02 rows (no usable cross-tab).
 
     A row missing any cell — in particular ``understood_only`` (some uk_02 rows
     record a produced sign/speech cross-tab but no comprehension total) — cannot
@@ -259,12 +262,13 @@ def prepare_joint_data(
     four, marg = _load_uk02_four_cell()
     include_uk06 = definition.include_uk06
 
-    # uk_02 four-cell rows: understood for the U likelihood; cells for the DM;
-    # marginal spoken/signed set NaN (subsumed by the DM, avoids double counting).
+    # uk_02 four-cell rows: the four-cell sum is the authoritative understood
+    # total; cells feed the DM; marginal spoken/signed are set NaN because they
+    # are subsumed by the DM and would otherwise be double counted.
     four_cols = {
         "study": UK02_STUDY_ID,
         "age": four["age"].to_numpy(dtype=float),
-        "understood": four["comprehension"].to_numpy(dtype=float),
+        "understood": four["cell_total"].to_numpy(dtype=float),
         "spoken": np.nan,
         "signed": np.nan,
         "understood_only": four["understood_only"].to_numpy(dtype=float),
@@ -296,6 +300,14 @@ def prepare_joint_data(
     if not include_uk06:
         m = (analysis_df["study"] == "uk_06") & analysis_df["signed"].notna()
         analysis_df.loc[m, "signed"] = np.nan
+
+    has_any_observation = (
+        analysis_df["understood"].notna()
+        | analysis_df["spoken"].notna()
+        | analysis_df["signed"].notna()
+        | analysis_df["signed_spoken"].notna()
+    )
+    analysis_df = analysis_df[has_any_observation].reset_index(drop=True)
 
     # Integer study codes (sorted for stability).
     unique_studies = sorted(analysis_df["study"].unique())
@@ -687,6 +699,7 @@ def build_model(context: JointContext, definition: JointModelDefinition):
         study_obs = pm.Data("study_obs", study_codes, dims=("obs_id",))
         if use_subject_codes:
             subject_obs = pm.Data("subject_obs", subject_codes, dims=("obs_id",))
+        _ = pm.Data("obs_cells_mask", has_cells_t.astype(int), dims=("obs_id",))
 
         # Latent full-grid trajectories (plain tensors). Option D anchors each GP
         # (per-draw zero at the reference age) when the matching flag is set.
@@ -920,14 +933,27 @@ def sample_posterior_predictive(context: JointContext, definition=None):
     context.set_trace(trace)
     trace.to_netcdf(os.path.join(context.reporting.output_dir, "trace.nc"))
 
-    # Observed uk_02 four-cell counts / ages (recomputed from analysis_df).
+    # Observed uk_02 four-cell counts / ages. Use the stored training mask so
+    # held-out four-cell rows stay aligned with posterior_predictive["cells_obs"].
     df = context.analysis_df
-    has_cells = df["signed_spoken"].notna().values
+    has_cells = np.array(trace.constant_data["obs_cells_mask"].values, dtype=bool)
     cell_counts = np.asarray(
         df.loc[has_cells, ["understood_only", "signed_only", "spoken_only", "signed_spoken"]],
         dtype=int,
     )
     cell_ages = np.asarray(df.loc[has_cells, "age"], dtype=float)
+    cell_pred = np.array(
+        trace.posterior_predictive["cells_obs"]
+        .stack(sample=("chain", "draw"))
+        .transpose("obs_cells_id", "cell_id", "sample")
+        .values
+    )
+    if int(has_cells.sum()) != cell_pred.shape[0]:
+        raise ValueError(
+            f"obs_cells_mask count ({int(has_cells.sum())}) does not match "
+            f"posterior predictive cells_obs length ({cell_pred.shape[0]}); "
+            "stored mask and likelihood rows are misaligned."
+        )
 
     samples = JointModelSamples(
         X_plot=np.array(trace.constant_data["X_plot"].values),
@@ -948,12 +974,7 @@ def sample_posterior_predictive(context: JointContext, definition=None):
         p_any_indep_query=_extract(trace, "p_any_indep_query", "query_id"),
         psi=np.array(trace.posterior["psi"].stack(sample=("chain", "draw")).values),
         cell_obs=cell_counts,
-        cell_pred=np.array(
-            trace.posterior_predictive["cells_obs"]
-            .stack(sample=("chain", "draw"))
-            .transpose("obs_cells_id", "cell_id", "sample")
-            .values
-        ),
+        cell_pred=cell_pred,
         cell_ages=cell_ages,
     )
     context.set_model_samples(samples)

--- a/src/vocab_growth/posterior_analysis.py
+++ b/src/vocab_growth/posterior_analysis.py
@@ -37,6 +37,60 @@ def extract_posterior_predictive(trace, name, dim):
     )
 
 
+def extract_posterior_predictive_float(trace, name, dim):
+    """Extract posterior-predictive samples for non-count deterministic values.
+
+    This mirrors :func:`extract_posterior_predictive`, but preserves floating
+    point values. It is used for predictive probabilities saved alongside
+    posterior-predictive count draws.
+    """
+    return np.array(
+        trace.posterior_predictive[name]
+        .stack(sample=("chain", "draw"))
+        .transpose(dim, "sample")
+        .values
+    )
+
+
+def add_probability_estimand_columns(
+    summary: pd.DataFrame,
+    p_population: np.ndarray,
+    p_subject_marginal: np.ndarray,
+    *,
+    n_trials: int,
+    hdi_prob: float = 0.90,
+) -> pd.DataFrame:
+    """Add explicit population and new-child p/Ey columns to a summary table.
+
+    ``posterior_summary_table`` keeps the historical ``p_*`` / ``Ey_*`` columns
+    as the latent population probability and expected count. For models with
+    subject random effects, the posterior-predictive ``Y_*`` columns can instead
+    target a new-child distribution that integrates over subject-level
+    variability. This helper makes both estimands visible without changing the
+    existing column contract.
+    """
+    out = summary.copy()
+
+    def add_block(prefix: str, draws: np.ndarray) -> None:
+        ey = draws * n_trials
+        p_hdi = np.array(
+            [stats_intervals.hdi_1d(row, hdi_prob=hdi_prob) for row in draws]
+        )
+        ey_hdi = np.array(
+            [stats_intervals.hdi_1d(row, hdi_prob=hdi_prob) for row in ey]
+        )
+        out[f"p_{prefix}_median"] = np.median(draws, axis=1)
+        out[f"p_{prefix}_hdi_lo"] = p_hdi[:, 0]
+        out[f"p_{prefix}_hdi_hi"] = p_hdi[:, 1]
+        out[f"Ey_{prefix}_median"] = np.median(ey, axis=1)
+        out[f"Ey_{prefix}_hdi_lo"] = ey_hdi[:, 0]
+        out[f"Ey_{prefix}_hdi_hi"] = ey_hdi[:, 1]
+
+    add_block("population", p_population)
+    add_block("subject_marginal", p_subject_marginal)
+    return out
+
+
 def posterior_summary_table(
     X_query: np.ndarray,
     p_query: np.ndarray,

--- a/tests/test_joint_four_cell.py
+++ b/tests/test_joint_four_cell.py
@@ -10,29 +10,40 @@ marginal-only set. Otherwise the NaN cell casts to a negative integer and trips
 the four-cell count validation in ``build_model``.
 """
 
+import dse_research_utils.statistics.models.reporting as reporting
+import dse_research_utils.statistics.models.sampling as sampling
 import numpy as np
 import pandas as pd
 
 import vocab_growth.environment as env
 from vocab_growth.models import common_joint_modality as cjm
+from vocab_growth.models.common import ModelFitContext
+from vocab_growth.models.definitions import VG15
 
 
 def _write_uk02_csv(path):
     rows = [
         # Complete, reconciling four-cell row -> belongs in `four`.
         dict(
-            age=30.0, comprehension=19, signed=6, spoken=7,
+            subject_id="child_1", age=30.0, comprehension=19, signed=6, spoken=7,
+            understood_only=10, signed_only=2, spoken_only=3, signed_spoken=4,
+        ),
+        # Complete and margin-reconciling, but the raw comprehension total
+        # differs from the four-cell sum. This still belongs in `four`; the
+        # prepared model data will use cell_total as the understood count.
+        dict(
+            subject_id="child_2", age=31.0, comprehension=22, signed=6, spoken=7,
             understood_only=10, signed_only=2, spoken_only=3, signed_spoken=4,
         ),
         # Reconciles on the signed/spoken margins, but understood_only (and the
         # comprehension total) is missing -> must be marginal-only.
         dict(
-            age=32.0, comprehension=np.nan, signed=6, spoken=7,
+            subject_id="child_3", age=32.0, comprehension=np.nan, signed=6, spoken=7,
             understood_only=np.nan, signed_only=2, spoken_only=3, signed_spoken=4,
         ),
         # No cross-tab at all -> marginal-only.
         dict(
-            age=28.0, comprehension=40, signed=5, spoken=5,
+            subject_id="child_4", age=28.0, comprehension=40, signed=5, spoken=5,
             understood_only=np.nan, signed_only=np.nan, spoken_only=np.nan,
             signed_spoken=np.nan,
         ),
@@ -46,8 +57,8 @@ def test_four_cell_loader_routes_incomplete_rows_to_marginal(tmp_path, monkeypat
 
     four, marg = cjm._load_uk02_four_cell()
 
-    # Only the complete, reconciling row is treated as a four-cell row.
-    assert len(four) == 1
+    # Only complete, margin-reconciling rows are treated as four-cell rows.
+    assert len(four) == 2
     assert len(marg) == 2
 
     cells = ["understood_only", "signed_only", "spoken_only", "signed_spoken"]
@@ -56,3 +67,53 @@ def test_four_cell_loader_routes_incomplete_rows_to_marginal(tmp_path, monkeypat
     # ...so the counts cast cleanly to non-negative integers (the original bug
     # cast a NaN cell to INT_MIN, tripping build_model's validation).
     assert np.asarray(four[cells], dtype=int).min() >= 0
+
+
+def test_prepare_joint_data_uses_cell_total_and_drops_empty_rows(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(env, "DATA_DIR", str(tmp_path))
+    _write_uk02_csv(tmp_path / "vocab_data_uk_02.csv")
+
+    merged = pd.DataFrame(
+        [
+            {
+                "study": "uk_05",
+                "age": 24.0,
+                "understood": np.nan,
+                "spoken": np.nan,
+                "signed": np.nan,
+                "subject_id": "empty_child",
+            },
+            {
+                "study": "uk_05",
+                "age": 25.0,
+                "understood": 30,
+                "spoken": np.nan,
+                "signed": np.nan,
+                "subject_id": "valid_child",
+            },
+        ]
+    )
+    monkeypatch.setattr(
+        cjm.vocab_data_utils,
+        "load_data",
+        lambda **kwargs: merged[kwargs["columns"]],
+    )
+
+    context = ModelFitContext(
+        reporting=reporting.ReportingConfiguration(
+            model_name="TEST_VG15_DATA",
+            config_name="test",
+            output_root_dir=str(tmp_path),
+            hdi=0.90,
+        ),
+        sampling=sampling.get_sampling_configuration("test"),
+    )
+    cjm.prepare_joint_data(context, VG15)
+    analysis_df = context.analysis_df
+
+    assert "empty_child" not in set(analysis_df["subject_id"])
+    four_rows = analysis_df[analysis_df["signed_spoken"].notna()]
+    np.testing.assert_array_equal(four_rows["understood"], four_rows["cell_total"])
+    assert 22 not in set(four_rows["understood"])

--- a/tests/test_posterior_analysis.py
+++ b/tests/test_posterior_analysis.py
@@ -7,6 +7,7 @@ import numpy as np
 import xarray as xr
 
 from vocab_growth.posterior_analysis import (
+    add_probability_estimand_columns,
     extract_posterior,
     extract_posterior_predictive,
     posterior_summary_table,
@@ -89,3 +90,29 @@ def test_posterior_summary_values_age_24():
     assert np.isclose(row["P(Y=0)"], 0.0)
     assert np.isclose(row["P(Y<=400)"], 1.0)  # all draws == 400
     assert np.isclose(row["P(Y>400)"], 0.0)
+
+
+def test_add_probability_estimand_columns_makes_population_and_subject_explicit():
+    summary = _summary()
+    p_population = np.vstack([
+        np.full(N_SAMPLES, 0.25),
+        np.full(N_SAMPLES, 0.50),
+    ])
+    p_subject = np.vstack([
+        np.full(N_SAMPLES, 0.20),
+        np.full(N_SAMPLES, 0.60),
+    ])
+
+    out = add_probability_estimand_columns(
+        summary,
+        p_population,
+        p_subject,
+        n_trials=800,
+        hdi_prob=0.90,
+    )
+
+    row = out[out["age_months"] == 12.0].iloc[0]
+    assert np.isclose(row["p_population_median"], 0.25)
+    assert np.isclose(row["Ey_population_median"], 200.0)
+    assert np.isclose(row["p_subject_marginal_median"], 0.20)
+    assert np.isclose(row["Ey_subject_marginal_median"], 160.0)


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).

## Summary

- Treat VG15 four-cell sums as the authoritative understood totals for complete `uk_02` four-cell rows.
- Drop VG15 rows that have age/study/subject metadata but no likelihood-contributing observation.
- Store and reuse the VG15 training four-cell mask so holdout posterior predictive extraction stays aligned.
- Add explicit population-level and subject-marginal p/Ey columns to bivariate subject-RE summary tables.
- Update VG08-VG10/VG15 report text and include VG14/VG15 in the standalone upload script.

## Why

Recent review found that VG15 could let the same four-cell assessment occasion contribute inconsistent understood totals, and could keep all-empty rows in the analysis frame. The bivariate subject-RE summary tables also mixed population-level p/Ey with new-child predictive Y columns without making both estimands explicit.

## Validation

- `conda run -n dse-vocab-growth ruff check src/vocab_growth/models/ src/vocab_growth/posterior_analysis.py scripts/upload.py tests/test_posterior_analysis.py tests/test_joint_four_cell.py`
- `conda run -n dse-vocab-growth pytest tests/test_posterior_analysis.py tests/test_build_utils.py tests/test_gp_utils.py`
- Manual VG15 data-path probe: 950 analysis rows after dropping empty rows; 0 all-likelihood-empty rows; 56 four-cell rows; all four-cell understood counts equal `cell_total`.

## Known Local Test Limitation

`tests/test_joint_four_cell.py` still cannot collect in this local shell because importing PreliZ triggers Numba's cache locator error before project assertions run:

`RuntimeError: cannot cache function 'garcia_approximation': no locator available for file ... preliz/internal/special.py`

This is the same environment-level import blockage observed before these changes.