### PR TITLE
[claude] Consolidate the trend + HSGP builder into gp_utils (#86)

### DIFF
--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -48,7 +48,7 @@ from vocab_growth.models.build_utils import (
 )
 from vocab_growth.models.definitions import UnivariateModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
-from vocab_growth.models.gp_utils import make_kappa_of_z
+from vocab_growth.models.gp_utils import GPGrid, make_kappa_of_z, trend_and_gp
 from vocab_growth.reporting import (
     config_table,
     console,
@@ -585,54 +585,28 @@ def build_model(context: ModelFitContext):
         _ = pm.Data("X_plot", X_plot.flatten(), dims=("plot_id",))
         _ = pm.Data("X_query", X_query.flatten(), dims=("query_id",))
 
-        # ---- Mean developmental trajectory ----
-
-        # Anchors
-        p_slope_low = context.model_config.p_slope_low_dist.to_pymc("p_slope_low")
-        p_slope_hi = context.model_config.p_slope_hi_dist.to_pymc("p_slope_hi")
-
-        # Slope (β₁)
-        beta_1 = pm.Deterministic(
-            "slope",
-            (pymc_utils.logit(p_slope_hi) - pymc_utils.logit(p_slope_low))
-            / (slope_age_b_z - slope_age_a_z),
+        # ---- Mean developmental trajectory + HSGP deviation ----
+        # Logit-linear trend + HSGP, built by the shared helper (gp_utils) so the
+        # graph is byte-identical to the previously inlined form: it stores the
+        # named `g` and `f_all` Deterministics and the slope/intercept/ell.
+        f_all = trend_and_gp(
+            cfg_low=context.model_config.p_slope_low_dist,
+            cfg_hi=context.model_config.p_slope_hi_dist,
+            cfg_ell=context.model_config.ell_unit_dist,
+            cfg_eta=context.model_config.eta_dist,
+            suffix="",
+            X_all_z_data=X_all_z_data,
+            grid=GPGrid(
+                sa_z=slope_age_a_z,
+                sb_z=slope_age_b_z,
+                ell_low_z=ell_low_z,
+                ell_high_z=ell_high_z,
+                M=M,
+                L=L,
+            ),
+            store_deterministic=True,
+            latent_name="f_all",
         )
-
-        # Intercept (β₀)
-        beta_0 = pm.Deterministic(
-            "intercept", pymc_utils.logit(p_slope_low) - beta_1 * slope_age_a_z
-        )
-
-        # Linear trend, evaluated at all input points (X_all_data)
-        mean_trend_all = beta_0 + beta_1 * X_all_z_data[:, 0]  # (n_all,)
-
-        # ---- Gaussian Process ----
-
-        # GP hyperparameters
-
-        # Length-scale ℓ (on the z-score scale)
-        ell_unit = context.model_config.ell_unit_dist.to_pymc("ell_unit")
-        ell = pm.Deterministic("ell", ell_low_z + (ell_high_z - ell_low_z) * ell_unit)
-
-        # Amplitude (marginal standard deviation)
-        eta = context.model_config.eta_dist.to_pymc("eta")
-
-        # * HSGP specification *
-
-        # co-variance function: radial basis function (RBF)
-        cov0 = pm.gp.cov.ExpQuad(1, ls=ell)
-
-        # unit-variance kernel: the amplitude η is applied to the basis function weights, not the kernel
-        hsgp0 = pm.gp.HSGP(cov_func=cov0, m=M, L=L)
-
-        # GP function values at all input points (obs + plot + query)
-        g_unit = hsgp0.prior("g_unit", X=X_all_z_data, dims="all_id")
-
-        # scale the raw GP values by the amplitude η to get the actual GP function values
-        g = pm.Deterministic("g", eta * g_unit, dims=("all_id",))
-
-        # the overall function is the sum of the mean trend and the GP deviation from that trend
-        f_all = pm.Deterministic("f_all", mean_trend_all + g, dims=("all_id",))
 
         # Slice for obs / plot / query
         f_obs = pm.Deterministic("f_obs", f_all[i_obs0:i_obs1], dims=("obs_id",))

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -59,7 +59,7 @@ from vocab_growth.models.common import (
 )
 from vocab_growth.models.definitions import BivariateModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
-from vocab_growth.models.gp_utils import make_kappa_of_z
+from vocab_growth.models.gp_utils import GPGrid, make_kappa_of_z, trend_and_gp
 from vocab_growth.plotting import (
     _save_csv,
     plot_comprehension_production_gap,
@@ -483,69 +483,42 @@ def build_model(context: BivariateContext):
         _ = pm.Data("obs_u_mask", has_u.astype(int), dims=("obs_id",))
         _ = pm.Data("obs_s_mask", has_s.astype(int), dims=("obs_id",))
 
-        # ============================================================
-        # Understood (U) trajectory: f_U(a) -> p_U(a)
-        # ============================================================
-
-        p_slope_low_u = config.p_slope_low_u_dist.to_pymc("p_slope_low_u")
-        p_slope_hi_u = config.p_slope_hi_u_dist.to_pymc("p_slope_hi_u")
-
-        slope_u = pm.Deterministic(
-            "slope_u",
-            (pymc_utils.logit(p_slope_hi_u) - pymc_utils.logit(p_slope_low_u))
-            / (slope_age_b_z - slope_age_a_z),
+        # Shared trend + HSGP builder (gp_utils); graph byte-identical to the
+        # inlined form (stores g_u/f_u_all and g_q/h_all + the slope/intercept/ell).
+        gp_grid = GPGrid(
+            sa_z=slope_age_a_z,
+            sb_z=slope_age_b_z,
+            ell_low_z=ell_low_z,
+            ell_high_z=ell_high_z,
+            M=M,
+            L=L,
         )
-        intercept_u = pm.Deterministic(
-            "intercept_u",
-            pymc_utils.logit(p_slope_low_u) - slope_u * slope_age_a_z,
+
+        # ---- Understood (U) trajectory: f_U(a) -> p_U(a) ----
+        f_u_all = trend_and_gp(
+            cfg_low=config.p_slope_low_u_dist,
+            cfg_hi=config.p_slope_hi_u_dist,
+            cfg_ell=config.ell_unit_u_dist,
+            cfg_eta=config.eta_u_dist,
+            suffix="_u",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=True,
+            latent_name="f_u_all",
         )
-        mean_trend_u = intercept_u + slope_u * X_all_z_data[:, 0]
 
-        # GP for understood
-        ell_unit_u = config.ell_unit_u_dist.to_pymc("ell_unit_u")
-        ell_u = pm.Deterministic(
-            "ell_u", ell_low_z + (ell_high_z - ell_low_z) * ell_unit_u
+        # ---- Production ratio: h(a) -> q(a) = sigmoid(h(a)) ----
+        h_all = trend_and_gp(
+            cfg_low=config.p_slope_low_q_dist,
+            cfg_hi=config.p_slope_hi_q_dist,
+            cfg_ell=config.ell_unit_q_dist,
+            cfg_eta=config.eta_q_dist,
+            suffix="_q",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=True,
+            latent_name="h_all",
         )
-        eta_u = config.eta_u_dist.to_pymc("eta_u")
-
-        cov_u = pm.gp.cov.ExpQuad(1, ls=ell_u)
-        hsgp_u = pm.gp.HSGP(cov_func=cov_u, m=M, L=L)
-        g_unit_u = hsgp_u.prior("g_unit_u", X=X_all_z_data, dims="all_id")
-        g_u = pm.Deterministic("g_u", eta_u * g_unit_u, dims=("all_id",))
-
-        f_u_all = pm.Deterministic("f_u_all", mean_trend_u + g_u, dims=("all_id",))
-
-        # ============================================================
-        # Production ratio: h(a) -> q(a) = sigmoid(h(a))
-        # ============================================================
-
-        p_slope_low_q = config.p_slope_low_q_dist.to_pymc("p_slope_low_q")
-        p_slope_hi_q = config.p_slope_hi_q_dist.to_pymc("p_slope_hi_q")
-
-        slope_q = pm.Deterministic(
-            "slope_q",
-            (pymc_utils.logit(p_slope_hi_q) - pymc_utils.logit(p_slope_low_q))
-            / (slope_age_b_z - slope_age_a_z),
-        )
-        intercept_q = pm.Deterministic(
-            "intercept_q",
-            pymc_utils.logit(p_slope_low_q) - slope_q * slope_age_a_z,
-        )
-        mean_trend_q = intercept_q + slope_q * X_all_z_data[:, 0]
-
-        # GP for production rate
-        ell_unit_q = config.ell_unit_q_dist.to_pymc("ell_unit_q")
-        ell_q = pm.Deterministic(
-            "ell_q", ell_low_z + (ell_high_z - ell_low_z) * ell_unit_q
-        )
-        eta_q = config.eta_q_dist.to_pymc("eta_q")
-
-        cov_q = pm.gp.cov.ExpQuad(1, ls=ell_q)
-        hsgp_q = pm.gp.HSGP(cov_func=cov_q, m=M, L=L)
-        g_unit_q = hsgp_q.prior("g_unit_q", X=X_all_z_data, dims="all_id")
-        g_q = pm.Deterministic("g_q", eta_q * g_unit_q, dims=("all_id",))
-
-        h_all = pm.Deterministic("h_all", mean_trend_q + g_q, dims=("all_id",))
 
         # ============================================================
         # Derived quantities: p_U, q, p_S

--- a/src/vocab_growth/models/common_bivariate_re.py
+++ b/src/vocab_growth/models/common_bivariate_re.py
@@ -63,7 +63,7 @@ from vocab_growth.models.common_bivariate import (
     sample_posterior_predictive,
 )
 from vocab_growth.models.definitions import BivariateModelDefinition
-from vocab_growth.models.gp_utils import make_kappa_of_z
+from vocab_growth.models.gp_utils import GPGrid, make_kappa_of_z, trend_and_gp
 from vocab_growth.reporting import (
     console,
     dataframe_table,
@@ -376,79 +376,45 @@ def build_model_re(
                 "subject_obs", subject_codes, dims=("obs_id",)
             )
 
-        # ============================================================
-        # Understood (U) trajectory: f_U(a) -> p_U(a)
-        # ============================================================
-
-        p_slope_low_u = config.p_slope_low_u_dist.to_pymc("p_slope_low_u")
-        p_slope_hi_u = config.p_slope_hi_u_dist.to_pymc("p_slope_hi_u")
-
-        slope_u = pm.Deterministic(
-            "slope_u",
-            (pymc_utils.logit(p_slope_hi_u) - pymc_utils.logit(p_slope_low_u))
-            / (slope_age_b_z - slope_age_a_z),
+        # Shared trend + HSGP builder (gp_utils); graph byte-identical to the
+        # inlined form: stores g_u/f_u_all and g_q/h_all (+ slope/intercept/ell),
+        # population-level latents (no study effect), Option-D anchor per outcome.
+        gp_grid = GPGrid(
+            sa_z=slope_age_a_z,
+            sb_z=slope_age_b_z,
+            ell_low_z=ell_low_z,
+            ell_high_z=ell_high_z,
+            M=M,
+            L=L,
         )
-        intercept_u = pm.Deterministic(
-            "intercept_u",
-            pymc_utils.logit(p_slope_low_u) - slope_u * slope_age_a_z,
+
+        # ---- Understood (U) trajectory: f_U(a) -> p_U(a) ----
+        f_u_all = trend_and_gp(
+            cfg_low=config.p_slope_low_u_dist,
+            cfg_hi=config.p_slope_hi_u_dist,
+            cfg_ell=config.ell_unit_u_dist,
+            cfg_eta=config.eta_u_dist,
+            suffix="_u",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=True,
+            latent_name="f_u_all",
+            anchor_idx=i_anchor if anchor_g_u else None,
         )
-        mean_trend_u = intercept_u + slope_u * X_all_z_data[:, 0]
 
-        # GP for understood
-        ell_unit_u = config.ell_unit_u_dist.to_pymc("ell_unit_u")
-        ell_u = pm.Deterministic(
-            "ell_u", ell_low_z + (ell_high_z - ell_low_z) * ell_unit_u
+        # ---- Production ratio: h(a) -> q(a) = sigmoid(h(a)) ----
+        h_all = trend_and_gp(
+            cfg_low=config.p_slope_low_q_dist,
+            cfg_hi=config.p_slope_hi_q_dist,
+            cfg_ell=config.ell_unit_q_dist,
+            cfg_eta=config.eta_q_dist,
+            suffix="_q",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=True,
+            latent_name="h_all",
+            anchor_idx=i_anchor if anchor_g_q else None,
         )
-        eta_u = config.eta_u_dist.to_pymc("eta_u")
-
-        cov_u = pm.gp.cov.ExpQuad(1, ls=ell_u)
-        hsgp_u = pm.gp.HSGP(cov_func=cov_u, m=M, L=L)
-        g_unit_u = hsgp_u.prior("g_unit_u", X=X_all_z_data, dims="all_id")
-        if anchor_g_u:
-            g_unit_u_centred = g_unit_u - g_unit_u[i_anchor]
-        else:
-            g_unit_u_centred = g_unit_u
-        g_u = pm.Deterministic("g_u", eta_u * g_unit_u_centred, dims=("all_id",))
-
-        # Population-level f_U (no study effect)
-        f_u_all = pm.Deterministic("f_u_all", mean_trend_u + g_u, dims=("all_id",))
-
-        # ============================================================
-        # Production ratio: h(a) -> q(a) = sigmoid(h(a))
-        # ============================================================
-
-        p_slope_low_q = config.p_slope_low_q_dist.to_pymc("p_slope_low_q")
-        p_slope_hi_q = config.p_slope_hi_q_dist.to_pymc("p_slope_hi_q")
-
-        slope_q = pm.Deterministic(
-            "slope_q",
-            (pymc_utils.logit(p_slope_hi_q) - pymc_utils.logit(p_slope_low_q))
-            / (slope_age_b_z - slope_age_a_z),
-        )
-        intercept_q = pm.Deterministic(
-            "intercept_q",
-            pymc_utils.logit(p_slope_low_q) - slope_q * slope_age_a_z,
-        )
-        mean_trend_q = intercept_q + slope_q * X_all_z_data[:, 0]
-
-        # GP for production rate
-        ell_unit_q = config.ell_unit_q_dist.to_pymc("ell_unit_q")
-        ell_q = pm.Deterministic(
-            "ell_q", ell_low_z + (ell_high_z - ell_low_z) * ell_unit_q
-        )
-        eta_q = config.eta_q_dist.to_pymc("eta_q")
-
-        cov_q = pm.gp.cov.ExpQuad(1, ls=ell_q)
-        hsgp_q = pm.gp.HSGP(cov_func=cov_q, m=M, L=L)
-        g_unit_q = hsgp_q.prior("g_unit_q", X=X_all_z_data, dims="all_id")
-        if anchor_g_q:
-            g_unit_q_centred = g_unit_q - g_unit_q[i_anchor]
-        else:
-            g_unit_q_centred = g_unit_q
-        g_q = pm.Deterministic("g_q", eta_q * g_unit_q_centred, dims=("all_id",))
-
-        # Population-level h (no study effect)
-        h_all = pm.Deterministic("h_all", mean_trend_q + g_q, dims=("all_id",))
 
         # ============================================================
         # Study-level random intercepts

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -84,7 +84,12 @@ from vocab_growth.models.common import (
 )
 from vocab_growth.models.definitions import JointModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
-from vocab_growth.models.gp_utils import make_kappa_of_z
+from vocab_growth.models.gp_utils import (
+    GPGrid,
+    intercept_and_gp,
+    make_kappa_of_z,
+    trend_and_gp,
+)
 from vocab_growth.plotting import _save_csv, plot_prior_samples_ratio
 from vocab_growth.posterior_analysis import extract_posterior as _extract
 from vocab_growth.reporting import (
@@ -642,57 +647,6 @@ def build_model(context: JointContext, definition: JointModelDefinition):
     if use_subject_codes:
         coords["subject_id"] = np.arange(n_subjects)
 
-    def trend_and_gp(cfg_low, cfg_hi, cfg_ell, cfg_eta, suffix, X_all_z_data, anchor_idx=None):
-        """Build a logit-linear trend + HSGP deviation; return the full-grid latent.
-
-        If ``anchor_idx`` is given (Option D), the GP is centred to pass through
-        zero at that grid row for every draw, so the linear trend alone sets the
-        level there and the GP only carries deviations.
-        """
-        p_lo = cfg_low.to_pymc(f"p_slope_low_{suffix}")
-        p_hi = cfg_hi.to_pymc(f"p_slope_hi_{suffix}")
-        slope = pm.Deterministic(
-            f"slope_{suffix}",
-            (pymc_utils.logit(p_hi) - pymc_utils.logit(p_lo)) / (sb_z - sa_z),
-        )
-        intercept = pm.Deterministic(
-            f"intercept_{suffix}", pymc_utils.logit(p_lo) - slope * sa_z
-        )
-        mean_trend = intercept + slope * X_all_z_data[:, 0]
-        ell_unit = cfg_ell.to_pymc(f"ell_unit_{suffix}")
-        ell = pm.Deterministic(
-            f"ell_{suffix}", ell_low_z + (ell_high_z - ell_low_z) * ell_unit
-        )
-        eta = cfg_eta.to_pymc(f"eta_{suffix}")
-        cov = pm.gp.cov.ExpQuad(1, ls=ell)
-        hsgp = pm.gp.HSGP(cov_func=cov, m=M, L=L)
-        g_unit = hsgp.prior(f"g_unit_{suffix}", X=X_all_z_data, dims="all_id")
-        if anchor_idx is not None:
-            g_unit = g_unit - g_unit[anchor_idx]
-        return mean_trend + eta * g_unit  # plain tensor (n_all,)
-
-    def intercept_and_gp(cfg_intercept, cfg_ell, cfg_eta, suffix, X_all_z_data, anchor_idx=None):
-        """Intercept-only mean (no age slope) + HSGP deviation; full-grid latent.
-
-        Used for the signed ratio: a free age slope would extrapolate the ratio
-        below the data floor (< ~18 mo), so the mean is intercept-only and the GP
-        carries the age-varying (rise-then-fall) shape. The study random
-        intercept is added at observation level by the caller. If ``anchor_idx``
-        is given (Option D), the GP passes through zero at that grid row per draw.
-        """
-        intercept = cfg_intercept.to_pymc(f"intercept_{suffix}")
-        ell_unit = cfg_ell.to_pymc(f"ell_unit_{suffix}")
-        ell = pm.Deterministic(
-            f"ell_{suffix}", ell_low_z + (ell_high_z - ell_low_z) * ell_unit
-        )
-        eta = cfg_eta.to_pymc(f"eta_{suffix}")
-        cov = pm.gp.cov.ExpQuad(1, ls=ell)
-        hsgp = pm.gp.HSGP(cov_func=cov, m=M, L=L)
-        g_unit = hsgp.prior(f"g_unit_{suffix}", X=X_all_z_data, dims="all_id")
-        if anchor_idx is not None:
-            g_unit = g_unit - g_unit[anchor_idx]
-        return intercept + eta * g_unit  # plain tensor (n_all,)
-
     with pm.Model(coords=coords) as model_pm:
         X_all_z_data = pm.Data("X_all_z", X_all_z, dims=("all_id", "x_dim"))
         _ = pm.Data("X_plot", X_plot.flatten(), dims=("plot_id",))
@@ -702,23 +656,49 @@ def build_model(context: JointContext, definition: JointModelDefinition):
             subject_obs = pm.Data("subject_obs", subject_codes, dims=("obs_id",))
         _ = pm.Data("obs_cells_mask", has_cells_t.astype(int), dims=("obs_id",))
 
-        # Latent full-grid trajectories (plain tensors). Option D anchors each GP
-        # (per-draw zero at the reference age) when the matching flag is set.
+        # Latent full-grid trajectories (plain tensors), built by the shared
+        # gp_utils helpers. Option D anchors each GP (per-draw zero at the
+        # reference age) when the matching flag is set.
+        gp_grid = GPGrid(
+            sa_z=sa_z,
+            sb_z=sb_z,
+            ell_low_z=ell_low_z,
+            ell_high_z=ell_high_z,
+            M=M,
+            L=L,
+        )
         f_u_all = trend_and_gp(
-            config.p_slope_low_u_dist, config.p_slope_hi_u_dist,
-            config.ell_unit_u_dist, config.eta_u_dist, "u", X_all_z_data,
+            cfg_low=config.p_slope_low_u_dist,
+            cfg_hi=config.p_slope_hi_u_dist,
+            cfg_ell=config.ell_unit_u_dist,
+            cfg_eta=config.eta_u_dist,
+            suffix="_u",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=False,
             anchor_idx=i_anchor if anchor_g_u else None,
         )
         h_all = trend_and_gp(
-            config.p_slope_low_q_dist, config.p_slope_hi_q_dist,
-            config.ell_unit_q_dist, config.eta_q_dist, "q", X_all_z_data,
+            cfg_low=config.p_slope_low_q_dist,
+            cfg_hi=config.p_slope_hi_q_dist,
+            cfg_ell=config.ell_unit_q_dist,
+            cfg_eta=config.eta_q_dist,
+            suffix="_q",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=False,
             anchor_idx=i_anchor if anchor_g_q else None,
         )
         # Signed marginal: intercept-only mean (no age slope) + GP hump; the
         # study random intercept delta_sign is added at obs level below.
         g_all = intercept_and_gp(
-            config.intercept_sign_dist,
-            config.ell_unit_sign_dist, config.eta_sign_dist, "sign", X_all_z_data,
+            cfg_intercept=config.intercept_sign_dist,
+            cfg_ell=config.ell_unit_sign_dist,
+            cfg_eta=config.eta_sign_dist,
+            suffix="_sign",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=False,
             anchor_idx=i_anchor if anchor_g_sign else None,
         )
 

--- a/src/vocab_growth/models/common_trivariate.py
+++ b/src/vocab_growth/models/common_trivariate.py
@@ -72,7 +72,12 @@ from vocab_growth.models.common import (
 )
 from vocab_growth.models.definitions import TrivariateModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
-from vocab_growth.models.gp_utils import make_kappa_of_z
+from vocab_growth.models.gp_utils import (
+    GPGrid,
+    intercept_and_gp,
+    make_kappa_of_z,
+    trend_and_gp,
+)
 from vocab_growth.plotting import (
     _save_csv,
     plot_comprehension_production_gap,
@@ -600,98 +605,58 @@ def build_model(context: TrivariateContext):
         _ = pm.Data("obs_s_mask", has_s.astype(int), dims=("obs_id",))
         _ = pm.Data("obs_sign_mask", has_sign.astype(int), dims=("obs_id",))
 
-        # ============================================================
-        # Understood (U) trajectory: f_U(a) -> p_U(a)
-        # ============================================================
-
-        p_slope_low_u = config.p_slope_low_u_dist.to_pymc("p_slope_low_u")
-        p_slope_hi_u = config.p_slope_hi_u_dist.to_pymc("p_slope_hi_u")
-
-        slope_u = pm.Deterministic(
-            "slope_u",
-            (pymc_utils.logit(p_slope_hi_u) - pymc_utils.logit(p_slope_low_u))
-            / (slope_age_b_z - slope_age_a_z),
+        # Shared trend + HSGP builder (gp_utils); graph byte-identical to the
+        # inlined form. Full-grid (n_all,) latents are returned as plain tensors
+        # (not stored Deterministics): only the obs/plot/query slices below are
+        # extracted, so storing the full arrays for every draw would waste a large
+        # amount of trace memory.
+        gp_grid = GPGrid(
+            sa_z=slope_age_a_z,
+            sb_z=slope_age_b_z,
+            ell_low_z=ell_low_z,
+            ell_high_z=ell_high_z,
+            M=M,
+            L=L,
         )
-        intercept_u = pm.Deterministic(
-            "intercept_u",
-            pymc_utils.logit(p_slope_low_u) - slope_u * slope_age_a_z,
+
+        # ---- Understood (U) trajectory: f_U(a) -> p_U(a) ----
+        f_u_all = trend_and_gp(
+            cfg_low=config.p_slope_low_u_dist,
+            cfg_hi=config.p_slope_hi_u_dist,
+            cfg_ell=config.ell_unit_u_dist,
+            cfg_eta=config.eta_u_dist,
+            suffix="_u",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=False,
         )
-        mean_trend_u = intercept_u + slope_u * X_all_z_data[:, 0]
 
-        # GP for understood
-        ell_unit_u = config.ell_unit_u_dist.to_pymc("ell_unit_u")
-        ell_u = pm.Deterministic(
-            "ell_u", ell_low_z + (ell_high_z - ell_low_z) * ell_unit_u
+        # ---- Production ratio: h(a) -> q(a) = sigmoid(h(a)) ----
+        h_all = trend_and_gp(
+            cfg_low=config.p_slope_low_q_dist,
+            cfg_hi=config.p_slope_hi_q_dist,
+            cfg_ell=config.ell_unit_q_dist,
+            cfg_eta=config.eta_q_dist,
+            suffix="_q",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=False,
         )
-        eta_u = config.eta_u_dist.to_pymc("eta_u")
 
-        cov_u = pm.gp.cov.ExpQuad(1, ls=ell_u)
-        hsgp_u = pm.gp.HSGP(cov_func=cov_u, m=M, L=L)
-        g_unit_u = hsgp_u.prior("g_unit_u", X=X_all_z_data, dims="all_id")
-        # Full-grid (n_all,) intermediates are kept as plain tensors rather than
-        # stored Deterministics: only the obs/plot/query slices below are
-        # extracted, so storing the full-grid arrays for every draw would waste
-        # a large amount of trace memory.
-        g_u = eta_u * g_unit_u
-
-        f_u_all = mean_trend_u + g_u
-
-        # ============================================================
-        # Production ratio: h(a) -> q(a) = sigmoid(h(a))
-        # ============================================================
-
-        p_slope_low_q = config.p_slope_low_q_dist.to_pymc("p_slope_low_q")
-        p_slope_hi_q = config.p_slope_hi_q_dist.to_pymc("p_slope_hi_q")
-
-        slope_q = pm.Deterministic(
-            "slope_q",
-            (pymc_utils.logit(p_slope_hi_q) - pymc_utils.logit(p_slope_low_q))
-            / (slope_age_b_z - slope_age_a_z),
-        )
-        intercept_q = pm.Deterministic(
-            "intercept_q",
-            pymc_utils.logit(p_slope_low_q) - slope_q * slope_age_a_z,
-        )
-        mean_trend_q = intercept_q + slope_q * X_all_z_data[:, 0]
-
-        # GP for production rate
-        ell_unit_q = config.ell_unit_q_dist.to_pymc("ell_unit_q")
-        ell_q = pm.Deterministic(
-            "ell_q", ell_low_z + (ell_high_z - ell_low_z) * ell_unit_q
-        )
-        eta_q = config.eta_q_dist.to_pymc("eta_q")
-
-        cov_q = pm.gp.cov.ExpQuad(1, ls=ell_q)
-        hsgp_q = pm.gp.HSGP(cov_func=cov_q, m=M, L=L)
-        g_unit_q = hsgp_q.prior("g_unit_q", X=X_all_z_data, dims="all_id")
-        g_q = eta_q * g_unit_q
-
-        h_all = mean_trend_q + g_q
-
-        # ============================================================
-        # Signed ratio: g_sign(a) -> r(a) = sigmoid(g_sign(a))
-        # ============================================================
-
+        # ---- Signed ratio: g_sign(a) -> r(a) = sigmoid(g_sign(a)) ----
         # Intercept-only mean (no age slope): structurally prevents a free slope
         # from extrapolating the signed ratio below the data floor (< ~18 mo),
         # while a wide intercept prior lets the data set the level. The GP carries
         # the age-varying (rise-then-fall) shape.
-        intercept_sign = config.intercept_sign_dist.to_pymc("intercept_sign")
-        mean_trend_sign = intercept_sign
-
-        # GP for signed rate
-        ell_unit_sign = config.ell_unit_sign_dist.to_pymc("ell_unit_sign")
-        ell_sign = pm.Deterministic(
-            "ell_sign", ell_low_z + (ell_high_z - ell_low_z) * ell_unit_sign
+        g_sign_all = intercept_and_gp(
+            cfg_intercept=config.intercept_sign_dist,
+            cfg_ell=config.ell_unit_sign_dist,
+            cfg_eta=config.eta_sign_dist,
+            suffix="_sign",
+            X_all_z_data=X_all_z_data,
+            grid=gp_grid,
+            store_deterministic=False,
         )
-        eta_sign = config.eta_sign_dist.to_pymc("eta_sign")
-
-        cov_sign = pm.gp.cov.ExpQuad(1, ls=ell_sign)
-        hsgp_sign = pm.gp.HSGP(cov_func=cov_sign, m=M, L=L)
-        g_unit_sign = hsgp_sign.prior("g_unit_sign", X=X_all_z_data, dims="all_id")
-        gp_sign = eta_sign * g_unit_sign
-
-        g_sign_all = mean_trend_sign + gp_sign
 
         # ============================================================
         # Derived quantities: p_U, q, p_S, r, p_Sign, p_any

--- a/src/vocab_growth/models/common_univariate_re.py
+++ b/src/vocab_growth/models/common_univariate_re.py
@@ -56,7 +56,7 @@ from vocab_growth.models.common import (
     sample_posterior_predictive,
 )
 from vocab_growth.models.definitions import UnivariateModelDefinition
-from vocab_growth.models.gp_utils import make_kappa_of_z
+from vocab_growth.models.gp_utils import GPGrid, make_kappa_of_z, trend_and_gp
 from vocab_growth.reporting import (
     console,
     dataframe_table,
@@ -289,44 +289,30 @@ def build_univariate_re_model(
         study_obs = pm.Data("study_obs", study_codes, dims=("obs_id",))
 
         # ============================================================
-        # Mean developmental trajectory
+        # Mean developmental trajectory + HSGP deviation
         # ============================================================
-
-        p_slope_low = config.p_slope_low_dist.to_pymc("p_slope_low")
-        p_slope_hi = config.p_slope_hi_dist.to_pymc("p_slope_hi")
-
-        beta_1 = pm.Deterministic(
-            "slope",
-            (pymc_utils.logit(p_slope_hi) - pymc_utils.logit(p_slope_low))
-            / (slope_age_b_z - slope_age_a_z),
+        # Shared helper (gp_utils); graph byte-identical to the inlined form
+        # (stores the named g / f_all; Option-D anchor when the model enables it).
+        # Population-level linear predictor (no study effect).
+        f_all = trend_and_gp(
+            cfg_low=config.p_slope_low_dist,
+            cfg_hi=config.p_slope_hi_dist,
+            cfg_ell=config.ell_unit_dist,
+            cfg_eta=config.eta_dist,
+            suffix="",
+            X_all_z_data=X_all_z_data,
+            grid=GPGrid(
+                sa_z=slope_age_a_z,
+                sb_z=slope_age_b_z,
+                ell_low_z=ell_low_z,
+                ell_high_z=ell_high_z,
+                M=M,
+                L=L,
+            ),
+            store_deterministic=True,
+            latent_name="f_all",
+            anchor_idx=i_anchor if anchor_g else None,
         )
-        beta_0 = pm.Deterministic(
-            "intercept",
-            pymc_utils.logit(p_slope_low) - beta_1 * slope_age_a_z,
-        )
-        mean_trend_all = beta_0 + beta_1 * X_all_z_data[:, 0]
-
-        # ============================================================
-        # Gaussian Process
-        # ============================================================
-
-        ell_unit = config.ell_unit_dist.to_pymc("ell_unit")
-        ell = pm.Deterministic("ell", ell_low_z + (ell_high_z - ell_low_z) * ell_unit)
-        eta = config.eta_dist.to_pymc("eta")
-
-        cov0 = pm.gp.cov.ExpQuad(1, ls=ell)
-        hsgp0 = pm.gp.HSGP(cov_func=cov0, m=M, L=L)
-        g_unit = hsgp0.prior("g_unit", X=X_all_z_data, dims="all_id")
-
-        if anchor_g:
-            g_unit_centred = g_unit - g_unit[i_anchor]
-        else:
-            g_unit_centred = g_unit
-
-        g = pm.Deterministic("g", eta * g_unit_centred, dims=("all_id",))
-
-        # Population-level linear predictor (no study effect)
-        f_all = pm.Deterministic("f_all", mean_trend_all + g, dims=("all_id",))
 
         # ============================================================
         # Study-level random intercepts (non-centred parameterisation)

--- a/src/vocab_growth/models/gp_utils.py
+++ b/src/vocab_growth/models/gp_utils.py
@@ -7,21 +7,27 @@ This module holds helpers that emit PyMC ops (as opposed to the pure-NumPy
 helpers in :mod:`vocab_growth.models.build_utils`). It is deliberately kept
 separate so the pure module stays ``pymc``-free.
 
-Currently it provides only :func:`make_kappa_of_z`, the age-varying dispersion
+It provides :func:`make_kappa_of_z`, the age-varying dispersion
 closure factory. The factory takes random variables the caller has already
 created (in the caller's own order) and returns a closure whose body is
 byte-identical to the ``kappa_of_z`` closures previously inlined in every engine,
 so it moves no random-variable creation and cannot change the model graph.
 
-The trend + HSGP construction (``trend_and_gp`` / ``intercept_and_gp``), which is
-still duplicated across the engines, is intended to be consolidated here in a
-follow-up; it is excluded from the current change because it moves the sole
-RNG-bearing call (``hsgp.prior()``) and requires empirical fit-equivalence proof.
+It also provides the trend + HSGP construction (``trend_and_gp`` /
+``intercept_and_gp``) shared by every engine. Because these carry the sole
+RNG-bearing call (``hsgp.prior()``), they are parameterised (``suffix``,
+``store_deterministic``, ``latent_name``, ``anchor_idx``, ``grid``) so each engine
+reproduces its previous PyMC graph byte-for-byte (same free RVs, in the same order,
+with the same names and ``logp``); the named-``Deterministic`` differences between
+engines change only what is stored in the trace, not the sampled distribution.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import pymc as pm
+from dse_research_utils.statistics.models.pymc_utils import logit
 
 
 def make_kappa_of_z(kappa_min, a_kappa, b_kappa):
@@ -37,3 +43,138 @@ def make_kappa_of_z(kappa_min, a_kappa, b_kappa):
         return kappa_min + pm.math.exp(a_kappa + b_kappa * z)
 
     return kappa_of_z
+
+
+@dataclass(frozen=True)
+class GPGrid:
+    """The standardised-grid + HSGP scalars the trend/GP helpers need.
+
+    These are values the engines already compute: the slope-anchor standardised
+    reference ages (``sa_z``, ``sb_z``), the length-scale bounds on the z scale
+    (``ell_low_z``, ``ell_high_z``), and the per-dimension HSGP basis counts ``M``
+    and boundaries ``L`` (each a length-one list for the 1-D age kernel, passed
+    straight to ``pm.gp.HSGP``). Bundling them keeps the helper signatures small and
+    identical across engines.
+    """
+
+    sa_z: float
+    sb_z: float
+    ell_low_z: float
+    ell_high_z: float
+    M: list[int]
+    L: list[float]
+
+
+def trend_and_gp(
+    *,
+    cfg_low,
+    cfg_hi,
+    cfg_ell,
+    cfg_eta,
+    suffix,
+    X_all_z_data,
+    grid,
+    store_deterministic,
+    latent_name=None,
+    anchor_idx=None,
+):
+    """Logit-linear trend + HSGP deviation; return the full-grid latent.
+
+    Emits exactly the ops previously inlined in every engine, so it moves no
+    random-variable creation and cannot change the model graph. ``suffix`` carries
+    its own leading underscore (``""`` for single-outcome engines; ``"_u"`` /
+    ``"_q"`` / ``"_sign"`` otherwise). When ``store_deterministic`` is true the GP
+    value ``g{suffix}`` and the latent ``latent_name`` are stored as named
+    ``Deterministic``\\ s (``dims=("all_id",)``); otherwise a plain tensor is
+    returned (the trace-memory discipline used by the trivariate / joint engines).
+    ``anchor_idx`` (Option D) centres the GP to pass through zero at that grid row
+    for every draw.
+    """
+    p_lo = cfg_low.to_pymc(f"p_slope_low{suffix}")
+    p_hi = cfg_hi.to_pymc(f"p_slope_hi{suffix}")
+    slope = pm.Deterministic(
+        f"slope{suffix}", (logit(p_hi) - logit(p_lo)) / (grid.sb_z - grid.sa_z)
+    )
+    intercept = pm.Deterministic(
+        f"intercept{suffix}", logit(p_lo) - slope * grid.sa_z
+    )
+    mean_trend = intercept + slope * X_all_z_data[:, 0]
+    return _gp_from_mean(
+        mean_trend,
+        cfg_ell=cfg_ell,
+        cfg_eta=cfg_eta,
+        suffix=suffix,
+        X_all_z_data=X_all_z_data,
+        grid=grid,
+        store_deterministic=store_deterministic,
+        latent_name=latent_name,
+        anchor_idx=anchor_idx,
+    )
+
+
+def intercept_and_gp(
+    *,
+    cfg_intercept,
+    cfg_ell,
+    cfg_eta,
+    suffix,
+    X_all_z_data,
+    grid,
+    store_deterministic,
+    latent_name=None,
+    anchor_idx=None,
+):
+    """Intercept-only mean (no age slope) + HSGP deviation; full-grid latent.
+
+    Used for the signed ratio, where a free age slope would extrapolate the ratio
+    below the data floor: the mean is the free RV ``intercept{suffix}`` (created via
+    ``to_pymc``, *not* a ``Deterministic``) and the GP carries the age-varying
+    shape. Otherwise identical to :func:`trend_and_gp` (see it for the parameters).
+    """
+    intercept = cfg_intercept.to_pymc(f"intercept{suffix}")
+    return _gp_from_mean(
+        intercept,
+        cfg_ell=cfg_ell,
+        cfg_eta=cfg_eta,
+        suffix=suffix,
+        X_all_z_data=X_all_z_data,
+        grid=grid,
+        store_deterministic=store_deterministic,
+        latent_name=latent_name,
+        anchor_idx=anchor_idx,
+    )
+
+
+def _gp_from_mean(
+    mean_trend,
+    *,
+    cfg_ell,
+    cfg_eta,
+    suffix,
+    X_all_z_data,
+    grid,
+    store_deterministic,
+    latent_name,
+    anchor_idx,
+):
+    """Shared HSGP tail: build ell/eta/HSGP, sample ``g_unit``, combine with the mean.
+
+    Factored out of :func:`trend_and_gp` / :func:`intercept_and_gp` so the two
+    differ only in their mean term. The op order is unchanged from the inlined
+    engines: ``ell_unit`` and ``eta`` are created after the mean term and before the
+    single RNG-bearing ``hsgp.prior`` call, so the free-RV stream is identical.
+    """
+    ell_unit = cfg_ell.to_pymc(f"ell_unit{suffix}")
+    ell = pm.Deterministic(
+        f"ell{suffix}", grid.ell_low_z + (grid.ell_high_z - grid.ell_low_z) * ell_unit
+    )
+    eta = cfg_eta.to_pymc(f"eta{suffix}")
+    cov = pm.gp.cov.ExpQuad(1, ls=ell)
+    hsgp = pm.gp.HSGP(cov_func=cov, m=grid.M, L=grid.L)
+    g_unit = hsgp.prior(f"g_unit{suffix}", X=X_all_z_data, dims="all_id")
+    if anchor_idx is not None:
+        g_unit = g_unit - g_unit[anchor_idx]
+    if store_deterministic:
+        g = pm.Deterministic(f"g{suffix}", eta * g_unit, dims=("all_id",))
+        return pm.Deterministic(latent_name, mean_trend + g, dims=("all_id",))
+    return mean_trend + eta * g_unit

--- a/tests/test_gp_utils.py
+++ b/tests/test_gp_utils.py
@@ -10,8 +10,15 @@ variables the caller has already created).
 """
 
 import numpy as np
+import preliz as pz
+import pymc as pm
 
-from vocab_growth.models.gp_utils import make_kappa_of_z
+from vocab_growth.models.gp_utils import (
+    GPGrid,
+    intercept_and_gp,
+    make_kappa_of_z,
+    trend_and_gp,
+)
 
 
 def test_make_kappa_of_z_at_zero():
@@ -33,3 +40,93 @@ def test_make_kappa_of_z_monotone_for_negative_b():
     hi = float(f(1.0).eval())
     # negative b_kappa => kappa decreases as standardised age increases
     assert lo > hi
+
+
+# --- trend_and_gp / intercept_and_gp -----------------------------------------
+
+_GRID = GPGrid(sa_z=-1.0, sb_z=1.0, ell_low_z=0.2, ell_high_z=2.0, M=[10], L=[2.0])
+
+
+def _model_with(call):
+    """Build a throwaway model, invoke ``call(X_all_z_data)`` in it, return it."""
+    x = np.linspace(-2.0, 2.0, 8).reshape(-1, 1)
+    with pm.Model(coords={"all_id": range(8), "x_dim": range(1)}) as m:
+        X = pm.Data("X_all_z", x, dims=("all_id", "x_dim"))
+        call(X)
+    return m
+
+
+def test_trend_and_gp_stores_named_deterministics():
+    def call(X):
+        trend_and_gp(
+            cfg_low=pz.Beta(alpha=1, beta=15),
+            cfg_hi=pz.Beta(alpha=1.1, beta=1.1),
+            cfg_ell=pz.Beta(alpha=2, beta=2),
+            cfg_eta=pz.HalfNormal(sigma=1.0),
+            suffix="_u",
+            X_all_z_data=X,
+            grid=_GRID,
+            store_deterministic=True,
+            latent_name="f_u_all",
+        )
+
+    m = _model_with(call)
+    free = {v.name for v in m.free_RVs}
+    det = {d.name for d in m.deterministics}
+    assert {"p_slope_low_u", "p_slope_hi_u", "ell_unit_u", "eta_u"} <= free
+    assert {"slope_u", "intercept_u", "ell_u", "g_u", "f_u_all"} <= det
+
+
+def test_trend_and_gp_plain_tensor_keeps_no_latent_deterministic():
+    def call(X):
+        trend_and_gp(
+            cfg_low=pz.Beta(alpha=1, beta=15),
+            cfg_hi=pz.Beta(alpha=1.1, beta=1.1),
+            cfg_ell=pz.Beta(alpha=2, beta=2),
+            cfg_eta=pz.HalfNormal(sigma=1.0),
+            suffix="_q",
+            X_all_z_data=X,
+            grid=_GRID,
+            store_deterministic=False,
+        )
+
+    det = {d.name for d in _model_with(call).deterministics}
+    assert {"slope_q", "intercept_q", "ell_q"} <= det  # scalars always stored
+    assert {"g_q", "h_all"}.isdisjoint(det)  # latent kept as a plain tensor
+
+
+def test_trend_and_gp_anchor_adds_no_free_rv():
+    cfg = dict(
+        cfg_low=pz.Beta(alpha=1, beta=15),
+        cfg_hi=pz.Beta(alpha=1.1, beta=1.1),
+        cfg_ell=pz.Beta(alpha=2, beta=2),
+        cfg_eta=pz.HalfNormal(sigma=1.0),
+        suffix="",
+        grid=_GRID,
+        store_deterministic=True,
+        latent_name="f_all",
+    )
+    plain = _model_with(lambda X: trend_and_gp(X_all_z_data=X, anchor_idx=None, **cfg))
+    anchored = _model_with(lambda X: trend_and_gp(X_all_z_data=X, anchor_idx=3, **cfg))
+    # Option-D centring is a deterministic transform: same free RVs, same order.
+    assert [v.name for v in plain.free_RVs] == [v.name for v in anchored.free_RVs]
+
+
+def test_intercept_and_gp_intercept_is_free_no_slope():
+    def call(X):
+        intercept_and_gp(
+            cfg_intercept=pz.Normal(mu=0, sigma=1),
+            cfg_ell=pz.Beta(alpha=2, beta=2),
+            cfg_eta=pz.HalfNormal(sigma=1.0),
+            suffix="_sign",
+            X_all_z_data=X,
+            grid=_GRID,
+            store_deterministic=False,
+        )
+
+    m = _model_with(call)
+    free = {v.name for v in m.free_RVs}
+    det = {d.name for d in m.deterministics}
+    assert "intercept_sign" in free  # intercept-only mean is a free RV
+    assert "slope_sign" not in det  # no slope for the signed trajectory
+    assert "ell_sign" in det

--- a/tests/test_trend_gp_consolidation.py
+++ b/tests/test_trend_gp_consolidation.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Graph-shape guard for the shared trend + HSGP builder (issue #86).
+
+The inlined trend + HSGP construction was lifted into
+``vocab_growth.models.gp_utils`` (``trend_and_gp`` / ``intercept_and_gp``) and
+adopted across all six engines. Because ``hsgp.prior`` is the sole RNG-bearing
+call, the consolidation must not change any model's PyMC graph. These tests build
+the real model for one representative of each engine (no sampling) and pin the
+graph shape the helpers must reproduce:
+
+- the trend / GP free RVs each engine creates;
+- the named ``Deterministic``\\ s the *store-deterministic* engines keep
+  (``g`` / ``f_all`` and the suffixed ``g_u`` / ``f_u_all`` / ``g_q`` / ``h_all``),
+  and that the trace-memory engines (trivariate / joint) do **not** store them;
+- that the q-side latent is ``h_all`` and never ``f_q_all`` (the latent name is
+  passed explicitly, not derived from the suffix); and
+- that the signed trajectory's ``intercept_sign`` is a free RV (intercept-only
+  mean), not a slope-derived ``Deterministic``.
+
+Builds the real models, so they need the prepared DuckDB; they skip cleanly when
+it is absent (the CI fit job runs ``prepare_data`` first, but bare ``pytest`` may
+not).
+"""
+
+import os
+
+import dse_research_utils.statistics.models.reporting as reporting
+import dse_research_utils.statistics.models.sampling as sampling
+import pytest
+
+import vocab_growth.data_utils as vocab_data_utils
+from vocab_growth.models import common
+from vocab_growth.models import common_bivariate as cb
+from vocab_growth.models import common_bivariate_re as cbr
+from vocab_growth.models import common_joint_modality as cj
+from vocab_growth.models import common_trivariate as ct
+from vocab_growth.models import common_univariate_re as cur
+from vocab_growth.models.common import ModelFitContext
+from vocab_growth.models.definitions import VG01, VG05, VG10, VG11, VG14, VG15
+
+_DEFS = {"VG01": VG01, "VG05": VG05, "VG10": VG10, "VG11": VG11, "VG14": VG14, "VG15": VG15}
+
+
+def _build(model_id, tmp_path, monkeypatch):
+    """Build a representative model for one engine (no sampling)."""
+    if not os.path.exists(vocab_data_utils.VOCABULARY_DATA_PATH):
+        pytest.skip("prepared vocabulary DuckDB not available")
+    # The model-graph render shells out to graphviz `dot`; not needed here.
+    for mod in (common, cur, cb, cbr, ct, cj):
+        monkeypatch.setattr(mod, "render_model_graph", lambda *a, **k: None, raising=False)
+    d = _DEFS[model_id]
+    ctx = ModelFitContext(
+        reporting=reporting.ReportingConfiguration(
+            model_name=d.model_id,
+            config_name=d.config_name,
+            output_root_dir=str(tmp_path),
+            hdi=0.90,
+        ),
+        sampling=sampling.get_sampling_configuration("dev"),
+    )
+    os.makedirs(ctx.reporting.output_dir, exist_ok=True)
+    if model_id == "VG01":
+        common.prepare_univariate_data(ctx, d)
+        common.configure_univariate_priors(ctx, d)
+        common.build_model(ctx)
+    elif model_id == "VG11":
+        cur.prepare_univariate_re_data(ctx, d)
+        common.configure_univariate_priors(ctx, d)
+        cur.build_univariate_re_model(ctx, d)
+    elif model_id == "VG05":
+        cb.prepare_bivariate_data(ctx, d)
+        cb.configure_bivariate_priors(ctx, d)
+        cb.build_model(ctx)
+    elif model_id == "VG10":
+        cbr.prepare_bivariate_re_data(ctx, d)
+        cb.configure_bivariate_priors(ctx, d)
+        cbr.build_model_re(ctx, d)
+    elif model_id == "VG14":
+        ct.prepare_trivariate_data(ctx, d)
+        ct.configure_trivariate_priors(ctx, d)
+        ct.build_model(ctx)
+    elif model_id == "VG15":
+        cj.prepare_joint_data(ctx, d)
+        cj.configure_joint_priors(ctx, d)
+        cj.build_model(ctx, d)
+    return ctx.model
+
+
+def _names(m):
+    return (
+        {v.name for v in m.free_RVs},
+        {d.name for d in m.deterministics},
+        set(m.named_vars),
+    )
+
+
+def test_common_vg01_graph(tmp_path, monkeypatch):
+    free, det, named = _names(_build("VG01", tmp_path, monkeypatch))
+    assert {"p_slope_low", "p_slope_hi", "ell_unit", "eta"} <= free
+    assert {"slope", "intercept", "ell", "g", "f_all"} <= det
+    assert "f_q_all" not in named
+
+
+def test_univariate_re_vg11_graph(tmp_path, monkeypatch):
+    free, det, _ = _names(_build("VG11", tmp_path, monkeypatch))
+    assert {"p_slope_low", "p_slope_hi", "ell_unit", "eta"} <= free
+    assert {"slope", "intercept", "ell", "g", "f_all"} <= det
+
+
+def test_bivariate_vg05_graph(tmp_path, monkeypatch):
+    free, det, named = _names(_build("VG05", tmp_path, monkeypatch))
+    assert {"p_slope_low_u", "p_slope_hi_u", "p_slope_low_q", "p_slope_hi_q"} <= free
+    # The q-side latent is `h_all`, never `f_q_all`.
+    assert {"g_u", "f_u_all", "g_q", "h_all"} <= det
+    assert "f_q_all" not in named
+
+
+def test_bivariate_re_vg10_graph(tmp_path, monkeypatch):
+    _, det, named = _names(_build("VG10", tmp_path, monkeypatch))
+    assert {"g_u", "f_u_all", "g_q", "h_all"} <= det
+    assert "f_q_all" not in named
+
+
+def test_trivariate_vg14_graph(tmp_path, monkeypatch):
+    free, det, _ = _names(_build("VG14", tmp_path, monkeypatch))
+    # Trace-memory engine: full-grid GP latents are plain tensors, not stored.
+    assert {"g_u", "f_u_all", "g_q", "h_all"}.isdisjoint(det)
+    # The slope/intercept/ell scalars are still stored.
+    assert {"slope_u", "slope_q", "ell_u", "ell_q", "ell_sign"} <= det
+    # Signed mean is intercept-only -> a free RV, not a slope-derived Deterministic.
+    assert "intercept_sign" in free
+    assert "slope_sign" not in det
+
+
+def test_joint_vg15_graph(tmp_path, monkeypatch):
+    free, det, _ = _names(_build("VG15", tmp_path, monkeypatch))
+    assert {"g_u", "f_u_all", "g_q", "h_all"}.isdisjoint(det)
+    assert {"slope_u", "slope_q", "ell_sign"} <= det
+    assert "intercept_sign" in free
+    assert "slope_sign" not in det


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

Completes the #66 consolidation (follow-up to #87): lifts the duplicated **trend + HSGP construction** out of all six model engines into shared helpers in `models/gp_utils.py`.

## What changed

- **`gp_utils.py`** — new `trend_and_gp` / `intercept_and_gp` (+ a `GPGrid` dataclass for the standardised-grid / HSGP scalars), generalised from the joint engine's local copy and parameterised by `suffix` (carries its own leading underscore), `store_deterministic`, `latent_name`, and `anchor_idx`.
- **All six engines** adopt the helpers; the joint engine's local nested copy is **retired**. ~360 lines of duplication removed.

## Byte-for-byte equivalence (the bar)

`hsgp.prior` is the sole RNG-bearing call, so the graph must be unchanged. For one model per engine — **VG01, VG11, VG05, VG10, VG14, VG15** — the ordered **free RVs (names + shapes)**, the named **Deterministics**, and **`model.logp()`** at the initial point are **byte-identical before vs after**. That proves the sampled distribution is unchanged; the only per-engine differences (whether `g` / `f_all` are stored as named Deterministics vs kept as plain tensors for trace-memory) affect only what is written to the trace, not sampling. VG15 was also re-fit end-to-end (`--config dev`) cleanly (ψ median ≈ 2.15, consistent with `main`).

## Tests

- New `tests/test_trend_gp_consolidation.py` builds one model per engine (no sampling) and pins the graph shape: the trend/GP free RVs, the stored Deterministics (incl. that the q-side latent is `h_all`, never `f_q_all`), and that the signed trajectory's `intercept_sign` is a free RV (intercept-only mean).
- `tests/test_gp_utils.py` extended with pure helper tests.
- `ruff check src/ scripts/` clean; full `pytest` green.

Closes #86. Closes #66.