### PR TITLE
Make model output root configurable for scratch-disk runs (#105)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,23 +65,24 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 ### Fit a model
 
 ```bash
-python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
+python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload] [--output-dir <dir>]
 ```
 
 - `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
+- `--output-dir`: root directory for model output. Overrides the `DSE_VOCAB_GROWTH_OUTPUT_DIR` environment variable; both fall back to the repository-local `output/`.
 
-Output (traces, figures, summary tables) is written to `output/models/<model_name>/`.
+Output (traces, figures, summary tables) is written to `<output-root>/models/<model_name>/`. The output root is resolved (highest precedence first) from `--output-dir`, then the `DSE_VOCAB_GROWTH_OUTPUT_DIR` environment variable, then the repository-local `output/` default — so reporting-quality VM runs can redirect the multi-gigabyte traces to a scratch disk without changing the layout. `fit_model.py`, `fit_sensitivity.py`, `sync_report_figures.py`, and `upload.py` all honour the same resolution (`vocab_growth.environment.output_root`), and the disk preflight prints the resolved root. The report figure cache (`docs/report/figures/`, below) always stays in the checkout.
 
 ### Sync report figures
 
 ```bash
-python scripts/sync_report_figures.py
+python scripts/sync_report_figures.py [--output-dir <dir>]
 ```
 
-Copies the plots (`.svg`/`.png`) and summary tables (`.csv`) from `output/models/` and `output/comparisons/` into `docs/report/figures/` (gitignored), which is the only source the Quarto report reads. Traces (`.nc`) are excluded. Run after fitting models or regenerating comparisons, before rendering the report.
+Copies the plots (`.svg`/`.png`) and summary tables (`.csv`) from the output root's `models/` and `comparisons/` (same resolution as above) into `docs/report/figures/` (gitignored), which is the only source the Quarto report reads. Traces (`.nc`) are excluded. Run after fitting models or regenerating comparisons, before rendering the report.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,23 +65,24 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 ### Fit a model
 
 ```bash
-python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
+python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload] [--output-dir <dir>]
 ```
 
 - `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
+- `--output-dir`: root directory for model output. Overrides the `DSE_VOCAB_GROWTH_OUTPUT_DIR` environment variable; both fall back to the repository-local `output/`.
 
-Output (traces, figures, summary tables) is written to `output/models/<model_name>/`.
+Output (traces, figures, summary tables) is written to `<output-root>/models/<model_name>/`. The output root is resolved (highest precedence first) from `--output-dir`, then the `DSE_VOCAB_GROWTH_OUTPUT_DIR` environment variable, then the repository-local `output/` default — so reporting-quality VM runs can redirect the multi-gigabyte traces to a scratch disk without changing the layout. `fit_model.py`, `fit_sensitivity.py`, `sync_report_figures.py`, and `upload.py` all honour the same resolution (`vocab_growth.environment.output_root`), and the disk preflight prints the resolved root. The report figure cache (`docs/report/figures/`, below) always stays in the checkout.
 
 ### Sync report figures
 
 ```bash
-python scripts/sync_report_figures.py
+python scripts/sync_report_figures.py [--output-dir <dir>]
 ```
 
-Copies the plots (`.svg`/`.png`) and summary tables (`.csv`) from `output/models/` and `output/comparisons/` into `docs/report/figures/` (gitignored), which is the only source the Quarto report reads. Traces (`.nc`) are excluded. Run after fitting models or regenerating comparisons, before rendering the report.
+Copies the plots (`.svg`/`.png`) and summary tables (`.csv`) from the output root's `models/` and `comparisons/` (same resolution as above) into `docs/report/figures/` (gitignored), which is the only source the Quarto report reads. Traces (`.nc`) are excluded. Run after fitting models or regenerating comparisons, before rendering the report.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,23 +65,24 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 ### Fit a model
 
 ```bash
-python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload]
+python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload] [--output-dir <dir>]
 ```
 
 - `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
+- `--output-dir`: root directory for model output. Overrides the `DSE_VOCAB_GROWTH_OUTPUT_DIR` environment variable; both fall back to the repository-local `output/`.
 
-Output (traces, figures, summary tables) is written to `output/models/<model_name>/`.
+Output (traces, figures, summary tables) is written to `<output-root>/models/<model_name>/`. The output root is resolved (highest precedence first) from `--output-dir`, then the `DSE_VOCAB_GROWTH_OUTPUT_DIR` environment variable, then the repository-local `output/` default — so reporting-quality VM runs can redirect the multi-gigabyte traces to a scratch disk without changing the layout. `fit_model.py`, `fit_sensitivity.py`, `sync_report_figures.py`, and `upload.py` all honour the same resolution (`vocab_growth.environment.output_root`), and the disk preflight prints the resolved root. The report figure cache (`docs/report/figures/`, below) always stays in the checkout.
 
 ### Sync report figures
 
 ```bash
