### PR TITLE
Improve model output templates

### DIFF
--- a/docs/models/OUTPUT_TEMPLATE_REVIEW.md
+++ b/docs/models/OUTPUT_TEMPLATE_REVIEW.md
@@ -1,0 +1,302 @@
+# Model Output Template Review
+
+> [!NOTE]
+> Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+
+> [!WARNING]
+> Working review note. The recommendations below are based on the checked-in
+> `docs/models/vgNN/index.qmd` templates, the model inventory in
+> `docs/models/README.md`, the prior ledger in `docs/models/PRIORS.md`, and the
+> current shared fitting engines.
+
+## Scope
+
+This note reviews each model output template against five questions:
+
+- Does the template describe the model accurately and sufficiently?
+- Does it describe all priors accurately and sufficiently?
+- Does it show sufficient prior predictive checks?
+- Does it show sufficient diagnostics?
+- Does it thoroughly explore findings and interesting posterior predictions?
+
+The report generation path copies `docs/models/vgNN/index.qmd` into each model
+output directory after fitting, so these checked-in `.qmd` files are the source
+templates for rendered model outputs.
+
+## Cross-model recommendations
+
+1. Add a consistent "Model at a glance" block to every template: population,
+   outcomes, age range, observation scale, anchor ages, data inclusion/exclusion
+   rules, random effects, GP anchoring, and primary derived quantities.
+2. Keep the prior plots, but add plain-language prior interpretation next to
+   them: probability scale, approximate word-count scale when applicable, and a
+   note when a prior is data-informed or computationally stabilising.
+3. Make prior predictive checks evaluative, not just visual: include a short
+   checklist for floor behaviour, ceiling behaviour, smoothness, count spread,
+   `q(a)` and `r(a)` plausibility, random-effect heterogeneity, and four-cell
+   composition where relevant.
+4. Standardise diagnostics: styled R-hat/ESS table, divergences, energy
+   diagnostics, max tree depth if available, trace plot, pair plot for the most
+   geometry-prone parameters, and a short "diagnostic read" paragraph.
+5. Add a "Main findings to inspect" section to every report. The current
+   templates often show the right artefacts but rarely say what substantive
+   claims the reader should or should not take from them.
+6. Add a "Limits and sensitivity targets" block for models with sparse data,
+   posterior-informed priors, random effects, GP anchoring, signing, or the
+   VG15 association parameter.
+
+## Model-by-model recommendations
+
+### VG01: DS spoken baseline
+
+- Model description is accurate for a single-outcome, no-hierarchy baseline.
+  Add explicit statements that repeated observations and study differences are
+  not modelled here, so this is a baseline rather than the preferred DS spoken
+  model.
+- Priors are displayed but not interpreted. Add the low/high anchor
+  distributions on the word-count scale, and explain the HSGP lengthscale,
+  amplitude, and age-varying `kappa` roles.
+- Prior predictive coverage is adequate in artefact count (`prior_samples`,
+  `prior_predictions`, `prior_predictive_checks`) but needs text saying whether
+  young-age floor, later-age upper tail, and count spread are plausible.
+- Diagnostics are visually sufficient but need a pass/fail paragraph, especially
+  for GP hyperparameters and `kappa`.
+- Posterior findings should highlight spoken vocabulary trajectory, peak
+  learning-rate age, uncertainty at older ages, and how this baseline compares
+  to joint/hierarchical DS models.
+
+### VG02: DS understood baseline
+
+- Model description is accurate. Add the same no-hierarchy caveat as VG01.
+- Priors need comprehension-specific interpretation: `Beta(1, 10)` at 24 months
+  and broad `Beta(1.1, 1.1)` at 84 months imply intentionally weak later-age
+  knowledge.
+- Prior predictive text should call out whether comprehension can reach
+  implausible ceilings or remain implausibly low at later ages before seeing
+  data.
+- Diagnostics should report whether the understood GP and age-varying
+  dispersion are well behaved.
+- Findings should focus on comprehension growth and uncertainty, then point to
+  VG05/VG10 for comprehension-production gaps.
+
+### VG03: TD spoken baseline
+
+- Model description is mostly sufficient, but add that this model uses a 25%
+  TD subsample and that VG11 is the full-data, study-random-effect successor.
+- Priors should be interpreted at 12 and 26 months and contrasted with the DS
+  anchor ages.
+- Prior predictive checks should include whether the TD prior reaches plausible
+  spoken counts by 24-30 months under the 800-word reference scale.
+- Diagnostics should note whether subsampling creates stable estimates across
+  the random seed or whether seed sensitivity should be checked.
+- Findings should compare the baseline TD spoken trajectory with VG11, not only
+  report it in isolation.
+
+### VG04: TD understood baseline
+
+- Model description accurately notes that Words & Sentences comprehension is
+  excluded because it is a production proxy. Add the 25% subsampling caveat and
+  reference VG12 as the full-data successor.
+- Priors should explain why the early TD understood anchor is tighter
+  (`Beta(1, 20)`) than the DS understood anchor.
+- Prior predictive checks should assess ceiling pressure because TD
+  comprehension can approach checklist limits quickly.
+- Diagnostics should include a short readout as in VG03.
+- Findings should report understood vocabulary growth and flag that TD
+  understood/spoken relationships are better handled in VG06/VG13.
+
+### VG05: DS baseline joint understood + spoken
+
+- Model description is accurate and sufficiently explains `p_S = p_U * q`.
+  Add a one-line statement that no study or subject random effects are included.
+- Priors show the right U, `q`, and dispersion plots. Add plain-scale summaries,
+  and explicitly label the baseline `q` anchors as broad regularisation.
+- Prior predictive checks should add an evaluative note for the induced spoken
+  trajectory, the comprehension-production gap, and whether `q(a)` is plausible
+  over 12-90 months.
+- Diagnostics are adequate but should focus on the bivariate geometry:
+  U anchors, `q` anchors, GP hyperparameters, and both `kappa` curves.
+- Posterior exploration is strong. Add a concise interpretation of `q(a)` versus
+  posterior predictive spoken/understood count ratios, since the template already
+  shows both.
+
+### VG06: TD baseline joint understood + spoken
+
+- Model description is accurate but should explicitly describe TD data handling:
+  WG/Oxford bivariate rows, WS spoken-only rows, 25% sampling, and the 800-word
+  reference scale.
+- Priors should explain that the `q` priors are broad defaults shared with VG05,
+  while U anchor ages/distributions are TD-specific.
+- Prior predictive checks should focus on the younger TD age range and
+  plausibility of `q(a)` by 24-30 months.
+- Diagnostics should include a short readout and any seed/subsampling caveat.
+- Findings should compare TD comprehension-production timing with DS joint
+  models and state that VG13 is the denser young-TD bivariate refinement.
+
+### VG07: DS joint with study random intercepts
+
+- Model description should add a compact equation or paragraph for study random
+  intercepts on U and `q`, and state that reported curves are population-level
+  with study effects set to zero.
+- Priors are incomplete in prose because the HalfNormal study-effect scale
+  priors (`tau_u`, `tau_q`) are not interpreted. Add their logit-scale and odds
+  multiplier meanings.
+- Prior predictive checks should include the implied between-study variation,
+  not only population trajectories.
+- Diagnostics should monitor `tau_u`, `tau_q`, study intercepts, and any
+  confounding with GP level.
+- Findings should show what study effects change relative to VG05: population
+  trajectory, uncertainty, `kappa`, and the comprehension-production gap.
+
+### VG08: DS joint with study REs and subject RE on understood
+
+- Model description is useful but should state the random-effect structure in a
+  standard at-a-glance block.
+- Priors should include `tau_subj_u` and clarify that subject-marginal posterior
+  predictive summaries integrate over a new child-level effect.
+- Prior predictive checks should include the implied child-to-child variation in
+  understood vocabulary.
+- Diagnostics should focus on `tau_subj_u`, `tau_u`, GP level, and whether the
+  subject RE reduces pressure on `kappa_u`.
+- Findings should compare population-level and subject-marginal predictions, and
+  explain how repeated observations change uncertainty versus VG07.
+
+### VG09: DS joint with subject REs on understood and `q`
+
+- Model description is accurate, including the motivation for adding a subject
+  RE on `q`. Add a short limitation note that this model motivated VG10 because
+  the extra hierarchy can expose a GP/trend/intercept ridge.
+- Priors should include `tau_subj_q` and make clear that the `q` anchors are
+  still the broad baseline anchors.
+- Prior predictive checks should inspect both subject-marginal U and
+  subject-marginal spoken predictions.
+- Diagnostics are especially important here. Add text for the known ridge-prone
+  parameters: `q` GP lengthscale/amplitude, `tau_subj_q`, `tau_q`, and `kappa_s`.
+- Findings should be framed as a structural stepping stone to VG10 unless
+  diagnostics are clean enough for substantive use.
+
+### VG10: DS joint with VG09 hierarchy plus stabilisation
+
+- Model description is good. Add a clear "what changed from VG09" block:
+  posterior-informed `q` anchors and per-draw GP anchors at 54 months.
+- Priors need stronger labelling: the tightened `q` priors are informed by VG07
+  posterior evidence and are not independent external priors.
+- Prior predictive checks should demonstrate that tightened `q` priors still
+  allow plausible spoken trajectories and gaps over 12-90 months.
+- Diagnostics should explicitly report whether the VG09 geometry issue is
+  resolved: R-hat/ESS for `q` hyperparameters, random-effect scales, and pair
+  plots around the anchored GP components.
+- Findings should be the main DS understood/spoken interpretive template:
+  population trajectories, subject-marginal predictions, `q(a)`, gap, learning
+  rates, and dispersion.
+
+### VG11: TD spoken with study random intercepts
+
+- Model description should be expanded. The current univariate wording hides
+  the important differences from VG03: full TD data, study random intercepts,
+  minimum study-size filter, and GP anchor at 19 months.
+- Priors should add `tau` for study effects and explain the GP anchor as a
+  stabilisation/identifiability constraint, not a substantive prior.
+- Prior predictive checks should include between-study heterogeneity and the
+  retained/dropped study count table.
+- Diagnostics should monitor `tau`, study intercepts, and GP anchor geometry.
+- Findings should compare with VG03 and show how using all TD data changes the
+  spoken trajectory and uncertainty.
+
+### VG12: TD understood with study random intercepts
+
+- Same structural improvements as VG11, with comprehension-specific data rules:
+  WG/Oxford only, WS comprehension excluded, full data, minimum study-size
+  filter, GP anchor at 19 months.
+- Priors should explain the `Beta(1, 20)` low anchor and `Beta(1.5, 1.1)` high
+  anchor on the word-count scale.
+- Prior predictive checks should assess rapid TD comprehension growth and
+  ceiling behaviour.
+- Diagnostics should focus on study-effect scales and GP hyperparameters.
+- Findings should compare with VG04 and then with VG13 for young bivariate TD
+  comprehension-production behaviour.
+
+### VG13: young TD joint model, ages 8-18 months
+
+- This template needs the largest expansion. The statistical description is
+  mostly accurate, but it says the study effects are "centred Normal"; the engine
+  implements them with a non-centred parameterisation (`delta = tau * z`) with
+  the same Normal marginal distribution.
+- Add a full priors section: U anchors at 10/16 months, broad baseline `q`
+  anchors, U/`q` GP lengthscale and amplitude, U/S `kappa`, `tau_u`, `tau_q`,
+  study-size filtering, and GP anchor at 13 months.
+- Add prior predictive checks. The bivariate engine already creates
+  `prior_samples_u.png`, `prior_samples_s.png`, and `prior_samples_q.png`; embed
+  and interpret them.
+- Diagnostics are present but should add a diagnostic readout for study-effect
+  scales and anchored GP parameters.
+- Posterior exploration is currently too thin. The same bivariate plotting
+  pipeline should provide many existing artefacts: `joint_trajectory_hdi`,
+  `posterior_summary_s.csv`, `posterior_summary_q.csv`,
+  `production_rate_by_understood`, `production_rate_predictive`,
+  `understood_vs_spoken`, `understood_vs_spoken_predictive`, outcome PMFs/CDFs,
+  count distributions, median trends, learning rates, and kappa plots. Add these
+  so VG13 is comparable to VG05-VG10.
+- Add a limitation callout: inference is intentionally restricted to 8-18
+  months, and outside that window it should not be used as a general TD
+  trajectory.
+
+### VG14: DS trivariate understood + spoken + signed
+
+- The template is one of the strongest overall. One accuracy fix is important:
+  the statistical model section says each of `f_U`, `h`, and `g_sign` has a
+  linear trend plus GP, but the signed ratio currently has an intercept-only mean
+  plus GP. The later signed-prior section says this correctly; make the model
+  section match.
+- Priors are well covered, including the signed-ratio rationale. Add a compact
+  prior table for signed intercept, signed lengthscale, signed amplitude, and all
+  three `kappa` curves.
+- Prior predictive checks are broad. Add an explicit interpretation of whether
+  the signed prior permits a plausible rise-and-fall pattern without implausible
+  pre-data extrapolation.
+- Diagnostics should focus on the sparse signing components: signed GP
+  hyperparameters, `kappa_sign`, and any pair-plot evidence of confounding.
+- Posterior findings are strong. Add a clear "upper-bound" warning near every
+  `p_any` section, and make the uk_02 validation gap a headline limitation rather
+  than a small subsidiary table.
+
+### VG15: DS joint sign/speech association model
+
+- Model description is scientifically rich, but the opening paragraph should
+  mention both study and subject random intercepts because the fitted definition
+  includes subject REs on U, `q`, and signing.
+- Priors are under-displayed relative to model complexity. Add all trajectory
+  priors, not just a subset: U low/high anchors, `q` low/high anchors, U/`q`/sign
+  GP length-scale parameters and amplitudes, signed intercept, all three `kappa` priors,
+  `tau_u`, `tau_q`, `tau_sign`, all subject `tau` priors, `log_psi`, and
+  `log_conc`.
+- Label the tightened `q` priors and `log_psi` prior as data-informed
+  regularisation. Add a sensitivity callout for neutral `psi`, wider `psi`, and
+  alternative concentration priors.
+- Prior predictive checks should include more than `r(a)` and `q(a)`: add
+  `p_U`, spoken, signed, `p_any`, prior four-cell composition, and prior
+  probability of `psi > 1` if the engine can generate them.
+- Diagnostics should use the styled table used elsewhere, add a pair plot for
+  `psi`, `conc`, signed GP hyperparameters, and random-effect scales, and
+  explicitly report whether `tau_subj_sign` is data-identified.
+- Posterior exploration should embed the CSVs already produced for U, spoken,
+  signed, `q`, `r`, `p_any`, and `psi`, not only `r`, `p_any`, and `psi`. Add a
+  section that separates population-level curves from subject-marginal
+  prediction, because the four-cell likelihood deliberately excludes subject
+  shifts from the `psi` composition.
+- Add an extrapolation warning to the composition and `p_any` plots: the scalar
+  `psi` is identified mostly by uk_02 four-cell rows from roughly 19-56 months,
+  so four-cell composition outside that age support is exploratory.
+
+## Suggested implementation order
+
+1. Fix accuracy issues first: VG14 signed mean description, VG13 non-centred
+   study-effect wording, and VG15 opening paragraph.
+2. Bring VG13 up to the same bivariate-report coverage as VG05-VG10, using
+   existing artefacts from the shared engine.
+3. Expand VG15 priors, diagnostics, and posterior summaries to match its model
+   complexity.
+4. Add random-effect prior and interpretation text to VG07-VG12.
+5. Add plain-language prior interpretation and diagnostic readout paragraphs to
+   VG01-VG06.
+6. Add cross-model sensitivity and limitation callouts for VG10, VG14, and VG15.

