### PR TITLE
Unify environment: hybrid conda/pip env on dse-research-utils 0.5.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,13 +8,20 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. During local development it is installed as an editable package from `../research/src/python`.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.5.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `environment.yml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 
-- **Python environment**: Conda (environment name `dse-vocab-growth`), Python 3.14, channels: `conda-forge`. Install/update with `conda env update -f environment.yml`.
+Hybrid two-layer environment (shared across DSE research repos):
+
+- **Compiled core** — the scientific stack (`numpy`/`scipy`/`pandas`/`pymc`/`nutpie`/`jax`/`arviz`, …) comes from **conda-forge** and must match the canonical spec shipped in `dse-research-utils` (`data/environment-core.yml`) so it cannot drift across repos. Verify with `dse-check-env environment.yml`.
+- **Pip layer** — the pure-Python tail and the shared library. `dse-research-utils` installs from the public git tag `v0.5.0` (`dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.5.0#subdirectory=src/python`); the package itself installs editable (`-e ./`).
+
+- **Python environment**: Conda/mamba (environment name `dse-vocab-growth`), Python 3.14, channel `conda-forge`. Create with `mamba env create -f environment.yml`; update with `conda env update -f environment.yml`.
+- **Windows**: there is no conda-forge `jax`/`jaxlib` win-64 build, so the stack cannot solve natively — use **WSL** (Ubuntu, linux-64).
+- **Local dev against research**: comment the `dse-research-utils[...] @ git+…` line in `environment.yml`'s pip block and uncomment the `-e ../research/src/python[...]` override.
+- **GPU**: opt-in overlay (`jax[cuda]`); the base env is CPU-only and cross-platform.
 - **Node dependencies** (spellcheck, formatting): `npm install`.
-- The package itself is installed in editable mode (`-e ./`) via the Conda environment.
 
 ## Commands
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,14 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7.0.0
-
 
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
@@ -32,7 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
-
       - name: Setup Python
         uses: actions/setup-python@v6.3.0
         with:
@@ -45,46 +46,29 @@ jobs:
         run: ruff check src/ scripts/
 
   model-fit-tests:
-    runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Native Windows is intentionally omitted: jax/jaxlib have no conda-forge
+        # win-64 build, so the compiled stack cannot solve there. Windows users
+        # work in Ubuntu on WSL (linux-64), which the ubuntu runner covers.
+        os: [ubuntu-26.04, macos-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -el {0}
-        working-directory: vocabulary-growth
     steps:
-      - name: Checkout vocabulary-growth
-        uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.0
 
+      - name: Setup conda environment
+        uses: mamba-org/setup-micromamba@v3.0.0
         with:
-          path: vocabulary-growth
+          environment-file: environment.yml
+          cache-environment: true
+          cache-downloads: true
 
-      - name: Checkout research (sibling dependency)
-        uses: actions/checkout@v7.0.0
-
-        with:
-          repository: dseinternational/research
-          path: research
-
-      - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v4
-        with:
-          activate-environment: dse-vocab-growth
-          miniforge-version: latest
-
-      - name: Cache conda env
-        id: conda-cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ env.CONDA }}/envs/dse-vocab-growth
-          key: conda-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('vocabulary-growth/environment.yml') }}
-
-      - name: Create env (cache miss)
-        if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda env update -n dse-vocab-growth -f environment.yml
-
-      - name: Install editable packages
-        run: |
-          pip install -e ../research/src/python
-          pip install -e .
+      - name: Verify environment core matches the canonical spec
+        run: dse-check-env environment.yml
 
       - name: Run pytest
         run: pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,20 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. During local development it is installed as an editable package from `../research/src/python`.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.5.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `environment.yml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 
-- **Python environment**: Conda (environment name `dse-vocab-growth`), Python 3.14, channels: `conda-forge`. Install/update with `conda env update -f environment.yml`.
+Hybrid two-layer environment (shared across DSE research repos):
+
+- **Compiled core** — the scientific stack (`numpy`/`scipy`/`pandas`/`pymc`/`nutpie`/`jax`/`arviz`, …) comes from **conda-forge** and must match the canonical spec shipped in `dse-research-utils` (`data/environment-core.yml`) so it cannot drift across repos. Verify with `dse-check-env environment.yml`.
+- **Pip layer** — the pure-Python tail and the shared library. `dse-research-utils` installs from the public git tag `v0.5.0` (`dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.5.0#subdirectory=src/python`); the package itself installs editable (`-e ./`).
+
+- **Python environment**: Conda/mamba (environment name `dse-vocab-growth`), Python 3.14, channel `conda-forge`. Create with `mamba env create -f environment.yml`; update with `conda env update -f environment.yml`.
+- **Windows**: there is no conda-forge `jax`/`jaxlib` win-64 build, so the stack cannot solve natively — use **WSL** (Ubuntu, linux-64).
+- **Local dev against research**: comment the `dse-research-utils[...] @ git+…` line in `environment.yml`'s pip block and uncomment the `-e ../research/src/python[...]` override.
+- **GPU**: opt-in overlay (`jax[cuda]`); the base env is CPU-only and cross-platform.
 - **Node dependencies** (spellcheck, formatting): `npm install`.
