### PR TITLE
[codex] Use shared storage publishing helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
           pip install -e ../research/src/python
           pip install -e .
 
+      - name: Run pytest
+        run: pytest
+
       - name: Prepare data
         run: python scripts/prepare_data.py
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,13 @@
 node_modules
 .venv
+.pytest_cache
+.pytest_cache/**
+**/.pytest_cache
+**/.pytest_cache/**
+.ruff_cache
+.ruff_cache/**
+**/.ruff_cache
+**/.ruff_cache/**
 output
 outputs
 _freeze

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
       - notebook>=7.6.0
       - orjson>=3.11.9
       - pandas-stubs
-      - pandas>=3.0.4
+      - pandas>=3.0.3
       - preliz>=0.27.0
       - pytest>=9.1.1
       - rich>=15.0.0

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "spellcheck": "cspell --show-suggestions --show-context \"**/*.md\" \"docs/**/*.qmd\"",
-    "format": "prettier --write \"**/*.md\"",
-    "format:check": "prettier --check \"**/*.md\""
+    "format": "node scripts/format-markdown.mjs --write",
+    "format:check": "node scripts/format-markdown.mjs --check"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "arviz-stats>=1.2.0",
   "arviz>=1.2.0",
   "duckdb>=1.5.2",
+  "dse-research-utils>=0.2.0",
   "jaxlib>=0.9.2",
   "matplotlib>=3.10.9",
   "numpy>=2.4.4",
@@ -24,7 +25,9 @@ dependencies = [
   "pandas>=3.0.3",
   "preliz>=0.18.0",
   "pymc>=6.0.1",
-  "scipy>=1.18.0"
+  "scipy>=1.18.0",
+  "rich>=15.0.0",
+  "xarray>=2026.4.0"
 ]
 
 [project.optional-dependencies]