--- a/docs/models/vg01/index.qmd
+++ b/docs/models/vg01/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -33,6 +37,16 @@ import pandas as pd
 
 We model the number of words spoken as a bounded count outcome out of 800 possible words. The expected proportion of words spoken is modelled as a smooth function of age. On the logit scale, this function is the sum of a linear developmental trend and a Gaussian process term that allows flexible nonlinear departures from linearity. To account for extra variation between children beyond that expected under a simple binomial model, we use a Beta-Binomial likelihood. The Beta-Binomial dispersion parameter is also allowed to vary with age, so the degree of heterogeneity may change over development. Priors for the linear trend are specified indirectly through the expected proportion of words spoken at two reference ages, making the prior assumptions more interpretable.
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** children with Down syndrome.
+- **Outcome:** words spoken out of the common 800-word reference inventory.
+- **Age anchors:** 24 and 84 months.
+- **Hierarchy:** none; study and repeated-child effects are not modelled here.
+- **Role in the model family:** baseline DS spoken trajectory, mainly for comparison with later joint and hierarchical models.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -42,6 +56,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The low-age anchor encodes a strong floor expectation for spoken words at 24 months. The 84-month anchor is deliberately broad, so the prior does not rule out either low or high later spoken vocabulary before seeing the data. The GP length-scale and amplitude priors allow smooth nonlinear departures from the anchor-defined trend, while the `kappa` priors allow extra-binomial heterogeneity to vary with age.
 
 ### Lengthscale
 