-python scripts/sync_report_figures.py
+python scripts/sync_report_figures.py [--output-dir <dir>]
 ```
 
-Copies the plots (`.svg`/`.png`) and summary tables (`.csv`) from `output/models/` and `output/comparisons/` into `docs/report/figures/` (gitignored), which is the only source the Quarto report reads. Traces (`.nc`) are excluded. Run after fitting models or regenerating comparisons, before rendering the report.
+Copies the plots (`.svg`/`.png`) and summary tables (`.csv`) from the output root's `models/` and `comparisons/` (same resolution as above) into `docs/report/figures/` (gitignored), which is the only source the Quarto report reads. Traces (`.nc`) are excluded. Run after fitting models or regenerating comparisons, before rendering the report.
 
 ## Architecture
 

--- a/scripts/aggregate_summary.py
+++ b/scripts/aggregate_summary.py
@@ -32,6 +32,7 @@ from typing import Any
 import arviz as az
 import pandas as pd
 
+from vocab_growth import environment as env
 from vocab_growth.models.definitions import MODEL_REGISTRY
 
 # (short model id, output-folder label), derived from the registry so a newly
@@ -41,9 +42,9 @@ MODELS = [
     (d.model_id, f"{d.model_id}-{d.config_name}") for d in MODEL_REGISTRY.values()
 ]
 
-LOG_DIR = "output/logs"
-MODELS_DIR = "output/models"
-COMPARE_DIR = "output/comparisons"
+LOG_DIR = os.path.join(env.output_root(), "logs")
+MODELS_DIR = env.models_output_dir()
+COMPARE_DIR = env.comparisons_output_dir()
 
 
 def parse_log_timings(log_path: str) -> dict[str, Any]:

--- a/scripts/compare_ds_td_expressive.py
+++ b/scripts/compare_ds_td_expressive.py
@@ -72,7 +72,7 @@ TD_UNDERSTOOD_KEY = "vg12"
 # spoken curve is used too, so spoken and p_any share one DS posterior).
 DS_SIGN_KEY = "vg14"
 
-OUT_DIR = os.path.join("output", "comparisons")
+OUT_DIR = env.comparisons_output_dir()
 SEED = 20260626
 PCT = 10.0
 # Vocabulary levels (words) for the level-indexed delay curves.

--- a/scripts/compare_ds_td_expressive.py
+++ b/scripts/compare_ds_td_expressive.py
@@ -9,7 +9,8 @@ DS and TD posteriors, so per-draw pairing gives exact credible intervals with
 **no joint/stacked model**. (The generative joint model that would make the gap
 itself a parameter is the reserved VG16; see ``compare_ds_td_re.py``.)
 
-Outputs (individual, linear-axis figures + CSVs) to ``output/comparisons/``:
+Outputs (individual, linear-axis figures + CSVs) to the configured comparisons
+dir (default ``output/comparisons/``; see ``vocab_growth.environment.output_root``):
 
 Expressive-specific delay (level-indexed — "as a function of TD performance")
   * ``ds_td_expressive_attainment_delay.{png,svg}`` — D_U(N), D_S(N): months DS

--- a/scripts/compare_ds_td_re.py
+++ b/scripts/compare_ds_td_re.py
@@ -73,7 +73,7 @@ DISP_DS_KEY = "vg07"
 # TD comparator per outcome: the univariate study-RE models.
 TD_KEYS = {"spoken": "vg11", "understood": "vg12"}
 
-OUT_DIR = os.path.join("output", "comparisons")
+OUT_DIR = env.comparisons_output_dir()
 SEED = 20260616
 GRID_STEP = 0.5  # months
 # Vocabulary levels (words) for the attainment-delay D(v) curve.

--- a/scripts/compare_ds_td_re.py
+++ b/scripts/compare_ds_td_re.py
@@ -21,7 +21,8 @@ generative object (partial pooling, a directly-estimated delay, difference-in-
 differences, the "delayed/scaled TD trajectory" hypothesis) is the reserved
 future **VG16** and is intentionally NOT built here.
 
-Estimands, per outcome, written to ``output/comparisons/``:
+Estimands, per outcome, written to the configured comparisons dir (default
+``output/comparisons/``; see ``vocab_growth.environment.output_root``):
 
 * ``ds_td_<outcome>_re_expected_words.csv``   — TD & DS expected words, the
   difference δ(a)=TD-DS (+90/50% HDI, P(TD>DS)) and the ratio.

--- a/scripts/compare_ds_td_trajectories.py
+++ b/scripts/compare_ds_td_trajectories.py
@@ -12,7 +12,8 @@ Reads the per-model CSVs already produced by the model fit pipeline:
 - `comprehension_production_gap.csv` — posterior median + HDI bands for the
   expected gap (p_U - p_S) * n_trials.
 
-Outputs (in `output/comparisons/`):
+Outputs (in the configured comparisons dir — default `output/comparisons/`, see
+`vocab_growth.environment.output_root`):
 
 - `ds_td_joint_trajectory.{png,svg}` — two panels, shared x-axis 0-115 months.
 - `ds_td_comprehension_production_gap.{png,svg}` — two panels, shared x-axis.

--- a/scripts/compare_ds_td_trajectories.py
+++ b/scripts/compare_ds_td_trajectories.py
@@ -31,7 +31,7 @@ from vocab_growth import environment as env
 
 DS_DIR = comparison.model_dir("vg10")
 TD_DIR = comparison.model_dir("vg13")
-OUT_DIR = "output/comparisons"
+OUT_DIR = env.comparisons_output_dir()
 
 UNDERSTOOD_COLOUR = "C0"
 SPOKEN_COLOUR = "C1"

--- a/scripts/compare_models.py
+++ b/scripts/compare_models.py
@@ -26,9 +26,10 @@ import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
 import pandas as pd
 
+from vocab_growth import environment as env
 from vocab_growth.comparison import first_crossing, model_dir, overlay_age_curves
 
-OUT_DIR = os.path.join("output", "comparisons")
+OUT_DIR = env.comparisons_output_dir()
 
 DS_COLOUR = plot_styles.COLOUR_BLUE
 TD_COLOUR = plot_styles.COLOUR_ORANGE

--- a/scripts/compare_sensitivity.py
+++ b/scripts/compare_sensitivity.py
@@ -27,7 +27,7 @@ from vocab_growth.sensitivity.registry import VARIANTS, variants_for
 def _model_dir(model_key: str, suffix: str | None = None) -> str:
     d = MODEL_REGISTRY[model_key]
     name = f"{d.model_id}-{d.config_name}" + (f"-{suffix}" if suffix else "")
-    return os.path.join(env.MODELS_OUTPUT_DIR, name)
+    return os.path.join(env.models_output_dir(), name)
 
 
 if __name__ == "__main__":
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         raise SystemExit(1)
 
     names = variants_for(args.model) if args.variant == "all" else [args.variant]
-    detail_dir = os.path.join(env.OUTPUT_DIR, "comparisons", "sensitivity")
+    detail_dir = os.path.join(env.comparisons_output_dir(), "sensitivity")
     os.makedirs(detail_dir, exist_ok=True)
 
     rows: list[dict] = []

--- a/scripts/data_coverage.py
+++ b/scripts/data_coverage.py
@@ -28,9 +28,10 @@ import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
 import pandas as pd
 
+from vocab_growth import environment as env
 from vocab_growth.data_utils import load_combined_data
 
-OUT_DIR = "output/data"
+OUT_DIR = os.path.join(env.output_root(), "data")
 
 AGE_BIN_EDGES = list(range(0, 121, 6))  # 0, 6, 12, …, 120 months
 

--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -49,12 +49,27 @@ if __name__ == "__main__":
         action="store_true",
         help="Include trace files (.nc) in the upload (excluded by default).",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help=(
+            "Root directory for model output (overrides "
+            "$DSE_VOCAB_GROWTH_OUTPUT_DIR; default: <repo>/output). Useful for "
+            "redirecting heavy traces to a scratch disk on ephemeral VMs."
+        ),
+    )
 
     freeze_support()
 
     setup.init_script()
 
     args = parser.parse_args()
+
+    # Resolve where heavy artefacts (traces, figures, tables) are written before
+    # any output path is computed. --output-dir wins over
+    # $DSE_VOCAB_GROWTH_OUTPUT_DIR, which wins over the repo-local output/ default.
+    env.set_output_root(args.output_dir)
 
     # Model modules follow the "model_<key>" naming convention 1:1 with
     # MODEL_REGISTRY (definitions.py), so the set of fittable models is
@@ -80,6 +95,7 @@ if __name__ == "__main__":
             ("Render Quarto", args.render),
             ("Upload to blob storage", args.upload),
             ("Include traces in upload", args.include_traces),
+            ("Output root", env.output_root()),
         ],
     )
 
@@ -88,7 +104,7 @@ if __name__ == "__main__":
     heavy = args.config in {"rep", "rep-lite"}
     env.preflight_disk(
         (20.0 if heavy else 2.0) * len(selected),
-        env.OUTPUT_DIR,
+        env.output_root(),
         label=f"{len(selected)} fit(s) [{args.config}]",
     )
 

--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -62,14 +62,15 @@ if __name__ == "__main__":
 
     freeze_support()
 
-    setup.init_script()
-
     args = parser.parse_args()
 
-    # Resolve where heavy artefacts (traces, figures, tables) are written before
-    # any output path is computed. --output-dir wins over
-    # $DSE_VOCAB_GROWTH_OUTPUT_DIR, which wins over the repo-local output/ default.
+    # Resolve the output root before any output path is computed — and before
+    # init_script(), in case script setup ever reads an output location.
+    # --output-dir wins over $DSE_VOCAB_GROWTH_OUTPUT_DIR, which wins over the
+    # repo-local output/ default.
     env.set_output_root(args.output_dir)
+
+    setup.init_script()
 
     # Model ids are registered in lower case (see definitions.py); normalise
     # user input so "VG01", "vg01", "Vg01" and "ALL" all resolve correctly.

--- a/scripts/fit_sensitivity.py
+++ b/scripts/fit_sensitivity.py
@@ -49,10 +49,21 @@ if __name__ == "__main__":
         default="test",
         help="Sampling configuration (default: test — the honest tier for robustness).",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help=(
+            "Root directory for model output (overrides "
+            "$DSE_VOCAB_GROWTH_OUTPUT_DIR; default: <repo>/output)."
+        ),
+    )
 
     freeze_support()
     setup.init_script()
     args = parser.parse_args()
+
+    env.set_output_root(args.output_dir)
 
     if args.model not in _RUNNER_BY_KEY:
         console.print(
@@ -72,11 +83,12 @@ if __name__ == "__main__":
             ("Variants", ", ".join(names)),
             ("Sampling config", args.config),
             ("Fits", len(variant_defs)),
+            ("Output root", env.output_root()),
         ],
     )
     env.preflight_disk(
         2.0 * len(variant_defs),
-        env.OUTPUT_DIR,
+        env.output_root(),
         label=f"{len(variant_defs)} sensitivity fit(s) [{args.config}]",
     )
 

--- a/scripts/fit_sensitivity.py
+++ b/scripts/fit_sensitivity.py
@@ -60,10 +60,10 @@ if __name__ == "__main__":
     )
 
     freeze_support()
-    setup.init_script()
     args = parser.parse_args()
-
+    # Set the output root before init_script(), in case script setup reads a path.
     env.set_output_root(args.output_dir)
+    setup.init_script()
 
     if args.model not in _RUNNER_BY_KEY:
         console.print(

--- a/scripts/kfold_loso.py
+++ b/scripts/kfold_loso.py
@@ -49,6 +49,7 @@ from scipy.special import logsumexp
 from scipy.stats import betabinom
 
 import vocab_growth.data_utils as data_utils
+from vocab_growth import environment as env
 from vocab_growth.models.common import ModelFitContext
 from vocab_growth.models.common_bivariate import (
     configure_bivariate_priors,
@@ -58,8 +59,8 @@ from vocab_growth.models.common_bivariate_re import build_model_re
 from vocab_growth.models.definitions import VG07, VG08, VG09, BivariateModelDefinition
 
 N_TRIALS = 800
-OUT_DIR = "output/comparisons"
-KFOLD_TMP_DIR = "output/kfold_tmp"
+OUT_DIR = env.comparisons_output_dir()
+KFOLD_TMP_DIR = os.path.join(env.output_root(), "kfold_tmp")
 
 
 @dataclass(frozen=True)

--- a/scripts/loo_compare.py
+++ b/scripts/loo_compare.py
@@ -32,10 +32,11 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from vocab_growth import environment as env
 from vocab_growth.models.definitions import MODEL_REGISTRY, ModelType
 
-MODELS_DIR = "output/models"
-OUT_DIR = "output/comparisons"
+MODELS_DIR = env.models_output_dir()
+OUT_DIR = env.comparisons_output_dir()
 
 # Registry-derived so a newly added univariate/bivariate model is picked up
 # automatically. Trivariate (VG14) and joint (VG15) models have a different

--- a/scripts/loso_compare.py
+++ b/scripts/loso_compare.py
@@ -40,12 +40,13 @@ from scipy.special import logsumexp
 from scipy.stats import betabinom
 
 import vocab_growth.data_utils as data_utils
+from vocab_growth import environment as env
 
 EPSILON = 1e-12
 N_TRIALS = 800
 
-MODELS_DIR = "output/models"
-OUT_DIR = "output/comparisons"
+MODELS_DIR = env.models_output_dir()
+OUT_DIR = env.comparisons_output_dir()
 
 
 @dataclass(frozen=True)

--- a/scripts/prior_predictive_audit.py
+++ b/scripts/prior_predictive_audit.py
@@ -43,7 +43,7 @@ def _context(definition) -> ModelFitContext:
         reporting=reporting.ReportingConfiguration(
             model_name=definition.model_id,
             config_name=definition.config_name,
-            output_root_dir=env.OUTPUT_DIR,
+            output_root_dir=env.output_root(),
             hdi=0.90,
         ),
         sampling=sampling.get_sampling_configuration("dev"),

--- a/scripts/prior_vs_posterior.py
+++ b/scripts/prior_vs_posterior.py
@@ -26,13 +26,14 @@ import numpy as np
 import preliz as pz
 from scipy import stats
 
+from vocab_growth import environment as env
 from vocab_growth.models.definitions import (
     MODEL_REGISTRY,
     BivariateModelDefinition,
     UnivariateModelDefinition,
 )
 
-MODELS_DIR = "output/models"
+MODELS_DIR = env.models_output_dir()
 
 # Registry-derived: covers every univariate/bivariate model, matching the two
 # prior-dispatch functions below. Trivariate (VG14) and joint (VG15)

--- a/scripts/regenerate_vg09_marginal_predictive.py
+++ b/scripts/regenerate_vg09_marginal_predictive.py
@@ -34,8 +34,9 @@ from scipy.stats import betabinom
 
 import vocab_growth.data_utils as data_utils
 import vocab_growth.plotting as plotting
+from vocab_growth import environment as env
 
-VG09_DIR = "output/models/VG09-age-understood-spoken-ds-re-subj-uq"
+VG09_DIR = os.path.join(env.models_output_dir(), "VG09-age-understood-spoken-ds-re-subj-uq")
 N_TRIALS = 800
 EPSILON = 1e-12
 SEED = 47

--- a/scripts/sync_report_figures.py
+++ b/scripts/sync_report_figures.py
@@ -21,6 +21,12 @@ Usage::
     python scripts/sync_report_figures.py                 # models + comparisons
     python scripts/sync_report_figures.py --models-only
     python scripts/sync_report_figures.py --comparisons-only
+    python scripts/sync_report_figures.py --output-dir /scratch/vg-output
+
+The source output root follows the same resolution as the fitting scripts:
+``--output-dir`` overrides ``$DSE_VOCAB_GROWTH_OUTPUT_DIR``, which overrides the
+repository-local ``output/`` default. The report figure store
+(``docs/report/figures/``) always stays in the checkout.
 """
 
 from __future__ import annotations
@@ -32,7 +38,6 @@ import shutil
 from vocab_growth import environment as env
 
 COPY_EXTS = (".svg", ".png", ".csv")
-COMPARISONS_DIR = os.path.join(env.OUTPUT_DIR, "comparisons")
 
 
 def _sync_dir(src: str, dst: str) -> int:
@@ -59,30 +64,44 @@ def main() -> None:
         action="store_true",
         help="Sync only the DS/TD comparison figures.",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help=(
+            "Root directory to read fitted output from (overrides "
+            "$DSE_VOCAB_GROWTH_OUTPUT_DIR; default: <repo>/output)."
+        ),
+    )
     args = parser.parse_args()
+
+    env.set_output_root(args.output_dir)
+    models_dir = env.models_output_dir()
+    comparisons_dir = env.comparisons_output_dir()
+    print(f"[output] reading fitted output from {env.output_root()}")
 
     total = 0
 
     if not args.comparisons_only:
-        if os.path.isdir(env.MODELS_OUTPUT_DIR):
-            for name in sorted(os.listdir(env.MODELS_OUTPUT_DIR)):
-                src = os.path.join(env.MODELS_OUTPUT_DIR, name)
+        if os.path.isdir(models_dir):
+            for name in sorted(os.listdir(models_dir)):
+                src = os.path.join(models_dir, name)
                 if os.path.isdir(src):
                     n = _sync_dir(src, os.path.join(env.REPORT_FIGS_DIR, name))
                     total += n
                     print(f"  {name}: {n} files")
         else:
-            print(f"[skip] no models output dir: {env.MODELS_OUTPUT_DIR}")
+            print(f"[skip] no models output dir: {models_dir}")
 
     if not args.models_only:
-        if os.path.isdir(COMPARISONS_DIR):
+        if os.path.isdir(comparisons_dir):
             n = _sync_dir(
-                COMPARISONS_DIR, os.path.join(env.REPORT_FIGS_DIR, "comparisons")
+                comparisons_dir, os.path.join(env.REPORT_FIGS_DIR, "comparisons")
             )
             total += n
             print(f"  comparisons: {n} files")
         else:
-            print(f"[skip] no comparisons dir: {COMPARISONS_DIR}")
+            print(f"[skip] no comparisons dir: {comparisons_dir}")
 
     print(f"[done] synced {total} files into {env.REPORT_FIGS_DIR}")
 

--- a/scripts/time_to_milestone.py
+++ b/scripts/time_to_milestone.py
@@ -37,8 +37,8 @@ from vocab_growth import environment as env
 from vocab_growth.comparison import invert_curve
 from vocab_growth.models.definitions import MODEL_REGISTRY, ModelType
 
-MODELS_DIR = "output/models"
-COMPARE_DIR = "output/comparisons"
+MODELS_DIR = env.models_output_dir()
+COMPARE_DIR = env.comparisons_output_dir()
 
 TARGETS = [25, 50, 100, 200, 400]
 
@@ -138,7 +138,7 @@ def process_bivariate(short: str, label: str, pop: str,
 
 
 def main() -> None:
-    env.preflight_disk(2.0, env.OUTPUT_DIR, label="milestone outputs")
+    env.preflight_disk(2.0, env.output_root(), label="milestone outputs")
     plot_styles.set_matplotlib_default_style()
     os.makedirs(COMPARE_DIR, exist_ok=True)
 

--- a/scripts/time_to_milestone.py
+++ b/scripts/time_to_milestone.py
@@ -15,13 +15,14 @@ percentile child first reach a target word count?**
 
 Targets: 25, 50, 100, 200, 400 words.
 
-Output per model:
+Output per model (paths are under the configured output root — default `output/`;
+see `vocab_growth.environment.output_root`):
 
-- `output/models/<MODEL>/time_to_milestone[_<u|s>].csv`
-- `output/models/<MODEL>/time_to_milestone[_<u|s>].png/.svg`
+- `<output-root>/models/<MODEL>/time_to_milestone[_<u|s>].csv`
+- `<output-root>/models/<MODEL>/time_to_milestone[_<u|s>].png/.svg`
 
 The same CSVs are also concatenated into
-`output/comparisons/time_to_milestone_all.csv` for cross-population
+`<output-root>/comparisons/time_to_milestone_all.csv` for cross-population
 contrasts.
 """
 

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -34,8 +34,20 @@ if __name__ == "__main__":
         action="store_true",
         help="Include trace files (.nc) in the upload (excluded by default).",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help=(
+            "Root directory to upload model output from (overrides "
+            "$DSE_VOCAB_GROWTH_OUTPUT_DIR; default: <repo>/output)."
+        ),
+    )
 
     args = parser.parse_args()
+
+    local_env.set_output_root(args.output_dir)
+    print(f"[output] uploading from {local_env.output_root()}")
 
     if args.model == "all":
         to_upload = list(MODEL_CONFIGS.items())
@@ -47,7 +59,7 @@ if __name__ == "__main__":
 
     for model_id, (model_name, config_name) in to_upload:
         model_label = f"{model_name}-{config_name}"
-        output_dir = os.path.join(local_env.MODELS_OUTPUT_DIR, model_label)
+        output_dir = os.path.join(local_env.models_output_dir(), model_label)
 
         if not os.path.isdir(output_dir):
             print(

--- a/scripts/vg07_study_effects.py
+++ b/scripts/vg07_study_effects.py
@@ -26,10 +26,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from vocab_growth import environment as env
 from vocab_growth.data_utils import load_data
 from vocab_growth.models.definitions import Population
 
-MODEL_DIR = "output/models/VG07-age-understood-spoken-ds-re"
+MODEL_DIR = os.path.join(env.models_output_dir(), "VG07-age-understood-spoken-ds-re")
 HDI_PROB = 0.90
 
 

--- a/src/vocab_growth/comparison.py
+++ b/src/vocab_growth/comparison.py
@@ -52,7 +52,7 @@ DEFAULT_MIN_COVERAGE = 0.80
 def model_dir(key: str) -> str:
     """Output directory for a registry key, e.g. 'vg11' -> .../VG11-age-...-td."""
     d = MODEL_REGISTRY[key]
-    return os.path.join(env.MODELS_OUTPUT_DIR, f"{d.model_id}-{d.config_name}")
+    return os.path.join(env.models_output_dir(), f"{d.model_id}-{d.config_name}")
 
 
 def trace_path(key: str) -> str:

--- a/src/vocab_growth/environment.py
+++ b/src/vocab_growth/environment.py
@@ -1,5 +1,15 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
+"""Filesystem locations for ``vocab_growth`` and the output-root resolver.
+
+The output root is resolved at call time by :func:`output_root`, with precedence:
+an explicit override set via :func:`set_output_root` (e.g. from ``--output-dir``) >
+the ``DSE_VOCAB_GROWTH_OUTPUT_DIR`` environment variable > the repository-local
+``output/`` default. :func:`models_output_dir` / :func:`comparisons_output_dir` are
+its ``models`` / ``comparisons`` subdirectories. ``docs/report/figures/``
+(``REPORT_FIGS_DIR``) is the report-facing cache and deliberately stays in the
+checkout, never under this root.
+"""
 
 import os
 import shutil
@@ -116,7 +126,10 @@ def preflight_disk(
     target = _normalise(path or output_root())
     free = free_space_gb(target)
     drive = os.path.splitdrive(target)[0] or target
-    print(f"[output] resolved output root: {output_root()}", flush=True)
+    # Surface the resolved root only when that is what we are actually checking, so
+    # this line can't disagree with the [disk] target when a caller passes a subdir.
+    if target == _normalise(output_root()):
+        print(f"[output] resolved output root: {output_root()}", flush=True)
     print(f"[disk] {free:.1f} GiB free on {drive} "
           f"(need >= {min_gb:.0f} GiB for {label})", flush=True)
     if free < min_gb:

--- a/src/vocab_growth/environment.py
+++ b/src/vocab_growth/environment.py
@@ -11,23 +11,90 @@ ROOT_DIR = os.path.dirname(_SRC_DIR)
 
 DATA_DIR = os.path.join(ROOT_DIR, "data")
 
-OUTPUT_DIR = os.path.join(ROOT_DIR, "output")
-
-MODELS_OUTPUT_DIR = os.path.join(OUTPUT_DIR, "models")
-
 DOCS_DIR = os.path.join(ROOT_DIR, "docs")
 
 REPORT_DIR = os.path.join(DOCS_DIR, "report")
 REPORT_FIGS_DIR = os.path.join(REPORT_DIR, "figures")
 
 
+# ---------------------------------------------------------------------------
+# Output-root resolution
+# ---------------------------------------------------------------------------
+# Model traces and reporting-quality artefacts are large (a reporting-config
+# ``trace.nc`` exceeds 10 GB), so on ephemeral VMs we want to redirect them to a
+# scratch disk without disturbing local development or report rendering. The
+# output root is therefore resolved at *call time*, with this precedence:
+#
+#   1. an explicit override set via ``set_output_root`` (e.g. from ``--output-dir``)
+#   2. the ``DSE_VOCAB_GROWTH_OUTPUT_DIR`` environment variable
+#   3. the repository-local ``<repo>/output`` default (unchanged behaviour)
+#
+# ``docs/report/figures/`` is deliberately *not* under this root: it is the
+# report-facing cache populated by ``scripts/sync_report_figures.py`` and always
+# lives in the checkout so the Quarto report renders without the scratch disk.
+OUTPUT_DIR_ENV_VAR = "DSE_VOCAB_GROWTH_OUTPUT_DIR"
+
+_DEFAULT_OUTPUT_DIR = os.path.join(ROOT_DIR, "output")
+
+_output_root_override: str | None = None
+
+
+def _normalise(path: str) -> str:
+    return os.path.abspath(os.path.expanduser(path))
+
+
+def set_output_root(path: str | None) -> None:
+    """Set a process-wide output-root override (typically from ``--output-dir``).
+
+    Takes precedence over ``$DSE_VOCAB_GROWTH_OUTPUT_DIR``. Pass ``None`` to clear
+    the override and fall back to the environment variable / default. Call this
+    once, early in a script's entry point, before any output path is resolved.
+    """
+    global _output_root_override
+    _output_root_override = _normalise(path) if path else None
+
+
+def output_root() -> str:
+    """Resolve the output root at call time (see module docstring for precedence)."""
+    if _output_root_override is not None:
+        return _output_root_override
+    env_value = os.environ.get(OUTPUT_DIR_ENV_VAR)
+    if env_value:
+        return _normalise(env_value)
+    return _DEFAULT_OUTPUT_DIR
+
+
+def models_output_dir() -> str:
+    """``<output root>/models`` — one subdirectory per fitted model."""
+    return os.path.join(output_root(), "models")
+
+
+def comparisons_output_dir() -> str:
+    """``<output root>/comparisons`` — cross-model / DS-vs-TD comparison artefacts."""
+    return os.path.join(output_root(), "comparisons")
+
+
+# Backwards-compatible module attributes. These were historically constants; they
+# now resolve dynamically (PEP 562 module ``__getattr__``) so any remaining
+# consumer honours the configured output root. Prefer the ``*_output_dir()``
+# helpers (and ``output_root()``) in new code.
+def __getattr__(name: str) -> str:
+    if name == "OUTPUT_DIR":
+        return output_root()
+    if name == "MODELS_OUTPUT_DIR":
+        return models_output_dir()
+    if name == "COMPARISONS_OUTPUT_DIR":
+        return comparisons_output_dir()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 def free_space_gb(path: str | None = None) -> float:
-    """Free space (GiB) on the volume backing ``path`` (default ``OUTPUT_DIR``).
+    """Free space (GiB) on the volume backing ``path`` (default: the output root).
 
     Walks up to the nearest existing parent if ``path`` does not exist yet, so it
     works for an output directory that is about to be created.
     """
-    target = os.path.abspath(path or OUTPUT_DIR)
+    target = _normalise(path or output_root())
     while not os.path.exists(target):
         parent = os.path.dirname(target)
         if parent == target:
@@ -43,11 +110,13 @@ def preflight_disk(
 
     Call at the start of any script that writes large artefacts (model traces are
     >10 GB at reporting configs) so a full volume fails fast rather than after a
-    multi-hour sample. Returns the free space in GiB when the check passes.
+    multi-hour sample. Prints the resolved output location so redirected runs are
+    obvious in job logs. Returns the free space in GiB when the check passes.
     """
-    target = os.path.abspath(path or OUTPUT_DIR)
+    target = _normalise(path or output_root())
     free = free_space_gb(target)
     drive = os.path.splitdrive(target)[0] or target
+    print(f"[output] resolved output root: {output_root()}", flush=True)
     print(f"[disk] {free:.1f} GiB free on {drive} "
           f"(need >= {min_gb:.0f} GiB for {label})", flush=True)
     if free < min_gb:

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -1284,7 +1284,7 @@ def run_fit_pipeline(
         reporting=reporting.ReportingConfiguration(
             model_name=definition.model_id,
             config_name=definition.config_name,
-            output_root_dir=local_env.OUTPUT_DIR,
+            output_root_dir=local_env.output_root(),
             hdi=0.90,
         ),
         sampling=sampling.get_sampling_configuration(config),

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for :mod:`vocab_growth.environment` output-root resolution (issue #105).
+
+The output root is resolved at call time with precedence
+``set_output_root()`` override > ``$DSE_VOCAB_GROWTH_OUTPUT_DIR`` > repo-local
+``output/``. The report figure cache (``docs/report/figures/``) is deliberately
+kept in the checkout and must never follow a redirected root.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import vocab_growth.environment as env
+
+
+@pytest.fixture(autouse=True)
+def _isolate_output_root(monkeypatch):
+    """Start each test with no env var and no override; always restore after."""
+    monkeypatch.delenv(env.OUTPUT_DIR_ENV_VAR, raising=False)
+    env.set_output_root(None)
+    yield
+    env.set_output_root(None)
+
+
+def test_default_is_repo_local_output():
+    assert env.output_root() == os.path.join(env.ROOT_DIR, "output")
+
+
+def test_models_and_comparisons_are_subdirs_of_root():
+    env.set_output_root("/scratch/vg")
+    assert env.models_output_dir() == os.path.join("/scratch/vg", "models")
+    assert env.comparisons_output_dir() == os.path.join("/scratch/vg", "comparisons")
+
+
+def test_env_var_redirects_root(monkeypatch):
+    monkeypatch.setenv(env.OUTPUT_DIR_ENV_VAR, "/scratch/vg")
+    assert env.output_root() == "/scratch/vg"
+    assert env.models_output_dir() == os.path.join("/scratch/vg", "models")
+
+
+def test_override_takes_precedence_over_env_var(monkeypatch):
+    monkeypatch.setenv(env.OUTPUT_DIR_ENV_VAR, "/scratch/vg")
+    env.set_output_root("/cli/dir")
+    assert env.output_root() == "/cli/dir"
+
+
+def test_clearing_override_falls_back_to_env_var(monkeypatch):
+    monkeypatch.setenv(env.OUTPUT_DIR_ENV_VAR, "/scratch/vg")
+    env.set_output_root("/cli/dir")
+    env.set_output_root(None)
+    assert env.output_root() == "/scratch/vg"
+
+
+def test_override_is_expanded_and_absolute():
+    env.set_output_root("~/foo/../foo")
+    assert env.output_root() == os.path.abspath(os.path.expanduser("~/foo/../foo"))
+
+
+def test_legacy_attributes_resolve_dynamically():
+    # The historical module constants are now PEP 562 shims that honour overrides.
+    env.set_output_root("/scratch/vg")
+    assert env.OUTPUT_DIR == env.output_root() == "/scratch/vg"
+    assert env.MODELS_OUTPUT_DIR == env.models_output_dir()
+    assert env.COMPARISONS_OUTPUT_DIR == env.comparisons_output_dir()
+
+
+def test_unknown_attribute_still_raises():
+    with pytest.raises(AttributeError):
+        _ = env.DOES_NOT_EXIST
+
+
+def test_report_figs_dir_stays_repo_local(monkeypatch):
+    monkeypatch.setenv(env.OUTPUT_DIR_ENV_VAR, "/scratch/vg")
+    assert env.REPORT_FIGS_DIR.startswith(env.ROOT_DIR)
+    assert "/scratch/vg" not in env.REPORT_FIGS_DIR


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

Closes #105.

## What

Makes the model output root configurable so reporting-quality VM runs can redirect the multi-gigabyte `trace.nc` artefacts to a scratch disk, without changing the established layout or breaking local development / report rendering.

A single **call-time resolver** in `vocab_growth.environment` resolves the output root with precedence:

1. `--output-dir <dir>` — per-process CLI override
2. `$DSE_VOCAB_GROWTH_OUTPUT_DIR` — environment variable
3. repository-local `output/` — unchanged default

New API: `output_root()`, `models_output_dir()`, `comparisons_output_dir()`, `set_output_root()`, `OUTPUT_DIR_ENV_VAR`. The historical `OUTPUT_DIR` / `MODELS_OUTPUT_DIR` module constants are retained as PEP 562 `__getattr__` shims that now resolve dynamically, so any remaining consumer honours the override.

## Changes

- **`environment.py`** — resolver + `set_output_root`; disk helpers default to the resolved root; `preflight_disk` prints the resolved location.
- **`--output-dir`** added to `fit_model.py`, `fit_sensitivity.py`, `sync_report_figures.py`, `upload.py` (each calls `set_output_root` before any path is computed → precedence over the env var).
- **Migrated every hard-coded `output/...` path** (17 scripts + `comparison.py` + the model pipeline in `common.py`) to the shared resolver, so the override consistently redirects both model and comparison outputs.
- `docs/report/figures/` deliberately stays in the checkout — the report cache is never redirected.
- Docs updated in `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`.
- New `tests/test_environment.py`.

## Acceptance criteria (from #105)

- [x] Existing commands write to repo-local `output/` when no override is supplied.
- [x] `DSE_VOCAB_GROWTH_OUTPUT_DIR` redirects model and comparison outputs to that root.
- [x] `--output-dir` redirects for that command and overrides the environment variable.
- [x] `sync_report_figures.py` copies report artefacts from the configured root into `docs/report/figures/`.
- [x] `upload.py` uploads from the configured root.
- [x] Disk preflight checks report the resolved output location.
- [x] Documentation describes the default and override behaviour.

## Verification

- `pytest` — all pass (incl. new `test_environment.py`).
- `ruff check src/ scripts/` — clean.
- `npm run spellcheck` — 0 issues; `npm run format:check` — clean.
- Runtime checks confirm `--output-dir`, the env var, precedence (`--output-dir` wins), and the unchanged repo-local default all resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