-- The package itself is installed in editable mode (`-e ./`) via the Conda environment.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,13 +8,20 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. During local development it is installed as an editable package from `../research/src/python`.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.5.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `environment.yml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 
-- **Python environment**: Conda (environment name `dse-vocab-growth`), Python 3.14, channels: `conda-forge`. Install/update with `conda env update -f environment.yml`.
+Hybrid two-layer environment (shared across DSE research repos):
+
+- **Compiled core** — the scientific stack (`numpy`/`scipy`/`pandas`/`pymc`/`nutpie`/`jax`/`arviz`, …) comes from **conda-forge** and must match the canonical spec shipped in `dse-research-utils` (`data/environment-core.yml`) so it cannot drift across repos. Verify with `dse-check-env environment.yml`.
+- **Pip layer** — the pure-Python tail and the shared library. `dse-research-utils` installs from the public git tag `v0.5.0` (`dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.5.0#subdirectory=src/python`); the package itself installs editable (`-e ./`).
+
+- **Python environment**: Conda/mamba (environment name `dse-vocab-growth`), Python 3.14, channel `conda-forge`. Create with `mamba env create -f environment.yml`; update with `conda env update -f environment.yml`.
+- **Windows**: there is no conda-forge `jax`/`jaxlib` win-64 build, so the stack cannot solve natively — use **WSL** (Ubuntu, linux-64).
+- **Local dev against research**: comment the `dse-research-utils[...] @ git+…` line in `environment.yml`'s pip block and uncomment the `-e ../research/src/python[...]` override.
+- **GPU**: opt-in overlay (`jax[cuda]`); the base env is CPU-only and cross-platform.
 - **Node dependencies** (spellcheck, formatting): `npm install`.
-- The package itself is installed in editable mode (`-e ./`) via the Conda environment.
 
 ## Commands
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,44 +2,49 @@ name: dse-vocab-growth
 channels:
   - conda-forge
 dependencies:
+  # ── shared conda-forge compiled core (canonical) ──────────────────────────
+  # Must match dse-research-utils' data/environment-core.yml exactly. Verify:
+  #   dse-check-env environment.yml
   - python=3.14.6
-  - graphviz>=14.1.2
-  - numba>=0.65.1
-  - numpy>=2.4.6,<2.5 # numba 0.65.1 requires numpy <2.5; lift cap when numba supports 2.5
-  - nutpie>=0.16.10
-  - pymc>=6.0.1
+  - numpy>=2.4.6,<2.5 # numba 0.65.1 requires numpy <2.5; lift the cap when numba supports 2.5
   - scipy>=1.18.0
+  - pandas>=3.0.3
+  - numba>=0.65.1
+  - matplotlib>=3.11.0
+  - scikit-learn>=1.9.0
+  - statsmodels>=0.14.6
+  - pymc>=6.0.1 # pulls pytensor + a C toolchain from conda-forge
+  - nutpie>=0.16.11
+  - numpyro>=0.21.0
+  - jax>=0.10.2 # CPU build; GPU acceleration via an environment-gpu.yml overlay
+  - arviz>=1.2.0
+  - arviz-base>=1.2.0
+  - arviz-stats>=1.2.0
+  - arviz-plots>=1.2.0
+  - preliz>=0.27.0
+  - h5py>=3.12.0
+  - h5netcdf>=1.3.0
+  - graphviz>=14.1.2
+  - python-graphviz>=0.20
+  # ── vocab-growth add-ons (compiled / columnar data) ───────────────────────
+  - duckdb>=1.5.4
   - pip
   - pip:
-      - azure-identity
-      - azure-storage-blob
-      - arviz>=1.2.0
-      - arviz-base>=1.2.0
-      - arviz-stats>=1.2.0
-      - arviz-plots>=1.2.0
-      - h5netcdf
-      - h5py # h5netcdf backend; pip h5netcdf no longer pulls this transitively (was via conda-forge)
-      - duckdb>=1.5.4
-      - hatch
-      - ipython>=9.15.0
-      - ipywidgets>=8.1.8
-      - jax>=0.10.2
-      - jupytext
-      - cycler>=0.12.1
-      - matplotlib>=3.11.0
-      - notebook>=7.6.0
-      - numpyro>=0.21.0
-      - orjson>=3.11.9
-      - pandas-stubs
-      - pandas>=3.0.3
-      - preliz>=0.27.0
-      - pytest>=9.1.1
-      - rich>=15.0.0
-      - ruff>=0.15.20
-      - scikit-learn>=1.9.0
-      - scipy-stubs
-      - seaborn>=0.13.2
-      - setuptools>=81.0.0
-      - xarray>=2026.4.0
-      - -e ../research/src/python #  for now, for local development
+      # Shared library from the public git tag (no auth; PyPI is a later
+      # graduation). Its extras pull the pure-Python tail: viz (seaborn),
+      # notebook (ipython/ipywidgets/notebook/jupytext), io (orjson/tabulate).
+      # This also pulls dse-research-utils' own runtime deps (azure-identity/
+      # -storage-blob, rich, psutil, pyyaml, …) — no need to list them here.
+      - dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.5.0#subdirectory=src/python
       - -e ./
+      # Local-dev override — to develop against a sibling checkout of research,
+      # comment the git line above and uncomment this instead:
+      # - -e ../research/src/python[viz,notebook,io]
+      # typing stubs + dev / build tooling
+      - pandas-stubs
+      - scipy-stubs
+      - hatch
+      - build
+      - pytest>=9.1.1
+      - ruff>=0.15.20
+      - setuptools>=82.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
   "arviz-plots>=1.2.0",
   "arviz-stats>=1.2.0",
   "arviz>=1.2.0",
-  "duckdb>=1.5.2",
-  "dse-research-utils>=0.2.0",
+  "duckdb>=1.5.4",
+  "dse-research-utils>=0.5.0",
   "jaxlib>=0.9.2",
   "matplotlib>=3.10.9",
   "numpy>=2.4.4",
@@ -38,6 +38,12 @@ dev = [
   "pytest>=9.0.3",
   "ruff>=0.15.18"
 ]
+
+[tool.uv.sources]
+# dse-research-utils isn't published to PyPI — resolve it from the public git
+# tag. (The conda env in environment.yml installs it from the same tag in its
+# pip layer; this entry is only consumed by uv.)
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.5.0" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"


### PR DESCRIPTION
> [!NOTE]
> Drafted by a LLM-based AI tool (Claude Code/Opus 4.8).

Migrates this repo to the shared two-layer ("hybrid") environment model, gated on the `dse-research-utils` `v0.5.0` tag.

## What changed

- **`environment.yml`** — conda-forge compiled core matched to the canonical spec (`dse-check-env` passes); `duckdb` add-on; pip layer installs `dse-research-utils[viz,notebook,io]` from the public git tag `v0.5.0` plus the editable package. The `-e ../research/src/python` sibling install is removed (kept as a commented local-dev override).
- **`pyproject.toml`** — bump `dse-research-utils>=0.5.0` and `duckdb>=1.5.4`; add `[tool.uv.sources]` resolving `dse-research-utils` from the git tag.
- **CI** — 2-OS matrix (`ubuntu-26.04`, `macos-latest`) via `mamba-org/setup-micromamba`; drop the sibling `research` checkout; add a `dse-check-env` drift gate.
- **Docs trio** (`CLAUDE.md`/`AGENTS.md`/`.github/copilot-instructions.md`) — document the hybrid model, WSL-on-Windows, and the git-tag install.

## Verification

- `dse-check-env environment.yml` → "conda-forge core matches the canonical spec" (run locally against the built `dse-research` env).
- `npm run spellcheck` and `npm run format:check` pass locally.
- Full conda solve + `pytest` + model-fit run are validated by CI (the env is not built locally in this PR).

## Extras rationale

`viz` (seaborn — used in `notebooks/001-vocab-data-variables.py`), `notebook` (ipython/ipywidgets/notebook/jupytext), `io` (orjson/tabulate). `duckdb` stays a conda add-on (compiled/columnar).