@@ -70,6 +86,8 @@ For full details and discussion, please refer to the technical report.
 ![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+Read these checks as a pre-data plausibility test: young-age spoken vocabulary should usually remain near the floor, older-age trajectories should not be forced to the ceiling, and simulated counts should show realistic between-child spread.
 
 ### Prior samples
 
@@ -128,7 +146,15 @@ _style_diagnostics(diagnostics)
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
+::: {.callout-note title="Diagnostic focus"}
+
+For this baseline model, focus on the slope anchors, GP hyperparameters, and age-varying `kappa` parameters. Poor diagnostics there would directly affect the spoken trajectory and learning-rate interpretation.
+
+:::
+
 ## Posterior predictions
+
+The main findings to inspect are the spoken vocabulary trajectory, the age at which the expected learning rate is largest, and how much uncertainty remains at older ages. Because this model has no study or subject effects, treat it as a baseline rather than the final DS spoken-vocabulary account.
 
 ### Posterior summary table for selected ages
 

--- a/docs/models/vg02/index.qmd
+++ b/docs/models/vg02/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -33,6 +37,16 @@ import pandas as pd
 
 We model the number of words understood as a bounded count outcome out of 800 possible words. The expected proportion of words understood is modelled as a smooth function of age. On the logit scale, this function is the sum of a linear developmental trend and a Gaussian process term that allows flexible nonlinear departures from linearity. To account for extra variation between children beyond that expected under a simple binomial model, we use a Beta-Binomial likelihood. The Beta-Binomial dispersion parameter is also allowed to vary with age, so the degree of heterogeneity may change over development. Priors for the linear trend are specified indirectly through the expected proportion of words understood at two reference ages, making the prior assumptions more interpretable.
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** children with Down syndrome.
+- **Outcome:** words understood out of the common 800-word reference inventory.
+- **Age anchors:** 24 and 84 months.
+- **Hierarchy:** none; study and repeated-child effects are not modelled here.
+- **Role in the model family:** baseline DS understood trajectory, mainly for comparison with joint understood-spoken models.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -42,6 +56,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The low-age anchor encodes a floor expectation for understood words at 24 months, but it is less floor-heavy than the spoken anchor because comprehension typically precedes production. The 84-month anchor is deliberately broad, so later comprehension is not forced toward either low or high vocabulary. The GP priors control smooth nonlinear departures from the anchor trend, and the age-varying `kappa` priors control extra-binomial heterogeneity.
 
 ### Lengthscale
 
@@ -70,6 +86,8 @@ For full details and discussion, please refer to the technical report.
 ![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+Read these checks as a pre-data plausibility test: young-age comprehension should usually remain low but not impossible, later-age comprehension should not be forced to the ceiling, and simulated counts should have realistic spread.
 
 ### Prior samples
 
@@ -128,7 +146,15 @@ _style_diagnostics(diagnostics)
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
+::: {.callout-note title="Diagnostic focus"}
+
+For this baseline model, focus on the understood anchors, GP hyperparameters, and age-varying `kappa` parameters. Poor diagnostics there would affect both the median comprehension trajectory and the width of posterior predictive intervals.
+
+:::
+
 ## Posterior predictions
+
+The main findings to inspect are the understood vocabulary trajectory, the age profile of expected learning rate, and uncertainty in the older-age tail. Use the joint models, especially the later DS bivariate models, when the question is the relationship between comprehension and spoken production.
 
 ### Posterior summary table for selected ages
 

--- a/docs/models/vg03/index.qmd
+++ b/docs/models/vg03/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -33,6 +37,16 @@ import pandas as pd
 
 We model the number of words spoken as a bounded count outcome out of an 800-word reference inventory. The expected proportion of words spoken is modelled as a smooth function of age. On the logit scale, this function is the sum of a linear developmental trend and a Gaussian process term that allows flexible nonlinear departures from linearity. To account for extra variation between children beyond that expected under a simple binomial model, we use a Beta-Binomial likelihood. The Beta-Binomial dispersion parameter is also allowed to vary with age, so the degree of heterogeneity may change over development. Wordbank WG, Oxford CDI, and Words & Sentences rows contribute spoken observations. Priors for the linear trend are specified indirectly through the expected proportion of words spoken at two reference ages, making the prior assumptions more interpretable.
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** typically developing children.
+- **Outcome:** words spoken out of the common 800-word reference inventory.
+- **Age anchors:** 12 and 26 months.
+- **Data handling:** 25% TD subsample; Wordbank WG, Oxford CDI, and Words & Sentences rows contribute spoken observations.
+- **Role in the model family:** baseline TD spoken trajectory; VG11 is the full-data study-random-effect successor.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -42,6 +56,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The TD anchor ages are much younger than the DS anchor ages because typical spoken vocabulary changes rapidly across the second year. The low-age anchor is near the floor at 12 months, while the 26-month anchor mildly favours larger vocabularies but remains broad on the 800-word scale. The GP and `kappa` priors match the shared univariate model machinery.
 
 ### Lengthscale
 
@@ -70,6 +86,8 @@ For full details and discussion, please refer to the technical report.
 ![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+Read these checks as a pre-data plausibility test over the TD age range: simulated spoken counts should be low near 9-12 months, capable of rapid growth by 24-30 months, and not mechanically pinned to the inventory ceiling.
 
 ### Prior samples
 
@@ -128,7 +146,15 @@ _style_diagnostics(diagnostics)
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
+::: {.callout-note title="Diagnostic focus"}
+
+Because this baseline model uses a random subsample of TD observations, diagnostics should be read together with the sampling seed and, for final claims, compared with the full-data VG11 model.
+
+:::
+
 ## Posterior predictions
+
+The main findings to inspect are the spoken trajectory and learning-rate profile across the TD age window. Use VG11 when the question requires the full TD data pool and dataset-level variation.
 
 ### Posterior summary table for selected ages
 

--- a/docs/models/vg04/index.qmd
+++ b/docs/models/vg04/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -33,6 +37,16 @@ import pandas as pd
 
 We model the number of words understood as a bounded count outcome out of an 800-word reference inventory. The expected proportion of words understood is modelled as a smooth function of age. On the logit scale, this function is the sum of a linear developmental trend and a Gaussian process term that allows flexible nonlinear departures from linearity. To account for extra variation between children beyond that expected under a simple binomial model, we use a Beta-Binomial likelihood. The Beta-Binomial dispersion parameter is also allowed to vary with age, so the degree of heterogeneity may change over development. Wordbank WG and Oxford CDI rows contribute independently measured understood observations; Words & Sentences rows are excluded because their comprehension values are production proxies. Priors for the linear trend are specified indirectly through the expected proportion of words understood at two reference ages, making the prior assumptions more interpretable.
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** typically developing children.
+- **Outcome:** words understood out of the common 800-word reference inventory.
+- **Age anchors:** 12 and 26 months.
+- **Data handling:** 25% TD subsample; Wordbank WG and Oxford CDI comprehension rows are included, and Words & Sentences comprehension proxies are excluded.
+- **Role in the model family:** baseline TD understood trajectory; VG12 is the full-data study-random-effect successor.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -42,6 +56,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The early TD understood anchor is tighter near the floor than the DS understood anchor because this model covers much younger children. The 26-month anchor mildly favours larger vocabularies while still allowing wide uncertainty on the 800-word scale. Prior predictive checks should be used to judge whether these anchors imply plausible rapid comprehension growth without excessive ceiling pressure.
 
 ### Lengthscale
 
@@ -70,6 +86,8 @@ For full details and discussion, please refer to the technical report.
 ![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+Read these checks as a pre-data plausibility test over the TD comprehension age range: simulated counts should allow rapid growth, but should not force the trajectory to the 800-word ceiling before the data are observed.
 
 ### Prior samples
 
@@ -128,7 +146,15 @@ _style_diagnostics(diagnostics)
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
+::: {.callout-note title="Diagnostic focus"}
+
+Because this baseline model uses a random subsample of TD observations, diagnostics should be read together with the sampling seed and, for final claims, compared with the full-data VG12 model.
+
+:::
+
 ## Posterior predictions
+
+The main findings to inspect are the understood trajectory, the learning-rate profile, and whether posterior predictive intervals show realistic spread near the high end of the TD comprehension range.
 
 ### Posterior summary table for selected ages
 

--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -33,6 +37,16 @@ import pandas as pd
 
 We jointly model words understood and words spoken as bounded count outcomes out of 800 possible words. The expected proportion of words understood, $p_U(a)$, is modelled as a smooth function of age using a linear trend plus a Gaussian process on the logit scale. The proportion of words spoken is derived as $p_S(a) = p_U(a) \cdot q(a)$, where $q(a) = \text{sigmoid}(h(a))$ is the production ratio -- the fraction of understood words that are spoken at age $a$. Since $q(a) \in (0, 1)$, this enforces $p_S \leq p_U$ by construction. Both $f_U(a)$ and $h(a)$ have their own linear trend and Gaussian process components, with HSGP approximations for scalability. Separate Beta-Binomial likelihoods with age-varying dispersion are used for each outcome. Observations where only one outcome is available are retained using separate observation indices.
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** children with Down syndrome.
+- **Outcomes:** words understood and words spoken.
+- **Decomposition:** $p_S(a)=p_U(a)q(a)$, so spoken vocabulary is bounded by comprehension.
+- **Age anchors:** 24 and 84 months for both the understood trajectory and `q`.
+- **Hierarchy:** none; study and repeated-child effects are introduced in later DS joint models.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -42,6 +56,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The understood trajectory uses the DS comprehension anchors. The production-ratio anchors are broad baseline priors: they regularise $q(a)=P(\text{speak}\mid\text{understood})$ without treating the fraction as a direct word count. The two dispersion blocks let extra-binomial heterogeneity differ between comprehension and spoken production.
 
 ### Understood trajectory
 
@@ -80,6 +96,8 @@ For full details and discussion, please refer to the technical report.
 ![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+For this joint baseline, inspect whether the prior induces plausible understood counts, plausible spoken counts, and a credible comprehension-production gap over the full 12-90 month query range.
 
 ### Prior samples -- words understood
 
@@ -137,6 +155,12 @@ _style_diagnostics(diagnostics)
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
+
+::: {.callout-note title="Diagnostic focus"}
+
+The bivariate geometry depends on the understood anchors, `q` anchors, GP hyperparameters, and both `kappa` curves. Weak diagnostics for `q` should be treated as directly relevant to the spoken trajectory.
+
+:::
 
 ## Joint trajectory
 

--- a/docs/models/vg06/index.qmd
+++ b/docs/models/vg06/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -33,6 +37,16 @@ import pandas as pd
 
 We jointly model words understood and words spoken as bounded count outcomes out of an 800-word reference inventory. The expected proportion of words understood, $p_U(a)$, is modelled as a smooth function of age using a linear trend plus a Gaussian process on the logit scale. The proportion of words spoken is derived as $p_S(a) = p_U(a) \cdot q(a)$, where $q(a) = \text{sigmoid}(h(a))$ is the production ratio -- the fraction of understood words that are spoken at age $a$. Since $q(a) \in (0, 1)$, this enforces $p_S \leq p_U$ by construction. Both $f_U(a)$ and $h(a)$ have their own linear trend and Gaussian process components, with HSGP approximations for scalability. Separate Beta-Binomial likelihoods with age-varying dispersion are used for each outcome. Wordbank WG and Oxford CDI rows contribute independently measured understood and spoken observations; Words & Sentences rows contribute spoken observations only.
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** typically developing children.
+- **Outcomes:** words understood and words spoken.
+- **Decomposition:** $p_S(a)=p_U(a)q(a)$, so spoken vocabulary is bounded by comprehension.
+- **Age anchors:** 12 and 26 months.
+- **Data handling:** 25% TD sample; Words & Sentences rows contribute spoken-only observations.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -42,6 +56,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The understood anchors are TD-specific and centred on a much younger developmental window than the DS joint models. The `q` anchors are the same broad baseline production-ratio priors used in VG05, so TD-DS comparisons should not be read as having identical anchor assumptions.
 
 ### Understood trajectory
 
@@ -80,6 +96,8 @@ For full details and discussion, please refer to the technical report.
 ![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+For this TD joint baseline, inspect whether the prior allows rapid comprehension growth, plausible spoken counts, and `q(a)` values that can rise over the 9-30 month query range without being forced to one.
 
 ### Prior samples -- words understood
 
@@ -137,6 +155,12 @@ _style_diagnostics(diagnostics)
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
+
+::: {.callout-note title="Diagnostic focus"}
+
+Read these diagnostics with the TD subsampling in mind. The `q` trajectory, GP hyperparameters, and both dispersion curves are the main checks for the joint TD interpretation; VG13 is the denser young-TD refinement.
+
+:::
 
 ## Joint trajectory
 

--- a/docs/models/vg07/index.qmd
+++ b/docs/models/vg07/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -38,6 +42,16 @@ $$h(a, s) = \text{intercept}_q + \text{slope}_q \cdot a_z + g_q(a) + \delta_q[s]
 
 where $\delta_U[s] \sim \text{Normal}(0, \tau_U)$ and $\delta_q[s] \sim \text{Normal}(0, \tau_q)$ are study-level random intercepts on the logit scale. Plot and query predictions use the population-level trajectory ($\delta = 0$).
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** children with Down syndrome.
+- **Outcomes:** words understood and words spoken.
+- **Hierarchy:** study random intercepts on both the understood trajectory and the production ratio.
+- **Reported curves:** population-level trajectories with study effects set to zero.
+- **Role in the lineage:** VG05 plus study-level heterogeneity.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -47,6 +61,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The trajectory and dispersion priors match the broad DS bivariate baseline. The study random-intercept scales use HalfNormal(0.5) priors on the logit scale for both understood and `q`, allowing meaningful between-study level differences while regularising weakly informed studies.
 
 ### Understood trajectory
 
@@ -85,6 +101,8 @@ For full details and discussion, please refer to the technical report.
 ![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+In addition to the population trajectories, read these checks with the study effects in mind: the prior should allow between-study heterogeneity without letting study shifts dominate the developmental curve.
 
 ### Prior samples -- words understood
 
@@ -142,6 +160,12 @@ _style_diagnostics(diagnostics)
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
+
+::: {.callout-note title="Diagnostic focus"}
+
+Check `tau_u`, `tau_q`, the study intercepts, and the GP level parameters for evidence that between-study shifts are trading off with the global developmental curves.
+
+:::
 
 ## Joint trajectory
 

--- a/docs/models/vg08/index.qmd
+++ b/docs/models/vg08/index.qmd
@@ -44,6 +44,16 @@ where $\delta_U[s] \sim \text{Normal}(0, \tau_U)$ and $\delta_q[s] \sim \text{No
 
 The subject random intercept is applied only to the understood outcome in this first iteration; the production ratio $q$ retains the study-only RE structure from VG07.
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** children with Down syndrome.
+- **Outcomes:** words understood and words spoken.
+- **Hierarchy:** study random intercepts on understood and `q`, plus subject random intercepts on understood.
+- **Reported curves:** population-level trajectories with study and subject effects set to zero.
+- **Subject-marginal predictions:** count summaries integrate over a new child-level understood effect where noted below.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -53,6 +63,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The study and subject random-effect scale priors use HalfNormal(0.5) distributions on the logit scale. The subject-level understood prior is important because repeated observations can otherwise inflate residual dispersion and make within-child observations look independent.
 
 ### Understood trajectory
 
@@ -91,6 +103,8 @@ For full details and discussion, please refer to the technical report.
 ![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+For VG08, prior predictive checks should be read at two levels: the population age curve and the amount of child-to-child variation implied by the subject random-effect prior on understood vocabulary.
 
 ### Prior samples -- words understood
 
@@ -148,6 +162,12 @@ _style_diagnostics(diagnostics)
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
+
+::: {.callout-note title="Diagnostic focus"}
+
+Check `tau_subj_u`, `tau_u`, the understood GP level, and `kappa_u`. If the subject random effect is doing useful work, residual understood dispersion should no longer need to absorb all repeated-child heterogeneity.
+
+:::
 
 ## Joint trajectory
 

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -42,6 +42,16 @@ $$h(a, s, i) = \text{intercept}_q + \text{slope}_q \cdot a_z + g_q(a) + \delta_q
 
 where $\delta_U[s] \sim \text{Normal}(0, \tau_U)$ and $\delta_q[s] \sim \text{Normal}(0, \tau_q)$ are study-level random intercepts on the logit scale, and $\delta^{\text{subj}}_U[i] = \tau^{\text{subj}}_U \cdot z^U_i$, $\delta^{\text{subj}}_q[i] = \tau^{\text{subj}}_q \cdot z^q_i$ with $z^U_i, z^q_i \sim \text{Normal}(0, 1)$ are non-centered subject-level random intercepts on the understood and production-ratio logits. Plot and query predictions use the population-level trajectory ($\delta = 0$ throughout).
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** children with Down syndrome.
+- **Outcomes:** words understood and words spoken.
+- **Hierarchy:** study random intercepts and subject random intercepts on both understood and `q`.
+- **Reported curves:** population-level trajectories with study and subject effects set to zero.
+- **Role in the lineage:** symmetry extension of VG08 and diagnostic stepping stone to VG10.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -51,6 +61,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+VG09 keeps the broad baseline `q` anchors while adding a subject random-effect scale for `q`. This is intentionally a demanding geometry: the `q` intercept, `q` GP, study effects, subject effects, and spoken dispersion can all compete to explain level and heterogeneity.
 
 ### Understood trajectory
 
@@ -89,6 +101,8 @@ For full details and discussion, please refer to the technical report.
 ![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+For VG09, inspect both understood and spoken prior predictions with the subject effects in mind. The checks should show plausible child-to-child variation without letting the `q` hierarchy create extreme spoken/comprehension ratios.
 
 ### Prior samples -- words understood
 
@@ -146,6 +160,12 @@ _style_diagnostics(diagnostics)
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
+
+::: {.callout-note title="Diagnostic focus"}
+
+VG09 is ridge-prone. Focus on the `q` GP length-scale and amplitude, `tau_q`, `tau_subj_q`, and `kappa_s`. Weak diagnostics here are the reason VG10 adds tighter `q` anchors and GP anchoring.
+
+:::
 
 ## Joint trajectory
 

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -49,6 +49,25 @@ $$h(a, s, i) = \text{intercept}_q + \text{slope}_q \cdot a_z + \tilde g_q(a) + \
 
 where $\tilde g_U(a) = \eta_U \cdot (\tilde u_U(a) - \tilde u_U(a_{\text{ref}}))$ and $\tilde g_q(a) = \eta_q \cdot (\tilde u_q(a) - \tilde u_q(a_{\text{ref}}))$ with $\tilde u_U, \tilde u_q$ the unit-amplitude HSGP draws. By construction, $\tilde g_U(a_{\text{ref}}) = \tilde g_q(a_{\text{ref}}) = 0$ on every draw. Plot and query predictions use the population-level trajectory ($\delta = 0$ throughout).
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** children with Down syndrome.
+- **Outcomes:** words understood and words spoken.
+- **Hierarchy:** study and subject random intercepts on both understood and `q`.
+- **Reported curves:** population-level trajectories with study and subject effects set to zero.
+- **Role in the lineage:** stabilised version of VG09 and the main DS understood-spoken interpretive template.
+
+:::
+
+::: {.callout-note title="What changed from VG09"}
+
+- **Tighter `q` anchors:** posterior-informed regularisation from the VG07 fit.
+- **GP anchoring:** both GPs are constrained to be zero at 54 months on every draw.
+- **Hierarchy:** study and subject random intercepts remain on both understood and `q`.
+- **Purpose:** reduce the trend/GP/random-effect redundancy that made VG09 harder to sample.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -58,6 +77,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The understood priors match VG09. The production-ratio anchors are intentionally tighter than the VG05-VG09 defaults: they are informed by the VG07 posterior and should be labelled as data-informed regularisation. They are used to stabilise the decomposition of spoken vocabulary into understood vocabulary times `q(a)`, not as independent prior evidence.
 
 ### Understood trajectory
 
@@ -96,6 +117,8 @@ For full details and discussion, please refer to the technical report.
 ![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+These checks should demonstrate that the tightened `q` anchors still allow plausible spoken trajectories and comprehension-production gaps over 12-90 months. If the prior predictive spoken curves are too narrow, the stabilising prior may be doing too much substantive work.
 
 ### Prior samples -- words understood
 
@@ -153,6 +176,12 @@ _style_diagnostics(diagnostics)
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
+
+::: {.callout-note title="Diagnostic focus"}
+
+The critical question is whether the VG09 geometry issue is resolved. Check R-hat and ESS for the `q` anchors, `q` GP hyperparameters, `tau_q`, `tau_subj_q`, and the anchored GP components.
+
+:::
 
 ## Joint trajectory
 

--- a/docs/models/vg11/index.qmd
+++ b/docs/models/vg11/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -33,6 +37,16 @@ import pandas as pd
 
 We model the number of words spoken as a bounded count outcome out of an 800-word reference inventory. The expected proportion of words spoken is modelled as a smooth function of age. On the logit scale, this function is the sum of a linear developmental trend, a Gaussian process term (anchored at 19 months to remove the GP–intercept ridge), and a dataset-level study random intercept. Study intercepts are modelled with a non-centred Normal parameterisation and absorbed at the observation level only; plot and query predictions use the population-level trajectory. To account for extra variation between children, we use a Beta-Binomial likelihood with age-varying dispersion. Wordbank WG, Oxford CDI, and Words & Sentences rows contribute spoken observations.
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** typically developing children.
+- **Outcome:** words spoken out of the common 800-word reference inventory.
+- **Data handling:** full TD data rather than the VG03 subsample; datasets with fewer than 200 observations are filtered.
+- **Hierarchy:** dataset-level study random intercepts.
+- **Stabilisation:** the GP is anchored at 19 months.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -42,6 +56,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The trajectory priors match the TD spoken baseline anchors at 12 and 26 months. The study random-effect scale uses a HalfNormal(0.5) prior on the logit scale. The 19-month GP anchor is a stabilisation constraint that separates the GP level from the intercept and study effects; it is not a substantive claim that development changes uniquely at 19 months.
 
 ### Lengthscale
 
@@ -70,6 +86,8 @@ For full details and discussion, please refer to the technical report.
 ![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+Prior predictive checks should be judged against the full TD spoken data window and the study-effect hierarchy: simulated trajectories should allow rapid TD growth while leaving room for dataset-level differences.
 
 ### Prior samples
 
@@ -133,7 +151,15 @@ _style_diagnostics(diagnostics)
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
+::: {.callout-note title="Diagnostic focus"}
+
+Check the study-effect scale, study intercepts, and GP hyperparameters. The purpose of VG11 is to use all TD spoken data while absorbing between-dataset variation, so weak diagnostics on those terms are substantively important.
+
+:::
+
 ## Posterior predictions
+
+The main findings to inspect are how the full-data, study-adjusted spoken trajectory differs from VG03, and whether the study random effects reduce uncertainty or reveal between-dataset heterogeneity.
 
 ### Posterior summary table for selected ages
 

--- a/docs/models/vg12/index.qmd
+++ b/docs/models/vg12/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -33,6 +37,16 @@ import pandas as pd
 
 We model the number of words understood as a bounded count outcome out of an 800-word reference inventory. The expected proportion of words understood is modelled as a smooth function of age. On the logit scale, this function is the sum of a linear developmental trend, a Gaussian process term (anchored at 19 months to remove the GP–intercept ridge), and a dataset-level study random intercept. Study intercepts are modelled with a non-centred Normal parameterisation and absorbed at the observation level only; plot and query predictions use the population-level trajectory. To account for extra variation between children, we use a Beta-Binomial likelihood with age-varying dispersion. Only Wordbank WG and Oxford CDI rows contribute understood observations; WS comprehension values are production proxies and are excluded.
 
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** typically developing children.
+- **Outcome:** words understood out of the common 800-word reference inventory.
+- **Data handling:** full TD data rather than the VG04 subsample; datasets with fewer than 200 observations are filtered.
+- **Hierarchy:** dataset-level study random intercepts.
+- **Stabilisation:** the GP is anchored at 19 months.
+
+:::
+
 ::: {.callout-note}
 
 For full details and discussion, please refer to the technical report.
@@ -42,6 +56,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The trajectory priors match the TD understood baseline anchors at 12 and 26 months. The low anchor is strongly floor-oriented, while the high anchor allows rapid TD comprehension growth without forcing a ceiling. The study random-effect scale uses a HalfNormal(0.5) prior on the logit scale, and the 19-month GP anchor is an identifiability constraint rather than a substantive developmental breakpoint.
 
 ### Lengthscale
 
@@ -70,6 +86,8 @@ For full details and discussion, please refer to the technical report.
 ![Dispersion prior distribution `b_kappa_mag_dist`](b_kappa_mag_dist.png){#fig-b-kappa-mag .lightbox fig-align="left"}
 
 ## Prior predictive checks
+
+Prior predictive checks should be judged against rapid TD comprehension growth and possible ceiling pressure. The prior should allow high comprehension by later query ages without making that outcome inevitable before seeing the data.
 
 ### Prior samples
 
@@ -133,7 +151,15 @@ _style_diagnostics(diagnostics)
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
+::: {.callout-note title="Diagnostic focus"}
+
+Check the study-effect scale, study intercepts, GP hyperparameters, and age-varying `kappa`. The full-data study hierarchy is the main difference from VG04.
+
+:::
+
 ## Posterior predictions
+
+The main findings to inspect are how the full-data, study-adjusted understood trajectory differs from VG04, and how much uncertainty remains near the upper end of the TD comprehension range.
 
 ### Posterior summary table for selected ages
 

--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -31,7 +35,18 @@ import pandas as pd
 
 ## Statistical model
 
-We model words understood and words spoken as bounded count outcomes out of an 800-word reference inventory, restricted to children aged 8–18 months. The understood trajectory and the production ratio $q = p_S / p_U$ are each modelled as smooth functions of age (linear trend + HSGP), with each GP anchored at 13 months to remove the GP–intercept ridge. Dataset-level study random intercepts (centred Normal) are added to both trajectories, absorbed at the observation level only. Plot and query predictions use the population-level trajectory. A Beta-Binomial likelihood with age-varying dispersion accounts for extra-binomial variability in both outcomes.
+We model words understood and words spoken as bounded count outcomes out of an 800-word reference inventory, restricted to children aged 8-18 months. The understood trajectory and the production ratio $q = p_S / p_U$ are each modelled as smooth functions of age (linear trend + HSGP). Both GPs are anchored at 13 months to remove the GP-intercept ridge. Dataset-level study random intercepts are added to both trajectories on the logit scale using a non-centred parameterisation, with the same marginal distribution as $\delta_U[s], \delta_q[s] \sim \text{Normal}(0,\tau)$. These study effects are absorbed at the observation level only; plot and query predictions use the population-level trajectory with study effects set to zero. Separate Beta-Binomial likelihoods with age-varying dispersion account for extra-binomial variability in both outcomes.
+
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** typically developing children.
+- **Age range:** 8-18 months only.
+- **Outcomes:** words understood and words spoken, each out of the common 800-word reference inventory.
+- **Mean structure:** $p_U(a)$ for understood and $q(a)=P(\text{speak}\mid\text{understood})$ for the production ratio; $p_S(a)=p_U(a)q(a)$.
+- **Hierarchy:** dataset-level study random intercepts on both $p_U$ and $q$.
+- **Stabilisation:** per-draw GP anchors at 13 months.
+
+:::
 
 ::: {.callout-note}
 
@@ -40,6 +55,68 @@ For full details and discussion, please refer to the technical report.
 :::
 
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
+
+## Priors
+
+The understood trajectory uses young-TD anchors at 10 and 16 months. The low-age anchor is concentrated near the floor, while the 16-month anchor remains deliberately broad because this model covers the steep early part of comprehension growth. The production-ratio priors are the broad baseline `q` priors used in the other bivariate models; they regularise the fraction of understood words that are spoken without forcing a single developmental shape.
+
+### Understood trajectory
+
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.png){#fig-ell-u .lightbox fig-align="left"}
+
+![Amplitude prior `eta_u_dist`](eta_u_dist.png){#fig-eta-u .lightbox fig-align="left"}
+
+![Low slope anchor (10 months) `p_slope_low_u_dist`](p_slope_low_u_dist.png){#fig-slope-low-u .lightbox fig-align="left"}
+
+![High slope anchor (16 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.png){#fig-slope-hi-u .lightbox fig-align="left"}
+
+### Production ratio
+
+The `q(a)` anchors are probabilities conditional on understanding, not direct word counts. A value of 0.25 means a child is expected to speak about one quarter of the words they understand at that age.
+
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
+
+![Amplitude prior `eta_q_dist`](eta_q_dist.png){#fig-eta-q .lightbox fig-align="left"}
+
+![Low slope anchor (10 months) `p_slope_low_q_dist`](p_slope_low_q_dist.png){#fig-slope-low-q .lightbox fig-align="left"}
+
+![High slope anchor (16 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.png){#fig-slope-hi-q .lightbox fig-align="left"}
+
+### Study random effects
+
+Study random-intercept scales use the shared HalfNormal(0.5) prior on the logit scale for both understood and production-ratio trajectories. This is regularising but still allows meaningful between-dataset differences. The study effects are included in the likelihood and omitted from the reported population-level curves.
+
+### Dispersion / overdispersion -- understood
+
+![`kappa_min_u_dist`](kappa_min_u_dist.png){#fig-kappa-min-u .lightbox fig-align="left"}
+
+![`a_kappa_u_dist`](a_kappa_u_dist.png){#fig-a-kappa-u .lightbox fig-align="left"}
+
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.png){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+
+### Dispersion / overdispersion -- spoken
+
+![`kappa_min_s_dist`](kappa_min_s_dist.png){#fig-kappa-min-s .lightbox fig-align="left"}
+
+![`a_kappa_s_dist`](a_kappa_s_dist.png){#fig-a-kappa-s .lightbox fig-align="left"}
+
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+
+## Prior predictive checks
+
+These checks should be read against the model's deliberately narrow 8-18 month target. The prior should allow rapid early comprehension growth, low-to-moderate spoken counts, smooth trajectories, and plausible `q(a)` values without using the later TD data that motivated the age restriction.
+
+### Prior samples -- words understood
+
+![Prior sample trajectories (understood)](prior_samples_u.png){#fig-prior-samples-u .lightbox fig-align="left"}
+
+### Prior samples -- words spoken
+
+![Prior sample trajectories (spoken)](prior_samples_s.png){#fig-prior-samples-s .lightbox fig-align="left"}
+
+### Prior samples -- production rate q(a)
+
+![Prior sample trajectories for production ratio q(a)](prior_samples_q.png){#fig-prior-samples-q .lightbox fig-align="left"}
 
 ## Data
 
@@ -86,23 +163,117 @@ _style_diagnostics(diagnostics)
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
-## Posterior predictions
+::: {.callout-note title="Diagnostic focus"}
 
-### Understood trajectory
+For this model the main geometry checks are the study-effect scales, the anchored GP hyperparameters, and the `q` trajectory. Treat any weak ESS or elevated R-hat on those parameters as directly relevant to the young-TD comprehension-production interpretation.
+
+:::
+
+## Joint trajectory
+
+![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
+
+![Joint posterior predictive trajectory with 50% and 75% HDI bands](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+
+::: {.callout-warning title="Age restriction"}
+
+VG13 is an 8-18 month model. It should not be used as a general TD trajectory beyond this window; the restriction avoids a region where only one bivariate dataset contributes.
+
+:::
+
+## Production ratio
+
+The first figure shows the latent $q(a)=P(\text{speak}\mid\text{understood})$ curve. The posterior predictive spoken/understood count ratio shown later is different: it includes outcome uncertainty and should not be read as the latent `q` parameter itself.
+
+![Production rate q(a)](production_rate.png){#fig-production-rate .lightbox fig-align="left"}
+
+![Production ratio by words understood](production_rate_by_understood.png){#fig-production-rate-by-understood .lightbox fig-align="left"}
+
+![Posterior predictive spoken/understood count ratio](production_rate_predictive.png){#fig-production-rate-predictive .lightbox fig-align="left"}
 
 ```{python}
-posterior_summary_u = pd.read_csv("posterior_summary_u.csv", index_col=0)
+summary_q = pd.read_csv("posterior_summary_q.csv")
+summary_q
+```
+
+## Comprehension-production gap
+
+The expected difference in word counts between understanding and production.
+
+![Comprehension-production gap](comprehension_production_gap.png){#fig-comprehension-production-gap .lightbox fig-align="left"}
+
+## Words understood vs words spoken
+
+![Expected words understood vs spoken](understood_vs_spoken.png){#fig-understood-vs-spoken .lightbox fig-align="left"}
+
+![Posterior predictive words understood vs spoken](understood_vs_spoken_predictive.png){#fig-understood-vs-spoken-predictive .lightbox fig-align="left"}
+
+## Posterior predictions -- words understood
+
+### Posterior summary table
+
+```{python}
+posterior_summary_u = pd.read_csv("posterior_summary_u.csv")
 posterior_summary_u
 ```
 
-### Joint trajectory
+### Posterior predictive PMF
 
-![joint_trajectory](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
+![posterior_predictive_pmf_u](posterior_predictive_pmf_u.png){#fig-pmf-u .lightbox fig-align="left"}
 
-### Production ratio $q$
+### Posterior predictive CDF
 
-![production_ratio](production_rate.png){#fig-production-ratio .lightbox fig-align="left"}
+![posterior_predictive_cdf_u](posterior_predictive_cdf_u.png){#fig-cdf-u .lightbox fig-align="left"}
 
-### Comprehension–production gap
+### Count distributions by age
 
-![comprehension_production_gap](comprehension_production_gap.png){#fig-gap .lightbox fig-align="left"}
+![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
+
+### Median trend
+
+![posterior_predictive_median_trend_u](posterior_predictive_median_trend_u.png){#fig-trend-u .lightbox fig-align="left"}
+
+![posterior_predictive_median_trend_u_smoothed](posterior_predictive_median_trend_u_smoothed.png){#fig-trend-u-smooth .lightbox fig-align="left"}
+
+### Learning rate
+
+![expected_learning_rate_u](expected_learning_rate_u.png){#fig-learning-rate-u .lightbox fig-align="left"}
+
+### Dispersion $\kappa$ -- understood
+
+![posterior_kappa_u](posterior_kappa_u.png){#fig-kappa-u .lightbox fig-align="left"}
+
+## Posterior predictions -- words spoken
+
+### Posterior summary table
+
+```{python}
+posterior_summary_s = pd.read_csv("posterior_summary_s.csv")
+posterior_summary_s
+```
+
+### Posterior predictive PMF
+
+![posterior_predictive_pmf_s](posterior_predictive_pmf_s.png){#fig-pmf-s .lightbox fig-align="left"}
+
+### Posterior predictive CDF
+
+![posterior_predictive_cdf_s](posterior_predictive_cdf_s.png){#fig-cdf-s .lightbox fig-align="left"}
+
+### Count distributions by age
+
+![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
+
+### Median trend
+
+![posterior_predictive_median_trend_s](posterior_predictive_median_trend_s.png){#fig-trend-s .lightbox fig-align="left"}
+
+![posterior_predictive_median_trend_s_smoothed](posterior_predictive_median_trend_s_smoothed.png){#fig-trend-s-smooth .lightbox fig-align="left"}
+
+### Learning rate
+
+![expected_learning_rate_s](expected_learning_rate_s.png){#fig-learning-rate-s .lightbox fig-align="left"}
+
+### Dispersion $\kappa$ -- spoken
+
+![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}

--- a/docs/models/vg14/index.qmd
+++ b/docs/models/vg14/index.qmd
@@ -15,6 +15,10 @@ format:
       - repo
 ---
 
+::: {.callout-note}
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+:::
+
 ::: {.callout-warning title="Warning: Preliminary model output"}
 
 This model output is preliminary and likely to change as the model evolves and further data are received.
@@ -23,6 +27,16 @@ If the model was not fitted in "reporting" mode, the results will be more approx
 :::
 
 This model adds **signing** as a third production modality alongside speaking. It jointly examines how age influences words understood, words spoken and words signed ($A \rightarrow U$, $A \rightarrow S$, $A \rightarrow \text{Sign}$; $U \rightarrow S$, $U \rightarrow \text{Sign}$), using a production-ratio reparameterization that enforces $p_S \leq p_U$ and $p_\text{Sign} \leq p_U$ by construction.
+
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** children with Down syndrome.
+- **Outcomes:** words understood, spoken, and signed.
+- **Decomposition:** spoken and signed vocabularies are each modelled as fractions of understood vocabulary.
+- **Signing structure:** signed ratio has an intercept-only mean plus GP, not a monotone age slope.
+- **Total expressive vocabulary:** `p_any` is an independence-based upper bound, not a data-identified union.
+
+:::
 
 ```{python}
 import matplotlib.pyplot as plt
@@ -39,7 +53,7 @@ $$
 p_S(a) = p_U(a) \cdot q(a), \qquad p_\text{Sign}(a) = p_U(a) \cdot r(a),
 $$
 
-where $q(a) = \text{sigmoid}(h(a))$ is the **production ratio** (the fraction of understood words that are spoken at age $a$) and $r(a) = \text{sigmoid}(g_\text{sign}(a))$ is the **signed ratio** (the fraction of understood words that are signed). Since $q(a), r(a) \in (0, 1)$, this enforces $p_S \leq p_U$ and $p_\text{Sign} \leq p_U$ by construction. Each of $f_U(a)$, $h(a)$ and $g_\text{sign}(a)$ has its own linear trend and Gaussian process components, with HSGP approximations for scalability. Separate Beta-Binomial likelihoods with age-varying dispersion are used for each outcome. Observations where only some outcomes are available are retained using separate observation indices.
+where $q(a) = \text{sigmoid}(h(a))$ is the **production ratio** (the fraction of understood words that are spoken at age $a$) and $r(a) = \text{sigmoid}(g_\text{sign}(a))$ is the **signed ratio** (the fraction of understood words that are signed). Since $q(a), r(a) \in (0, 1)$, this enforces $p_S \leq p_U$ and $p_\text{Sign} \leq p_U$ by construction. The understood trajectory $f_U(a)$ and spoken-ratio trajectory $h(a)$ each have a linear trend plus a Gaussian process. The signed-ratio trajectory instead has an intercept-only mean plus a Gaussian process; this avoids imposing a monotone signing slope and lets the GP carry the observed rise-and-fall pattern. Separate Beta-Binomial likelihoods with age-varying dispersion are used for each outcome. Observations where only some outcomes are available are retained using separate observation indices.
 
 ### Total expressive vocabulary
 
@@ -51,7 +65,7 @@ $$
 
 ::: {.callout-important title="p_any is an independence-based upper bound"}
 
-This formula assumes signing and speaking are **conditionally independent given age** (the Option 1 limitation of issue #49). The signed and spoken blocks share the understood trajectory $p_U(a)$ but are otherwise modelled independently. In reality a word is often signed *before* it is spoken, so the two are **positively associated**: in the only source with the four-cell breakdown (`uk_02`), words produced in both modalities are observed more often than independence predicts (0.18 vs $r \cdot q$ 0.14 over 20–56 months). Because positive association reduces the union, $p_\text{any}$ as computed here **over-states** the true total expressive vocabulary — it is an **upper bound** (≈ 4 percentage points high against the `uk_02` observed union; see the validation below). VG14 therefore gives a first, lightweight read on the sign→speech hand-off; the planned VG15 model relaxes the independence assumption using the `uk_02` four-cell (sign-only / sign+speech / speech-only / neither) breakdown to identify the within-understood signed–spoken association directly.
+This formula assumes signing and speaking are **conditionally independent given age** (the Option 1 limitation of issue #49). The signed and spoken blocks share the understood trajectory $p_U(a)$ but are otherwise modelled independently. In reality a word is often signed _before_ it is spoken, so the two are **positively associated**: in the only source with the four-cell breakdown (`uk_02`), words produced in both modalities are observed more often than independence predicts (0.18 vs $r \cdot q$ 0.14 over 20-56 months). Because positive association reduces the union, $p_\text{any}$ as computed here **over-states** the true total expressive vocabulary. It is an **upper bound** (about 4 percentage points high against the `uk_02` observed union; see the validation below). VG14 therefore gives a first, lightweight read on the sign-to-speech hand-off; VG15 relaxes the independence assumption using the `uk_02` four-cell (sign-only / sign+speech / speech-only / neither) breakdown to identify the within-understood signed-spoken association directly.
 
 :::
 
@@ -64,6 +78,8 @@ For full details and discussion, please refer to the technical report.
 ![Model diagram](gp_model_graph.svg){#fig-model .lightbox fig-align="left"}
 
 ## Priors
+
+The understood and spoken-ratio priors follow the baseline DS bivariate structure. The signed-ratio prior is different by design: it uses an intercept-only signed mean, a shorter signed GP length-scale, and a larger signed GP amplitude so the prior can express a signing hump without forcing a monotone developmental trend. The signed prior should therefore be judged mainly through prior predictive trajectories for `r(a)` and signed counts, not by the intercept plot alone.
 
 ### Understood trajectory
 
@@ -121,6 +137,8 @@ The empirical signed fraction of understood words is a **hump** — near zero be
 
 ## Prior predictive checks
 
+For VG14 the key prior predictive question is whether signing can rise and fall over the observed age range without implying substantial signing before the signing data begin. The prior should also leave the understood and spoken trajectories broad enough that the signed pathway does not indirectly force total expressive vocabulary.
+
 ### Prior samples -- words understood
 
 ![Prior sample trajectories (understood)](prior_samples_u.png){#fig-prior-samples-u .lightbox fig-align="left"}
@@ -140,6 +158,12 @@ The empirical signed fraction of understood words is a **hump** — near zero be
 ### Prior samples -- signed rate r(a)
 
 ![Prior sample trajectories for signed ratio r(a)](prior_samples_r.png){#fig-prior-samples-r .lightbox fig-align="left"}
+
+::: {.callout-note title="Prior predictive focus"}
+
+Inspect the signed-count and signed-ratio panels together. A plausible prior should allow near-floor signing at the youngest ages, a preschool rise, and a later decline, while still allowing uncertainty where signing observations are sparse.
+
+:::
 
 ## Data
 
@@ -186,6 +210,12 @@ _style_diagnostics(diagnostics)
 
 ![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
 
+::: {.callout-note title="Diagnostic focus"}
+
+The sparse signing pathway is the main diagnostic pressure point. Pay particular attention to the signed GP length-scale and amplitude, `kappa_sign`, and any pair-plot evidence that the signed level, signed GP, and dispersion are trading off.
+
+:::
+
 ## Joint trajectory
 
 ![Joint posterior predictive trajectory for words understood, spoken and signed](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
@@ -225,7 +255,7 @@ summary_q
 
 ## Signed ratio
 
-The signed ratio $r(a) = p_\text{Sign}(a) / p_U(a)$ is the fraction of understood words that are signed at each age. The robust, headline finding is that signing **rises from near zero in infancy to a substantial fraction — about 0.4–0.5 of understood words — by age 2–3**: children sign words they understand but cannot yet say. Signing is a *bridge*, not a 12-month-dominant modality (the baseline fit's monotone decline from 0.58 was an artefact).
+The signed ratio $r(a) = p_\text{Sign}(a) / p_U(a)$ is the fraction of understood words that are signed at each age. The robust, headline finding is that signing **rises from near zero in infancy to a substantial fraction — about 0.4–0.5 of understood words — by age 2–3**: children sign words they understand but cannot yet say. Signing is a _bridge_, not a 12-month-dominant modality (the baseline fit's monotone decline from 0.58 was an artefact).
 
 ::: {.callout-warning title="The peak age and the decline are study-confounded — not a precise developmental fact"}
 

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -26,7 +26,17 @@ This model output is preliminary and likely to change as the model evolves and f
 If the model was not fitted in "reporting" mode, the results will be more approximate than when additional sampling has been performed.
 :::
 
-This model (issue #49, Option 3) estimates the **within-understood association** between signing and speaking — the overlap that VG14 assumed away — and adds **study random intercepts**, replacing VG14's independence-based `p_any` upper bound with a _data-identified_ total expressive vocabulary.
+This model (issue #49, Option 3) estimates the **within-understood association** between signing and speaking, the overlap that VG14 assumed away. It adds study random intercepts, subject random intercepts on all three latent trajectories, and VG10-style GP anchoring, replacing VG14's independence-based `p_any` upper bound with a _data-identified_ total expressive vocabulary.
+
+::: {.callout-note title="Model at a glance"}
+
+- **Population:** children with Down syndrome.
+- **Outcomes:** words understood, spoken, signed, and four-cell sign/speech composition.
+- **Association:** scalar Plackett odds ratio `psi`, identified mainly from `uk_02`.
+- **Hierarchy:** study and subject random intercepts on understood, `q`, and signing.
+- **Stabilisation:** VG10-style tightened `q` anchors and GP anchors at 54 months.
+
+:::
 
 ```{python}
 import matplotlib.pyplot as plt
@@ -77,23 +87,102 @@ The association $\psi$ is identified by the ~60 uk_02 rows with the four-cell cr
 
 ## Priors
 
-### Trajectories (understood / spoken-ratio / signed-ratio)
+VG15 inherits the DS understood priors from the bivariate lineage, the signed-ratio prior from VG14, and the VG10 posterior-informed `q` anchors. The `q` anchors and the weakly positive `log_psi` prior are data-informed regularisation, not independent external evidence; they should be carried into sensitivity checks.
 
-![`p_slope_low_u_dist`](p_slope_low_u_dist.png){.lightbox fig-align="left" width=380}
-![`eta_u_dist`](eta_u_dist.png){.lightbox fig-align="left" width=380}
-![`intercept_sign_dist` (signed mean is intercept-only)](intercept_sign_dist.png){.lightbox fig-align="left" width=380}
-![`eta_sign_dist`](eta_sign_dist.png){.lightbox fig-align="left" width=380}
+### Understood trajectory
+
+![Lengthscale prior `ell_unit_u_dist`](ell_unit_u_dist.png){#fig-ell-u .lightbox fig-align="left"}
+
+![Amplitude prior `eta_u_dist`](eta_u_dist.png){#fig-eta-u .lightbox fig-align="left"}
+
+![Low slope anchor (24 months) `p_slope_low_u_dist`](p_slope_low_u_dist.png){#fig-slope-low-u .lightbox fig-align="left"}
+
+![High slope anchor (84 months) `p_slope_hi_u_dist`](p_slope_hi_u_dist.png){#fig-slope-hi-u .lightbox fig-align="left"}
+
+### Production ratio
+
+The `q(a)` anchors are tightened relative to VG05-VG09 and VG14: the low-age anchor uses `Beta(3, 22)` and the high-age anchor uses `Beta(20, 4)`. These priors stabilise the same hierarchy and GP anchoring strategy used in VG10.
+
+![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
+
+![Amplitude prior `eta_q_dist`](eta_q_dist.png){#fig-eta-q .lightbox fig-align="left"}
+
+![Low slope anchor (24 months) `p_slope_low_q_dist`](p_slope_low_q_dist.png){#fig-slope-low-q .lightbox fig-align="left"}
+
+![High slope anchor (84 months) `p_slope_hi_q_dist`](p_slope_hi_q_dist.png){#fig-slope-hi-q .lightbox fig-align="left"}
+
+### Signed ratio
+
+The signed mean is intercept-only. A shorter signed GP length-scale and larger signed GP amplitude let the prior express a signing rise and later decline without imposing a monotone signed slope.
+
+![Lengthscale prior `ell_unit_sign_dist`](ell_unit_sign_dist.png){#fig-ell-sign .lightbox fig-align="left"}
+
+![Amplitude prior `eta_sign_dist`](eta_sign_dist.png){#fig-eta-sign .lightbox fig-align="left"}
+
+![`intercept_sign_dist` (signed mean is intercept-only)](intercept_sign_dist.png){#fig-intercept-sign .lightbox fig-align="left"}
+
+### Random-effect scales
+
+Study and subject random-intercept scales use HalfNormal(0.5) priors on the logit scale for understood, spoken-ratio and signed-ratio trajectories. The reported age curves are population-level curves with random effects set to zero; the random effects enter the likelihood to account for study composition and repeated measurements.
+
+### Dispersion / overdispersion
+
+![`kappa_min_u_dist`](kappa_min_u_dist.png){#fig-kappa-min-u .lightbox fig-align="left"}
+
+![`a_kappa_u_dist`](a_kappa_u_dist.png){#fig-a-kappa-u .lightbox fig-align="left"}
+
+![`b_kappa_mag_u_dist`](b_kappa_mag_u_dist.png){#fig-b-kappa-mag-u .lightbox fig-align="left"}
+
+![`kappa_min_s_dist`](kappa_min_s_dist.png){#fig-kappa-min-s .lightbox fig-align="left"}
+
+![`a_kappa_s_dist`](a_kappa_s_dist.png){#fig-a-kappa-s .lightbox fig-align="left"}
+
+![`b_kappa_mag_s_dist`](b_kappa_mag_s_dist.png){#fig-b-kappa-mag-s .lightbox fig-align="left"}
+
+![`kappa_min_sign_dist`](kappa_min_sign_dist.png){#fig-kappa-min-sign .lightbox fig-align="left"}
+
+![`a_kappa_sign_dist`](a_kappa_sign_dist.png){#fig-a-kappa-sign .lightbox fig-align="left"}
+
+![`b_kappa_mag_sign_dist`](b_kappa_mag_sign_dist.png){#fig-b-kappa-mag-sign .lightbox fig-align="left"}
 
 ### Association and concentration
 
 ![Plackett log odds-ratio prior `log_psi_dist`](log_psi_dist.png){#fig-log-psi .lightbox fig-align="left" width=380}
 ![Dirichlet-Multinomial log-concentration prior `log_conc_dist`](log_conc_dist.png){#fig-log-conc .lightbox fig-align="left" width=380}
 
+::: {.callout-note title="Sensitivity targets"}
+
+Prior sensitivity should focus on the posterior-informed `q` anchors, signed GP amplitude and length-scale, signed intercept, random-effect scales, `log_psi`, and the Dirichlet-Multinomial concentration prior.
+
+:::
+
 ## Prior predictive checks
+
+These checks should show that the model can generate plausible understood, spoken, signed, and total-expressive trajectories before seeing the data. The key VG15-specific questions are whether the prior allows a signing hump, whether `p_any` is not forced close to the independence bound, and whether `q(a)` remains plausible under the tightened VG10-style anchors.
+
+### Prior samples -- words understood
+
+![Prior samples -- words understood](prior_samples_u.png){#fig-prior-u .lightbox fig-align="left"}
+
+### Prior samples -- words spoken
+
+![Prior samples -- words spoken](prior_samples_s.png){#fig-prior-s .lightbox fig-align="left"}
+
+### Prior samples -- words signed
+
+![Prior samples -- words signed](prior_samples_sign.png){#fig-prior-sign .lightbox fig-align="left"}
+
+### Prior samples -- signed ratio r(a)
 
 ![Prior r(a) = P(sign | understood)](prior_samples_r.png){#fig-prior-r .lightbox fig-align="left"}
 
+### Prior samples -- production ratio q(a)
+
 ![Prior q(a) = P(speak | understood)](prior_samples_q.png){#fig-prior-q .lightbox fig-align="left"}
+
+### Prior samples -- total expressive probability
+
+![Prior p_any(a)](prior_samples_p_any.png){#fig-prior-p-any .lightbox fig-align="left"}
 
 ## Data
 
@@ -106,12 +195,82 @@ descriptive_stats
 
 ```{python}
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-diagnostics
+
+
+def _flag_red(v, threshold, *, above):
+    bad = v > threshold if above else v < threshold
+    return "color: #b00; font-weight: bold;" if bad else ""
+
+
+def _style_diagnostics(df):
+    styler = df.style.format(precision=3)
+    if "r_hat" in df.columns:
+        styler = styler.map(
+            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
+        )
+    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
+    if ess_cols:
+        styler = styler.map(
+            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
+        )
+    styler.set_caption(
+        "Reported convergence diagnostics. Cells highlighted red flag "
+        "r̂ > 1.01 or ESS < 400."
+    )
+    return styler
+
+
+_style_diagnostics(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}
 
 ![trace_plot](trace_plot.png){#fig-trace .lightbox fig-align="left"}
+
+![pair_plot](pair_plot.png){#fig-pair .lightbox fig-align="left"}
+
+::: {.callout-note title="Diagnostic focus"}
+
+Check `psi`, `conc`, the signed GP hyperparameters, and all study/subject random-effect scales. The signed subject scale is especially important because sparse four-cell data can otherwise trade association strength against child-level signing heterogeneity.
+
+:::
+
+## Posterior vocabulary summaries
+
+These tables report population-level query-age summaries with study and subject random effects set to zero. They are interpretable as the expected trajectory for the reference population, not as the full predictive distribution for a new child.
+
+### Words understood
+
+```{python}
+summary_u = pd.read_csv("posterior_summary_u.csv")
+summary_u
+```
+
+### Words spoken
+
+```{python}
+summary_s = pd.read_csv("posterior_summary_s.csv")
+summary_s
+```
+
+### Words signed
+
+```{python}
+summary_sign = pd.read_csv("posterior_summary_sign.csv")
+summary_sign
+```
+
+### Production and signed ratios
+
+```{python}
+summary_q = pd.read_csv("posterior_summary_q.csv")
+summary_r = pd.read_csv("posterior_summary_r.csv")
+summary_q
+```
+
+```{python}
+summary_r
+```
 
 ## Association psi
 
@@ -128,6 +287,12 @@ summary_psi
 
 The four mutually-exclusive states of an understood word (sign-only, sign+speech, speak-only, neither) as fractions of understood vocabulary over age — words migrating from sign into speech.
 
+::: {.callout-warning title="Four-cell extrapolation"}
+
+The scalar association parameter is identified mainly by `uk_02` four-cell rows from about 19-56 months. Composition curves outside that support combine marginal trajectories with the scalar-$\psi$ assumption and should be treated as exploratory.
+
+:::
+
 ![Four-cell composition trajectory](four_cell_composition.png){#fig-composition .lightbox fig-align="left"}
 
 ## Total expressive vocabulary (data-identified)
@@ -141,14 +306,13 @@ summary_p_any = pd.read_csv("posterior_summary_p_any.csv")
 summary_p_any
 ```
 
-## Signed vs spoken ratio (study REs marginalised)
+## Signed vs spoken ratio
 
-The population sign and speak ratios with study composition absorbed by the random intercepts. Compare the signed peak/recede with VG14, where it was study-confounded.
+The population sign and speak ratios with study and subject effects set to zero. Compare the signed peak/recede with VG14, where the signed curve was more strongly confounded with study composition.
 
 ![Signed vs spoken ratio](signed_vs_spoken_rate.png){#fig-rates .lightbox fig-align="left"}
 
 ```{python}
-summary_r = pd.read_csv("posterior_summary_r.csv")
 summary_r
 ```
 

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -954,6 +954,21 @@ def sample(context: JointContext):
 
 def diagnostics(context: JointContext):
     var_names = [v.name for v in context.model.unobserved_RVs if v.size.eval() <= 2]
+    posterior_vars = set(context.trace.posterior.data_vars)
+
+    def prioritized_unique_var_names(
+        names: list[str],
+        priority: tuple[str, ...] = ("psi", "conc"),
+    ) -> list[str]:
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for name in (*priority, *names):
+            if name in posterior_vars and name not in seen:
+                ordered.append(name)
+                seen.add(name)
+        return ordered
+
+    plot_var_names = prioritized_unique_var_names(var_names)
     diag = az.summary(context.trace, var_names=var_names, round_to=4,
                       ci_prob=context.reporting.hdi, ci_kind="hdi")
     diag.to_csv(os.path.join(context.reporting.output_dir, "diagnostics.csv"), index=True)
@@ -961,7 +976,7 @@ def diagnostics(context: JointContext):
     _report_diagnostic_warnings(diag)
     pair_plot_var_names = capped_plot_var_names(
         context.trace,
-        var_names + ["psi", "conc"],
+        plot_var_names,
         squared=True,
     )
     if pair_plot_var_names:
@@ -972,7 +987,7 @@ def diagnostics(context: JointContext):
             filename="pair_plot",
         )
         plt.close()
-    tv = capped_plot_var_names(context.trace, var_names + ["psi", "conc"])
+    tv = capped_plot_var_names(context.trace, plot_var_names)
     az.plot_trace(context.trace, var_names=tv, figure_kwargs={"figsize": plot_styles.FIGSIZE_XL})
     plt.savefig(os.path.join(context.reporting.output_dir, "trace_plot.png"), dpi=300)
     plt.close()

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -50,6 +50,7 @@ import arviz as az
 import dse_research_utils.environment.info as env_info
 import dse_research_utils.math.constants as math_constants
 import dse_research_utils.metadata.packages as package_metadata
+import dse_research_utils.plot.diagnostics_mcmc as plot_diagnostics_mcmc
 import dse_research_utils.plot.styles as plot_styles
 import dse_research_utils.statistics.descriptive as descriptive_stats
 import dse_research_utils.statistics.models.data as model_data
@@ -85,7 +86,11 @@ from vocab_growth.models.common import (
 from vocab_growth.models.definitions import JointModelDefinition
 from vocab_growth.models.diagnostics_utils import capped_plot_var_names
 from vocab_growth.models.gp_utils import make_kappa_of_z
-from vocab_growth.plotting import _save_csv, plot_prior_samples_ratio
+from vocab_growth.plotting import (
+    _save_csv,
+    plot_prior_samples,
+    plot_prior_samples_ratio,
+)
 from vocab_growth.posterior_analysis import extract_posterior as _extract
 from vocab_growth.reporting import (
     config_table,
@@ -871,19 +876,59 @@ def build_model(context: JointContext, definition: JointModelDefinition):
 
 
 def prior_predictive_checks(context: JointContext):
-    """Light prior predictive check: r(a), q(a), psi spans independence."""
+    """Prior predictive checks for the joint sign/speech model."""
     with context.model:
         prior = pm.sample_prior_predictive(
             draws=500, random_seed=context.sampling.random_seed,
             compile_kwargs=dict(mode="FAST_COMPILE"),
         )
     context.set_prior_samples(prior)
-    for var, ylab, fname in [("r_plot", "r(a) = P(sign | understood)", "prior_samples_r"),
-                             ("q_plot", "q(a) = P(speak | understood)", "prior_samples_q")]:
-        s = prior.prior[var].stack(sample=("chain", "draw")).transpose("plot_id", "sample")
+
+    def prior_matrix(var: str) -> np.ndarray:
+        return (
+            prior.prior[var]
+            .stack(sample=("chain", "draw"))
+            .transpose("plot_id", "sample")
+            .values
+        )
+
+    x_plot = prior.constant_data["X_plot"].values
+    analysis_df = context.analysis_df
+
+    p_u = prior_matrix("p_u_plot")
+    q = prior_matrix("q_plot")
+    r = prior_matrix("r_plot")
+    p_s = p_u * q
+    p_sign = p_u * r
+
+    for y_col, samples, y_label, fname in [
+        ("understood", p_u, "Words understood", "prior_samples_u"),
+        ("spoken", p_s, "Words spoken", "prior_samples_s"),
+        ("signed", p_sign, "Words signed", "prior_samples_sign"),
+    ]:
+        observed = analysis_df[analysis_df[y_col].notna()]
+        fig = plot_prior_samples(
+            x_plot,
+            samples,
+            observed["age"],
+            observed[y_col],
+            n_trials=context.model_data.n_trials,
+            x_label="Age (months)",
+            y_label=y_label,
+            filename=fname,
+            output_dir=context.reporting.output_dir,
+        )
+        plt.close(fig)
+
+    for var, ylab, fname in [
+        ("r_plot", "r(a) = P(sign | understood)", "prior_samples_r"),
+        ("q_plot", "q(a) = P(speak | understood)", "prior_samples_q"),
+        ("p_any_plot", "p_any(a) total expressive probability", "prior_samples_p_any"),
+    ]:
+        s = prior_matrix(var)
         fig = plot_prior_samples_ratio(
-            prior.constant_data["X_plot"].values,
-            s.values,
+            x_plot,
+            s,
             y_label=ylab,
             filename=fname,
             output_dir=context.reporting.output_dir,
@@ -914,6 +959,19 @@ def diagnostics(context: JointContext):
     diag.to_csv(os.path.join(context.reporting.output_dir, "diagnostics.csv"), index=True)
     dataframe_table(diag, title="Posterior diagnostics")
     _report_diagnostic_warnings(diag)
+    pair_plot_var_names = capped_plot_var_names(
+        context.trace,
+        var_names + ["psi", "conc"],
+        squared=True,
+    )
+    if pair_plot_var_names:
+        plot_diagnostics_mcmc.plot_kde_pair(
+            context.trace,
+            var_names=pair_plot_var_names,
+            output_dir=context.reporting.output_dir,
+            filename="pair_plot",
+        )
+        plt.close()
     tv = capped_plot_var_names(context.trace, var_names + ["psi", "conc"])
     az.plot_trace(context.trace, var_names=tv, figure_kwargs={"figsize": plot_styles.FIGSIZE_XL})
     plt.savefig(os.path.join(context.reporting.output_dir, "trace_plot.png"), dpi=300)
@@ -987,6 +1045,23 @@ def posterior_summary(context: JointContext):
     hdi = context.reporting.hdi
     od = context.reporting.output_dir
 
+    def probability_summary(X, draws, prefix, label):
+        h = az.hdi(draws, prob=hdi)
+        Ey = draws * n_trials
+        Ey_h = az.hdi(Ey, prob=hdi)
+        d = pd.DataFrame({
+            "age_months": X,
+            f"p_{prefix}_median": np.median(draws, axis=1),
+            f"p_{prefix}_hdi_lo": h[:, 0],
+            f"p_{prefix}_hdi_hi": h[:, 1],
+            f"Ey_{prefix}_median": np.median(Ey, axis=1),
+            f"Ey_{prefix}_hdi_lo": Ey_h[:, 0],
+            f"Ey_{prefix}_hdi_hi": Ey_h[:, 1],
+        })
+        d.to_csv(os.path.join(od, f"posterior_summary_{prefix}.csv"), index=False)
+        dataframe_table(d.round(3), title=label, show_index=False)
+        return d
+
     def ratio_summary(X, draws, prefix):
         med = np.median(draws, axis=1)
         h = az.hdi(draws, prob=hdi)
@@ -995,6 +1070,9 @@ def posterior_summary(context: JointContext):
         d.to_csv(os.path.join(od, f"posterior_summary_{prefix}.csv"), index=False)
         return d
 
+    probability_summary(s.X_query, s.p_u_query, "u", "Words understood")
+    probability_summary(s.X_query, s.p_u_query * s.q_query, "s", "Words spoken")
+    probability_summary(s.X_query, s.p_u_query * s.r_query, "sign", "Words signed")
     ratio_summary(s.X_query, s.r_query, "r")
     ratio_summary(s.X_query, s.q_query, "q")
 
@@ -1098,7 +1176,7 @@ def _run_joint_plots(context: JointContext):
     context.plots["psi_posterior"] = fig
     plt.close(fig)
 
-    # 4) signed rate r(a) (study REs absorb composition)
+    # 4) signed rate r(a) and spoken rate q(a), population level
     fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_XL)
     r_med = np.median(s.r_plot, axis=1)
     r_hdi = az.hdi(s.r_plot, prob=hdi)
@@ -1110,7 +1188,7 @@ def _run_joint_plots(context: JointContext):
     ax.set_ylabel("Fraction of understood words")
     ax.set_ylim(0, 1)
     ax.legend(loc="upper left", frameon=True)
-    ax.set_title("Signed vs spoken ratio (population, study REs marginalised)")
+    ax.set_title("Signed vs spoken ratio (population-level)")
     fig.savefig(os.path.join(od, "signed_vs_spoken_rate.png"), dpi=300)
     fig.savefig(os.path.join(od, "signed_vs_spoken_rate.svg"))
     context.plots["signed_vs_spoken_rate"] = fig


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).

## Summary

- Add a model output template review note and at-a-glance/diagnostic guidance across VG01-VG15.
- Expand VG13 and VG15 report templates to cover priors, prior predictive checks, diagnostics, and posterior summaries more thoroughly.
- Update the VG15 joint modality engine to emit richer prior predictive artefacts, posterior query summaries, and a pair plot used by the report.

## Validation

- `prettier --parser markdown --check` on all VG model templates
- `cspell --show-suggestions --show-context` on all VG model templates plus `OUTPUT_TEMPLATE_REVIEW.md`
- `ruff check src/vocab_growth/models/common_joint_modality.py`
- Python AST parse for `src/vocab_growth/models/common_joint_modality.py`

Note: `python -m py_compile` was not used as final validation because Windows denied writing to `__pycache__`; the no-bytecode AST parse passed instead.