--- a/scripts/format-markdown.mjs
+++ b/scripts/format-markdown.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+
+const mode = process.argv[2];
+
+if (!["--check", "--write"].includes(mode)) {
+  console.error("Usage: node scripts/format-markdown.mjs --check|--write");
+  process.exit(2);
+}
+
+const trackedMarkdown = spawnSync("git", ["ls-files", "--", "*.md", ":(exclude)data/**/*.md"], {
+  encoding: "utf8",
+});
+
+if (trackedMarkdown.status !== 0) {
+  if (trackedMarkdown.stderr) {
+    process.stderr.write(trackedMarkdown.stderr);
+  } else if (trackedMarkdown.error) {
+    console.error(trackedMarkdown.error.message);
+  }
+  process.exit(trackedMarkdown.status ?? 1);
+}
+
+const files = trackedMarkdown.stdout.split(/\r?\n/u).filter(Boolean);
+
+if (files.length === 0) {
+  process.exit(0);
+}
+
+const prettier = process.platform === "win32" ? "prettier.cmd" : "prettier";
+const result = spawnSync(prettier, [mode, ...files], {
+  shell: process.platform === "win32",
+  stdio: "inherit",
+});
+
+process.exit(result.status ?? 1);

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -370,6 +370,7 @@ def prepare_joint_data(
 
     context.set_model_data(bmd, analysis_df)
     context.dataframes["descriptive_stats"] = desc
+    os.makedirs(context.reporting.output_dir, exist_ok=True)
     desc.to_csv(
         os.path.join(context.reporting.output_dir, "descriptive_statistics.csv"),
         index=True,

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -3,8 +3,6 @@
 
 from collections.abc import Callable
 
-from dse_research_utils.storage.azure import upload_directory_to_blob_storage
-
 from vocab_growth.reporting import (
     format_duration,
     heading,
@@ -37,6 +35,8 @@ def upload_to_blob_storage(
     str
         The public URL of the uploaded ``index.html`` report.
     """
+    from dse_research_utils.storage.azure import upload_directory_to_blob_storage
+
     heading(f"Uploading {model_label} to Azure Blob Storage")
     key_value_table(
         "Upload target",

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -1,22 +1,17 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import mimetypes
-import os
-import time
-import uuid
 from collections.abc import Callable
-from urllib.parse import urlparse
 
-from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobServiceClient, ContentSettings
+from dse_research_utils.storage.azure import upload_directory_to_blob_storage
 
 from vocab_growth.reporting import (
-    console,
     format_duration,
     heading,
     key_value_table,
 )
+
+DEFAULT_PROJECT = "vocabulary-growth"
 
 
 def upload_to_blob_storage(
@@ -42,82 +37,36 @@ def upload_to_blob_storage(
     str
         The public URL of the uploaded ``index.html`` report.
     """
-    container_url = os.environ.get("DSERESEARCH_BLOB_CONTAINER_URL")
-    if not container_url:
-        console.print(
-            "[bold red]Error: DSERESEARCH_BLOB_CONTAINER_URL environment variable is not set.[/bold red]"
-        )
-        console.print("Set it to your Azure Blob container URL, e.g.:")
-        console.print(
-            "  export DSERESEARCH_BLOB_CONTAINER_URL='https://<account>.blob.core.windows.net/<container>'"
-        )
-        raise RuntimeError(
-            "DSERESEARCH_BLOB_CONTAINER_URL environment variable is not set."
-        )
-
-    parsed = urlparse(container_url.rstrip("/"))
-    account_url = f"{parsed.scheme}://{parsed.netloc}"
-    container_name = parsed.path.lstrip("/")
-
-    run_id = uuid.uuid7()
-    blob_prefix = f"projects/vocabulary-growth/output/{run_id}/{model_label}"
-
     heading(f"Uploading {model_label} to Azure Blob Storage")
     key_value_table(
         "Upload target",
         [
             ("Source", output_dir),
-            ("Container", container_name),
-            ("Prefix", f"{blob_prefix}/"),
+            ("Project", DEFAULT_PROJECT),
             ("Include traces", include_traces),
         ],
     )
 
-    credential = DefaultAzureCredential()
-    blob_service_client = BlobServiceClient(account_url, credential=credential)
-    container_client = blob_service_client.get_container_client(container_name)
+    result = upload_directory_to_blob_storage(
+        output_dir,
+        model_label,
+        project=DEFAULT_PROJECT,
+        include_traces=include_traces,
+        skip=skip,
+    )
 
-    uploaded = 0
-    skipped = 0
-    bytes_sent = 0
-    started = time.perf_counter()
-    for root, _dirs, files in os.walk(output_dir):
-        for filename in files:
-            local_path = os.path.join(root, filename)
-            relative_path = os.path.relpath(local_path, output_dir).replace("\\", "/")
+    if result.report_url is None:
+        raise RuntimeError(f"No index.html report was uploaded for {model_label}.")
 
-            if not include_traces and filename.endswith(".nc"):
-                skipped += 1
-                continue
-            if skip is not None and skip(relative_path):
-                skipped += 1
-                continue
-
-            blob_name = f"{blob_prefix}/{relative_path}"
-
-            content_type, _ = mimetypes.guess_type(filename)
-            if content_type is None:
-                content_type = "application/octet-stream"
-
-            bytes_sent += os.path.getsize(local_path)
-            with open(local_path, "rb") as f:
-                container_client.upload_blob(
-                    blob_name,
-                    f,
-                    overwrite=True,
-                    content_settings=ContentSettings(content_type=content_type),
-                )
-            uploaded += 1
-
-    report_url = f"{account_url}/{container_name}/{blob_prefix}/index.html"
     key_value_table(
         f"Upload complete — {model_label}",
         [
-            ("Files uploaded", uploaded),
-            ("Files skipped", skipped),
-            ("Bytes uploaded", f"{bytes_sent / 1_000_000:.1f} MB"),
-            ("Elapsed", format_duration(time.perf_counter() - started)),
-            ("Report URL", report_url),
+            ("Files uploaded", result.uploaded_files),
+            ("Files skipped", result.skipped_files),
+            ("Bytes uploaded", f"{result.bytes_uploaded / 1_000_000:.1f} MB"),
+            ("Elapsed", format_duration(result.elapsed_seconds)),
+            ("Prefix", result.prefix_url),
+            ("Report URL", result.report_url),
         ],
     )
-    return report_url
+    return result.report_url


### PR DESCRIPTION
> [!NOTE]
> Drafted by a LLM-based AI tool (Codex/GPT-5).

## Summary

- Replace the project-local Azure Blob upload logic with the shared `dse_research_utils.storage.azure` helper.
- Keep the existing vocabulary-specific rich reporting around upload progress and report URLs.
- Add the shared tracked-Markdown formatting helper to avoid recursive glob issues in local cache directories.
- Add `pytest` to the existing conda-backed CI job after editable package installation.

## Impact

Vocabulary Growth now follows the same Azure publishing path and Markdown command surface as the shared research repository and Language Reading Predictors. The storage wrapper depends on the shared utility added in dseinternational/research#48, so this PR should be merged after the shared utility is available.

## Validation

- `python -m ruff check --no-cache src/vocab_growth/storage.py`
- `node scripts/format-markdown.mjs --check`
- `npm run spellcheck`