### PR TITLE
Drop dependabot conda ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,19 +14,6 @@ updates:
     assignees:
       - frankbuckley
 
-  - package-ecosystem: conda
-    directory: /
-    schedule:
-      interval: daily
-      time: "05:00"
-      timezone: "Europe/London"
-    groups:
-      conda-dependencies:
-        patterns:
-          - "*"
-    assignees:
-      - frankbuckley
-
   - package-ecosystem: npm
     directory: /
     schedule:


### PR DESCRIPTION
> [!NOTE]
> Drafted by a LLM-based AI tool (Claude Code/Opus 4.8).

Removes the `conda` package-ecosystem from `.github/dependabot.yml` (mirrors dseinternational/research#56).

## Why

Dependabot's conda updater doesn't grasp the inter-package constraints in the conda-forge scientific stack (pymc↔pytensor, numba↔numpy ABI pins, jax, arviz), so it proposes individually-plausible but mutually-breaking floor bumps. It also only edits `environment.yml`, so any bump to a canonical-core package would fail the `dse-check-env` drift gate (the core is pinned in lockstep via `dse-research-utils`' `data/environment-core.yml`, which dependabot cannot see or update). Conda / `environment.yml` updates are handled deliberately instead; `pip`/`npm`/`github-actions` coverage is retained.

## Context

This change was originally part of the env-unification PR but was pushed moments after that PR squash-merged, so it landed on an orphaned branch and never reached `main`. This re-lands it.