### PR TITLE
Make fit_model.py model id case-insensitive

### DIFF
--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -56,6 +56,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # Model ids are registered in lower case (see definitions.py); normalise
+    # user input so "VG01", "vg01", "Vg01" and "ALL" all resolve correctly.
+    args.model = args.model.lower()
+
     # Model modules follow the "model_<key>" naming convention 1:1 with
     # MODEL_REGISTRY (definitions.py), so the set of fittable models is
     # derived from the registry rather than a second, hand-maintained list


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

`scripts/fit_model.py` did an exact, case-sensitive match of the `model` argument against `MODEL_REGISTRY`, whose keys are lowercase (`vg01`, `vg02`, …). Passing an uppercase id like `VG01` fell through to the "Unknown model" branch and exited, even though the CLAUDE.md model inventory refers to models as `VG01`–`VG15`.

This normalises the argument to lower case right after parsing, so `VG01`, `vg01`, `Vg01`, and `ALL`/`all` all resolve correctly. Registry keys are unchanged; only the incoming argument is normalised.

## Test

```
python ./scripts/fit_model.py VG01
```

now resolves to `vg01` and proceeds into the fitting pipeline instead of erroring with `Unknown model: VG01`.