### PR TITLE
Fix Python review findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,5 +69,10 @@ ignore = [
     "E741",  # ambiguous variable name — mathematical names (l, X, y) are meaningful
 ]
 
+[tool.ruff.lint.per-file-ignores]
+"notebooks/*.py" = [
+    "B018",  # notebook display expressions are intentional in Jupytext percent files
+]
+
 [tool.ruff.lint.isort]
 known-first-party = ["vocab_growth"]

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -311,7 +311,7 @@ con.execute(
            vuk1.produced,
            vuk1.survey_vocab_max
     FROM vocab_uk_01 as vuk1
-    UNION
+    UNION ALL
     SELECT 'uk_02'          as study,
            vuk2.subject_id,
            CASE
@@ -330,7 +330,7 @@ con.execute(
                ELSE NULL
            END                as survey_vocab_max
     FROM vocab_uk_02 as vuk2
-    UNION
+    UNION ALL
     SELECT 'ie_01'                                                   as study,
            vie.subject_id,
            NULL                                                        as sex,
@@ -341,7 +341,7 @@ con.execute(
            null                                                        as produced,
            800                                                         as survey_vocab_max
     FROM vocab_ie_01 as vie
-    UNION
+    UNION ALL
     SELECT 'ie_01'                                               as study,
            vie.subject_id,
            NULL                                                    as sex,
@@ -352,7 +352,7 @@ con.execute(
            vie.says_total_end                                      as produced,
            800                                                     as survey_vocab_max
     FROM vocab_ie_01 as vie
-    UNION
+    UNION ALL
     SELECT 'us_01'                          as study,
            concat('id_', hex(hash(child_id))) as subject_id,
            sex,
@@ -371,7 +371,7 @@ con.execute(
       AND language IN ({_ENGLISH_SQL_LIST})
       AND lower(health_conditions) = 'down syndrome'
       AND production <= 100
-    UNION
+    UNION ALL
     SELECT 'uk_03'                           as study,
            vuk2025.subject_id,
            NULL                                as sex,
@@ -382,7 +382,7 @@ con.execute(
            vuk2025.production                  as produced,
            418                                 as survey_vocab_max
     FROM vocab_uk_03 as vuk2025
-    UNION
+    UNION ALL
     SELECT 'it_01'                           as study,
            vit2013.subject_id,
            NULL                                as sex,
@@ -393,7 +393,7 @@ con.execute(
            vit2013.spoken                      as produced,
            vit2013.form_max_spoken             as survey_vocab_max
     FROM vocab_it_01 as vit2013
-    UNION
+    UNION ALL
     SELECT 'uk_04'                           as study,
         vuk2013.subject_id,
         NULL                                as sex,
@@ -404,7 +404,7 @@ con.execute(
         vuk2013.spoken                      as produced,
         418                                 as survey_vocab_max
     FROM vocab_uk_04 as vuk2013
-        UNION
+        UNION ALL
     SELECT 'uk_05'                           as study,
         vuk05.subject_id,
         NULL                                as sex,
@@ -415,7 +415,7 @@ con.execute(
         vuk05.spoken                      as produced,
         418                                 as survey_vocab_max
     FROM vocab_uk_05 as vuk05
-        UNION
+        UNION ALL
     SELECT 'us_02'                           as study,
         vus02.subject_id,
         NULL                                as sex,
@@ -426,7 +426,7 @@ con.execute(
         vus02.spoken                     as produced,
         418                                 as survey_vocab_max
     FROM vocab_us_02 as vus02
-        UNION
+        UNION ALL
     SELECT 'uk_06'                           as study,
         vuk06.subject_id,
         NULL                                as sex,
@@ -437,7 +437,7 @@ con.execute(
         vuk06.spoken                      as produced,
         800                                 as survey_vocab_max
     FROM vocab_uk_06 as vuk06
-        UNION
+        UNION ALL
     SELECT 'ie_02'                           as study,
         vie2.subject_id,
         NULL                                as sex,
@@ -449,7 +449,7 @@ con.execute(
         800                                 as survey_vocab_max
     FROM vocab_ie_02 as vie2
     WHERE vie2.english_speaking = 'yes'
-    UNION
+    UNION ALL
     -- nz_01 (Foster-Cohen): production-only, no comprehension. The CSV columns are
     -- modality-exclusive, so any-modality spoken = spoken + spoken_signed (a + c)
     -- and signed = signed + spoken_signed (b + c). 675-item NZCDI ceiling.

--- a/src/vocab_growth/comparison.py
+++ b/src/vocab_growth/comparison.py
@@ -504,7 +504,7 @@ def interp_draws(ages: np.ndarray, Y: np.ndarray, grid: np.ndarray) -> np.ndarra
     """Linear-interpolate each row of ``Y`` (n_draw, n_age) onto a shared ``grid``."""
     out = np.empty((Y.shape[0], grid.size), dtype=float)
     for i in range(Y.shape[0]):
-        out[i] = np.interp(grid, ages, Y[i])
+        out[i] = np.interp(grid, ages, Y[i], left=np.nan, right=np.nan)
     return out
 
 
@@ -605,19 +605,64 @@ def expressive_specific_delay(
     }
 
 
+def _first_crossing_age_targets(
+    W: np.ndarray,
+    ages: np.ndarray,
+    targets: np.ndarray,
+) -> np.ndarray:
+    """Per-draw first crossing age for one target per draw.
+
+    ``np.interp(target, W, ages)`` only works when each trajectory is monotone.
+    The fitted GP trajectories are not constrained that way, so this mirrors
+    :func:`first_crossing_age` but lets the target vary by draw.
+    """
+    targets = np.asarray(targets, dtype=float)
+    if targets.shape != (W.shape[0],):
+        raise ValueError("targets must have shape (n_draw,).")
+
+    out = np.full(W.shape[0], np.nan)
+    valid = np.isfinite(targets)
+    if not valid.any():
+        return out
+
+    W_valid = W[valid]
+    targets_valid = targets[valid]
+    mask = W_valid >= targets_valid[:, None]
+    any_above = mask.any(axis=1)
+    first_idx = mask.argmax(axis=1)
+    j_prev = np.maximum(first_idx - 1, 0)
+
+    y0 = np.take_along_axis(W_valid, j_prev[:, None], axis=1).squeeze(1)
+    y1 = np.take_along_axis(W_valid, first_idx[:, None], axis=1).squeeze(1)
+    a0 = ages[j_prev]
+    a1 = ages[first_idx]
+    with np.errstate(invalid="ignore", divide="ignore"):
+        denom = y1 - y0
+        interp = np.where(
+            denom == 0,
+            a1,
+            a0 + (targets_valid - y0) * (a1 - a0) / denom,
+        )
+    crossing = np.where(first_idx == 0, ages[0], interp)
+    below_support = (first_idx == 0) & (W_valid[:, 0] > targets_valid)
+    crossing = np.where(below_support, np.nan, crossing)
+    out[valid] = np.where(any_above, crossing, np.nan)
+    return out
+
+
 def _invert_trajectory(
     ages: np.ndarray, W: np.ndarray, targets: np.ndarray
 ) -> np.ndarray:
-    """Per-draw age at which monotone ``W`` (n_draw, n_age) reaches ``targets``.
+    """Per-draw first age at which ``W`` (n_draw, n_age) reaches ``targets``.
 
     ``targets`` is ``(n_draw, n_target)``. Linear interpolation on each draw's
-    (age-increasing) curve; NaN where a target lies outside that draw's observed
-    level range — i.e. where matching would require extrapolating the reference.
+    first crossing; NaN where a target lies outside that draw's observed level
+    range — i.e. where matching would require extrapolating the reference.
     """
     n_draw, n_target = targets.shape
     out = np.full((n_draw, n_target), np.nan)
-    for d in range(n_draw):
-        out[d] = np.interp(targets[d], W[d], ages, left=np.nan, right=np.nan)
+    for j in range(n_target):
+        out[:, j] = _first_crossing_age_targets(W, ages, targets[:, j])
     return out
 
 

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -884,10 +884,9 @@ def sample_posterior_predictive(context: BivariateContext, definition=None):
 
     For models with subject-level random intercepts (use_subject_re_u and/or
     use_subject_re_q), the y_*_plot / y_*_query nodes are constructed using
-    marginal probabilities that integrate over a freshly-sampled subject RE
-    drawn from the corresponding prior. This makes y_u_query etc. the
-    correct predictive distribution for an unseen DS child, rather than
-    the population-mean conditional distribution.
+    probabilities from one freshly-sampled subject RE per posterior draw. That
+    gives a coherent unseen-child trajectory across age rather than independent
+    one-age marginals at each plot or query point.
     """
     n_trials = context.model_data.n_trials
 
@@ -906,34 +905,24 @@ def sample_posterior_predictive(context: BivariateContext, definition=None):
 
     with context.model:
         # Subject-marginalised probabilities if subject REs are present.
-        # delta_subj_*_marg_{plot,query} are auxiliary RVs sampled from the
-        # subject-RE prior during sample_posterior_predictive — they are not
-        # part of the likelihood and do not affect posterior sampling.
+        # delta_subj_*_marg are auxiliary scalar RVs sampled from the subject-RE
+        # prior during sample_posterior_predictive. Reusing one scalar across
+        # plot/query ages makes y_*_plot a coherent unseen-child trajectory.
         if use_subject_re_u:
             tau_subj_u = context.model_variables["tau_subj_u"]
             f_u_plot_var = context.model_variables["f_u_plot"]
             f_u_query_var = context.model_variables["f_u_query"]
-            delta_u_plot_marg = pm.Normal(
-                "_delta_subj_u_plot_marg", mu=0.0, sigma=tau_subj_u, dims="plot_id"
-            )
-            delta_u_query_marg = pm.Normal(
-                "_delta_subj_u_query_marg", mu=0.0, sigma=tau_subj_u, dims="query_id"
-            )
-            p_u_plot = pm.math.sigmoid(f_u_plot_var + delta_u_plot_marg)
-            p_u_query = pm.math.sigmoid(f_u_query_var + delta_u_query_marg)
+            delta_u_marg = pm.Normal("_delta_subj_u_marg", mu=0.0, sigma=tau_subj_u)
+            p_u_plot = pm.math.sigmoid(f_u_plot_var + delta_u_marg)
+            p_u_query = pm.math.sigmoid(f_u_query_var + delta_u_marg)
 
         if use_subject_re_q:
             tau_subj_q = context.model_variables["tau_subj_q"]
             h_plot_var = context.model_variables["h_plot"]
             h_query_var = context.model_variables["h_query"]
-            delta_q_plot_marg = pm.Normal(
-                "_delta_subj_q_plot_marg", mu=0.0, sigma=tau_subj_q, dims="plot_id"
-            )
-            delta_q_query_marg = pm.Normal(
-                "_delta_subj_q_query_marg", mu=0.0, sigma=tau_subj_q, dims="query_id"
-            )
-            q_plot_marg = pm.math.sigmoid(h_plot_var + delta_q_plot_marg)
-            q_query_marg = pm.math.sigmoid(h_query_var + delta_q_query_marg)
+            delta_q_marg = pm.Normal("_delta_subj_q_marg", mu=0.0, sigma=tau_subj_q)
+            q_plot_marg = pm.math.sigmoid(h_plot_var + delta_q_marg)
+            q_query_marg = pm.math.sigmoid(h_query_var + delta_q_marg)
             p_s_plot = p_u_plot * q_plot_marg
             p_s_query = p_u_query * q_query_marg
         elif use_subject_re_u:

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -108,6 +108,7 @@ CELL_NAMES = ["neither", "sign_only", "speak_only", "both"]
 # Order of nz_01's three within-produced cells (the four-cell composition
 # conditioned on produced, dropping the unobservable "neither"/understood-only).
 PROD_CELL_NAMES = ["sign_only", "speak_only", "both"]
+PROD_CELL_COLUMNS = ["prod_signed_only", "prod_spoken_only", "prod_signed_spoken"]
 
 
 # ============================================================
@@ -623,7 +624,7 @@ def build_model(context: JointContext, definition: JointModelDefinition):
     idx_prod = np.where(has_prod_t)[0]
     if idx_prod.size:
         prod_counts = np.asarray(
-            df.loc[has_prod_t, ["prod_signed_only", "prod_spoken_only", "prod_signed_spoken"]],
+            df.loc[has_prod_t, PROD_CELL_COLUMNS],
             dtype=int,
         )
         prod_total = np.asarray(df.loc[has_prod_t, "prod_total"], dtype=int)
@@ -1059,6 +1060,30 @@ def diagnostics(context: JointContext):
     )
 
 
+def _extract_produced_cell_observations(
+    df: pd.DataFrame,
+    has_prod: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Observed nz_01 produced-cell counts and ages for rows flagged by ``has_prod``."""
+    if not has_prod.any():
+        return (
+            np.zeros((0, len(PROD_CELL_NAMES)), dtype=int),
+            np.zeros(0, dtype=float),
+        )
+
+    missing = [col for col in (*PROD_CELL_COLUMNS, "age") if col not in df.columns]
+    if missing:
+        raise ValueError(
+            "obs_prod_mask marks produced-cell rows, but analysis_df is missing "
+            f"columns: {', '.join(missing)}"
+        )
+
+    return (
+        np.asarray(df.loc[has_prod, PROD_CELL_COLUMNS], dtype=int),
+        np.asarray(df.loc[has_prod, "age"], dtype=float),
+    )
+
+
 def sample_posterior_predictive(context: JointContext, definition=None):
     """Posterior predictive for the observed cell-count likelihoods."""
     with context.model:
@@ -1096,11 +1121,7 @@ def sample_posterior_predictive(context: JointContext, definition=None):
         )
 
     has_prod = np.array(trace.constant_data["obs_prod_mask"].values, dtype=bool)
-    prod_counts = np.asarray(
-        df.loc[has_prod, ["prod_signed_only", "prod_spoken_only", "prod_signed_spoken"]],
-        dtype=int,
-    )
-    prod_ages = np.asarray(df.loc[has_prod, "age"], dtype=float)
+    prod_counts, prod_ages = _extract_produced_cell_observations(df, has_prod)
     if "nz_prod_cells_obs" in trace.posterior_predictive:
         prod_pred = np.array(
             trace.posterior_predictive["nz_prod_cells_obs"]

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -191,6 +191,11 @@ class JointModelSamples:
     cell_pred: np.ndarray  # (n_cells_obs, 4, n_samples) predicted
     cell_ages: np.ndarray  # (n_cells_obs,)
 
+    # nz_01 produced-cell posterior predictive (counts) and observed
+    prod_cell_obs: np.ndarray  # (n_prod_obs, 3) observed
+    prod_cell_pred: np.ndarray  # (n_prod_obs, 3, n_samples) predicted
+    prod_cell_ages: np.ndarray  # (n_prod_obs,)
+
 
 JointContext = ModelFitContext[JointModelConfiguration, JointModelSamples]
 
@@ -734,6 +739,7 @@ def build_model(context: JointContext, definition: JointModelDefinition):
         if use_subject_codes:
             subject_obs = pm.Data("subject_obs", subject_codes, dims=("obs_id",))
         _ = pm.Data("obs_cells_mask", has_cells_t.astype(int), dims=("obs_id",))
+        _ = pm.Data("obs_prod_mask", has_prod_t.astype(int), dims=("obs_id",))
 
         # Latent full-grid trajectories (plain tensors), built by the shared
         # gp_utils helpers. Option D anchors each GP (per-draw zero at the
@@ -1054,10 +1060,13 @@ def diagnostics(context: JointContext):
 
 
 def sample_posterior_predictive(context: JointContext, definition=None):
-    """Posterior predictive for the uk_02 four cells (for the cell PPC)."""
+    """Posterior predictive for the observed cell-count likelihoods."""
     with context.model:
+        var_names = ["cells_obs"]
+        if "nz_prod_cells_obs" in context.model.named_vars:
+            var_names.append("nz_prod_cells_obs")
         trace = pm.sample_posterior_predictive(
-            context.trace, var_names=["cells_obs"], extend_inferencedata=True,
+            context.trace, var_names=var_names, extend_inferencedata=True,
             progressbar=sys.stdout.isatty(),
             random_seed=context.sampling.random_seed,
         )
@@ -1086,6 +1095,28 @@ def sample_posterior_predictive(context: JointContext, definition=None):
             "stored mask and likelihood rows are misaligned."
         )
 
+    has_prod = np.array(trace.constant_data["obs_prod_mask"].values, dtype=bool)
+    prod_counts = np.asarray(
+        df.loc[has_prod, ["prod_signed_only", "prod_spoken_only", "prod_signed_spoken"]],
+        dtype=int,
+    )
+    prod_ages = np.asarray(df.loc[has_prod, "age"], dtype=float)
+    if "nz_prod_cells_obs" in trace.posterior_predictive:
+        prod_pred = np.array(
+            trace.posterior_predictive["nz_prod_cells_obs"]
+            .stack(sample=("chain", "draw"))
+            .transpose("obs_prod_id", "prod_cell_id", "sample")
+            .values
+        )
+        if int(has_prod.sum()) != prod_pred.shape[0]:
+            raise ValueError(
+                f"obs_prod_mask count ({int(has_prod.sum())}) does not match "
+                f"posterior predictive nz_prod_cells_obs length ({prod_pred.shape[0]}); "
+                "stored mask and likelihood rows are misaligned."
+            )
+    else:
+        prod_pred = np.zeros((0, len(PROD_CELL_NAMES), 0), dtype=int)
+
     samples = JointModelSamples(
         X_plot=np.array(trace.constant_data["X_plot"].values),
         X_query=np.array(trace.constant_data["X_query"].values),
@@ -1107,6 +1138,9 @@ def sample_posterior_predictive(context: JointContext, definition=None):
         cell_obs=cell_counts,
         cell_pred=cell_pred,
         cell_ages=cell_ages,
+        prod_cell_obs=prod_counts,
+        prod_cell_pred=prod_pred,
+        prod_cell_ages=prod_ages,
     )
     context.set_model_samples(samples)
 
@@ -1288,6 +1322,38 @@ def _run_joint_plots(context: JointContext):
     fig.savefig(os.path.join(od, "uk02_cell_ppc.svg"))
     context.plots["uk02_cell_ppc"] = fig
     plt.close(fig)
+
+    # 6) nz_01 produced-cell PPC (observed vs predicted produced-cell totals)
+    if s.prod_cell_obs.size and s.prod_cell_pred.size:
+        fig, ax = plt.subplots(figsize=plot_styles.FIGSIZE_MD)
+        obs_tot = s.prod_cell_obs.sum(axis=0)  # (3,)
+        pred_tot = s.prod_cell_pred.sum(axis=0)  # (3, n_samples)
+        pred_med = np.median(pred_tot, axis=1)
+        lo, hi = 100 * (1 - hdi) / 2, 100 * (1 + hdi) / 2
+        pred_lo = np.percentile(pred_tot, lo, axis=1)
+        pred_hi = np.percentile(pred_tot, hi, axis=1)
+        yerr = np.vstack([pred_med - pred_lo, pred_hi - pred_med])
+        xpos = np.arange(len(PROD_CELL_NAMES))
+        ax.bar(xpos - 0.18, obs_tot, width=0.36, color="C0", label="observed")
+        ax.bar(
+            xpos + 0.18,
+            pred_med,
+            width=0.36,
+            color="C3",
+            alpha=0.7,
+            label="predicted (median)",
+            yerr=yerr,
+            capsize=4,
+        )
+        ax.set_xticks(xpos)
+        ax.set_xticklabels(PROD_CELL_NAMES)
+        ax.set_ylabel("Total produced-cell count (nz_01)")
+        ax.legend(frameon=True)
+        ax.set_title("nz_01 produced-cell posterior predictive check")
+        fig.savefig(os.path.join(od, "nz01_produced_cell_ppc.png"), dpi=300)
+        fig.savefig(os.path.join(od, "nz01_produced_cell_ppc.svg"))
+        context.plots["nz01_produced_cell_ppc"] = fig
+        plt.close(fig)
 
 
 # ============================================================

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -32,6 +32,12 @@ def _hdi_by_sample(values: np.ndarray, prob: float) -> np.ndarray:
     return az.hdi(values_da, prob=prob, dim="sample").to_numpy()
 
 
+def _hdi_by_row(values: np.ndarray, prob: float) -> np.ndarray:
+    """Compute HDI over the second axis for each row of ``values``."""
+    values_da = xr.DataArray(np.asarray(values).T, dims=("sample", "point"))
+    return az.hdi(values_da, prob=prob, dim="sample").to_numpy()
+
+
 # ------------------------------------------------------------
 # Prior predictive plots
 # ------------------------------------------------------------
@@ -291,11 +297,12 @@ def plot_posterior_predictive_pmf(
     plt.figure(figsize=plot_styles.FIGSIZE_XL)
 
     for _a, j in zip(X_query, idxs, strict=True):
-        draws = np.clip(y_plot[j, :].astype(int), x_lo, x_hi)
+        draws = y_plot[j, :].astype(int)
 
         # Empirical PMF on common support
-        counts = np.bincount(draws - x_lo, minlength=len(k))
-        pmf = counts[: len(k)] / counts.sum()
+        in_support = (draws >= x_lo) & (draws <= x_hi)
+        counts = np.bincount(draws[in_support] - x_lo, minlength=len(k))
+        pmf = counts[: len(k)] / draws.size
         # Step line (discrete PMF)
         plt.step(k, pmf, where="mid", lw=2, label=f"{X_plot[j]:.0f}m")
 
@@ -313,9 +320,10 @@ def plot_posterior_predictive_pmf(
         _save_png_svg(plt.gcf(), output_dir, filename)
         csv_data = {"word_count": k}
         for _a, j in zip(X_query, idxs, strict=True):
-            draws = np.clip(y_plot[j, :].astype(int), x_lo, x_hi)
-            counts = np.bincount(draws - x_lo, minlength=len(k))
-            pmf = counts[: len(k)] / counts.sum()
+            draws = y_plot[j, :].astype(int)
+            in_support = (draws >= x_lo) & (draws <= x_hi)
+            counts = np.bincount(draws[in_support] - x_lo, minlength=len(k))
+            pmf = counts[: len(k)] / draws.size
             csv_data[f"pmf_{X_plot[j]:.0f}m"] = pmf
         _save_csv(pd.DataFrame(csv_data), output_dir, filename)
 
@@ -880,13 +888,11 @@ def plot_posterior_kappa(
     X_query = np.asarray(X_query, dtype=float).reshape(-1)
     kappa_query_samps = np.asarray(kappa_query)
 
-    q_lo = (1.0 - hdi_prob) / 2.0
-    q_hi = 1.0 - q_lo
-
     # --- Plot grid ---
-    kappa_plot_lo = np.quantile(kappa_plot_samps, q_lo, axis=1)
     kappa_plot_med = np.quantile(kappa_plot_samps, 0.5, axis=1)
-    kappa_plot_hi = np.quantile(kappa_plot_samps, q_hi, axis=1)
+    kappa_plot_hdi = _hdi_by_row(kappa_plot_samps, hdi_prob)
+    kappa_plot_lo = kappa_plot_hdi[:, 0]
+    kappa_plot_hi = kappa_plot_hdi[:, 1]
 
     df_kappa_plot = pd.DataFrame(
         {
@@ -901,9 +907,10 @@ def plot_posterior_kappa(
 
     # --- Query ages ---
 
-    kappa_query_lo = np.quantile(kappa_query_samps, q_lo, axis=1)
     kappa_query_med = np.quantile(kappa_query_samps, 0.5, axis=1)
-    kappa_query_hi = np.quantile(kappa_query_samps, q_hi, axis=1)
+    kappa_query_hdi = _hdi_by_row(kappa_query_samps, hdi_prob)
+    kappa_query_lo = kappa_query_hdi[:, 0]
+    kappa_query_hi = kappa_query_hdi[:, 1]
 
     df_kappa_query = pd.DataFrame(
         {
@@ -926,7 +933,7 @@ def plot_posterior_kappa(
         kappa_plot_lo,
         kappa_plot_hi,
         alpha=0.25,
-        label=f"{int(hdi_prob * 100)}% credible interval",
+        label=f"{int(hdi_prob * 100)}% HDI",
     )
     ax.plot(X_plot, kappa_plot_med, lw=2.5, label="Median κ(age)")
 

--- a/tests/test_bivariate_re_holdout_mask.py
+++ b/tests/test_bivariate_re_holdout_mask.py
@@ -16,6 +16,7 @@ No graphviz / ``dot`` binary is required.
 """
 
 import os
+from dataclasses import replace
 
 import dse_research_utils.statistics.models.data as model_data
 import dse_research_utils.statistics.models.pymc_utils as pymc_utils
@@ -50,7 +51,7 @@ def _as_dataset(node):
     return node if isinstance(node, xr.Dataset) else node.to_dataset()
 
 
-def _build_holdout_model(tmp_path, monkeypatch):
+def _build_holdout_model(tmp_path, monkeypatch, definition=VG07):
     """Build the real VG07 model on synthetic data carrying a ``holdout`` column.
 
     Returns the populated context plus the synthetic ``understood`` / ``spoken``
@@ -83,6 +84,7 @@ def _build_holdout_model(tmp_path, monkeypatch):
             "spoken": spoken,
             "study": ["study_a"] * (n // 2) + ["study_b"] * (n - n // 2),
             "study_code": [0] * (n // 2) + [1] * (n - n // 2),
+            "subject_code": np.repeat(np.arange(n // 2), 2),
             "holdout": holdout,
         }
     )
@@ -101,11 +103,11 @@ def _build_holdout_model(tmp_path, monkeypatch):
     bmd = model_data.BinomialModelData(
         X_obs=ages.reshape(-1, 1),
         y_obs=np.zeros(n, dtype=int),
-        n_trials=VG07.n_trials,
+        n_trials=definition.n_trials,
     )
     context.set_model_data(bmd, analysis_df)
-    configure_bivariate_priors(context, VG07)
-    build_model_re(context, VG07)
+    configure_bivariate_priors(context, definition)
+    build_model_re(context, definition)
 
     return context, understood, spoken, holdout
 
@@ -149,6 +151,21 @@ def test_holdout_masks_round_trip_through_extract_model_samples(tmp_path, monkey
     np.testing.assert_array_equal(np.isnan(samples.y_s_obs), ~has_s_train)
     np.testing.assert_array_equal(samples.y_u_obs[has_u_train], understood[has_u_train])
     np.testing.assert_array_equal(samples.y_s_obs[has_s_train], spoken[has_s_train])
+
+
+def test_subject_marginal_predictive_uses_one_new_subject_per_draw(tmp_path, monkeypatch):
+    definition = replace(VG07, use_subject_re_u=True, use_subject_re_q=True)
+    context, *_ = _build_holdout_model(tmp_path, monkeypatch, definition)
+
+    context.set_trace(_prior_as_posterior_trace(context))
+    sample_posterior_predictive(context, definition)
+
+    assert "_delta_subj_u_plot_marg" not in context.model.named_vars
+    assert "_delta_subj_u_query_marg" not in context.model.named_vars
+    assert "_delta_subj_q_plot_marg" not in context.model.named_vars
+    assert "_delta_subj_q_query_marg" not in context.model.named_vars
+    assert context.model.named_vars["_delta_subj_u_marg"].ndim == 0
+    assert context.model.named_vars["_delta_subj_q_marg"].ndim == 0
 
 
 def test_extract_model_samples_guards_against_misaligned_mask(tmp_path, monkeypatch):

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -67,6 +67,15 @@ def test_evaluate_at_ages_interp_and_out_of_range():
     assert np.isnan(comparison.evaluate_at_ages(Y, ages, np.array([25.0]))[0])
 
 
+def test_interp_draws_out_of_range_returns_nan():
+    ages = np.array([0.0, 10.0, 20.0])
+    Y = np.array([[0.0, 100.0, 200.0]])
+    out = comparison.interp_draws(ages, Y, np.array([-1.0, 5.0, 21.0]))
+    assert np.isnan(out[0, 0])
+    assert np.isclose(out[0, 1], 50.0)
+    assert np.isnan(out[0, 2])
+
+
 # ---- HDI / summary ----
 def test_hdi_from_samples_uniform_grid():
     x = np.linspace(0.0, 1.0, 1001)
@@ -99,6 +108,24 @@ def test_compute_q_at_U_constant_ratio():
     S = 0.3 * U
     q = comparison.compute_q_at_U(ages, U, S, np.array([100.0, 400.0]))
     assert np.allclose(q[~np.isnan(q)], 0.3, atol=1e-6)
+
+
+def test_comprehension_equivalent_age_uses_first_crossing_for_nonmonotone_reference():
+    ages_ds = np.array([0.0, 1.0])
+    U_ds = np.array([[0.0, 7.0]])
+    S_ds = U_ds.copy()
+    ages_td = np.array([0.0, 1.0, 2.0, 3.0])
+    # This reference draw first crosses 7 words between ages 0 and 1, then dips.
+    # Plain np.interp(target, W, ages) is undefined here because W is not sorted.
+    U_td = np.array([[0.0, 10.0, 5.0, 15.0]])
+    S_td = U_td.copy()
+
+    out = comparison.comprehension_equivalent_age(
+        ages_ds, U_ds, S_ds, ages_td, U_td, S_td, np.array([1.0])
+    )
+
+    assert np.isclose(out["cea_U"][0, 0], 0.7)
+    assert np.isclose(out["cea_S"][0, 0], 0.7)
 
 
 def test_invert_curve_linear():

--- a/tests/test_nz01_produced_cells.py
+++ b/tests/test_nz01_produced_cells.py
@@ -61,7 +61,7 @@ def test_nz01_loader_maps_cells_and_drops_zero_produced(tmp_path, monkeypatch):
     )
 
 
-def _prepare(tmp_path, monkeypatch, definition):
+def _prepare_context(tmp_path, monkeypatch, definition):
     """Run ``prepare_joint_data`` for ``definition`` with nz_01 + uk_02 fixtures."""
     monkeypatch.setattr(env, "DATA_DIR", str(tmp_path))
     _write_nz01_csv(tmp_path / "vocab_data_nz_01.csv")
@@ -106,6 +106,12 @@ def _prepare(tmp_path, monkeypatch, definition):
         sampling=sampling.get_sampling_configuration("test"),
     )
     cjm.prepare_joint_data(context, definition)
+    return context
+
+
+def _prepare(tmp_path, monkeypatch, definition):
+    """Return the prepared analysis frame for ``definition``."""
+    context = _prepare_context(tmp_path, monkeypatch, definition)
     return context.analysis_df
 
 
@@ -135,3 +141,15 @@ def test_prepare_joint_data_excludes_nz01_when_flag_false(tmp_path, monkeypatch)
         assert analysis_df["prod_signed_spoken"].notna().sum() == 0
     # ...and the nz_01 marginal is still excluded (not silently re-added as marginal).
     assert "nz_marginal_only" not in set(analysis_df["subject_id"])
+
+
+def test_build_model_registers_nz01_produced_cell_likelihood(tmp_path, monkeypatch):
+    context = _prepare_context(tmp_path, monkeypatch, VG15)
+    monkeypatch.setattr(cjm, "_plot_and_print_dist", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cjm, "render_model_graph", lambda *args, **kwargs: None)
+
+    cjm.configure_joint_priors(context, VG15)
+    cjm.build_model(context, VG15)
+
+    assert "obs_prod_mask" in context.model.named_vars
+    assert "nz_prod_cells_obs" in context.model.named_vars

--- a/tests/test_nz01_produced_cells.py
+++ b/tests/test_nz01_produced_cells.py
@@ -18,6 +18,7 @@ import dse_research_utils.statistics.models.reporting as reporting
 import dse_research_utils.statistics.models.sampling as sampling
 import numpy as np
 import pandas as pd
+import pytest
 
 import vocab_growth.environment as env
 from vocab_growth.models import common_joint_modality as cjm
@@ -141,6 +142,24 @@ def test_prepare_joint_data_excludes_nz01_when_flag_false(tmp_path, monkeypatch)
         assert analysis_df["prod_signed_spoken"].notna().sum() == 0
     # ...and the nz_01 marginal is still excluded (not silently re-added as marginal).
     assert "nz_marginal_only" not in set(analysis_df["subject_id"])
+
+
+def test_produced_cell_observation_extraction_tolerates_empty_mask_without_columns():
+    df = pd.DataFrame({"age": [30.0, 48.0]})
+    counts, ages = cjm._extract_produced_cell_observations(
+        df,
+        np.zeros(len(df), dtype=bool),
+    )
+
+    assert counts.shape == (0, len(cjm.PROD_CELL_NAMES))
+    assert ages.shape == (0,)
+
+
+def test_produced_cell_observation_extraction_rejects_inconsistent_mask():
+    df = pd.DataFrame({"age": [30.0]})
+
+    with pytest.raises(ValueError, match="obs_prod_mask marks produced-cell rows"):
+        cjm._extract_produced_cell_observations(df, np.array([True]))
 
 
 def test_build_model_registers_nz01_produced_cell_likelihood(tmp_path, monkeypatch):

--- a/tests/test_plotting_helpers.py
+++ b/tests/test_plotting_helpers.py
@@ -5,6 +5,7 @@ import os
 import types
 
 import numpy as np
+import pandas as pd
 import pytest
 from matplotlib.figure import Figure
 
@@ -12,6 +13,8 @@ from vocab_growth.plotting import (
     _maybe_savgol,
     _resolve_savgol_window_length,
     plot_comprehension_production_gap,
+    plot_posterior_kappa,
+    plot_posterior_predictive_pmf,
     plot_production_rate,
 )
 
@@ -43,6 +46,39 @@ def test_plot_comprehension_production_gap_returns_figure_and_writes_files(tmp_p
     assert isinstance(fig, Figure)
     for ext in ("png", "svg", "csv"):
         assert os.path.exists(os.path.join(str(tmp_path), f"gap.{ext}"))
+
+
+def test_plot_posterior_predictive_pmf_does_not_fold_tails_into_endpoints(tmp_path):
+    draws = np.array([0] * 5 + [1] * 495 + [2] * 495 + [10] * 5)
+    plot_posterior_predictive_pmf(
+        X_query=np.array([12.0]),
+        X_plot=np.array([12.0]),
+        y_plot=draws.reshape(1, -1),
+        n_trials=10,
+        output_dir=str(tmp_path),
+        filename="pmf",
+    )
+
+    pmf = pd.read_csv(tmp_path / "pmf.csv")
+    assert pmf["word_count"].tolist() == [1, 2]
+    np.testing.assert_allclose(pmf["pmf_12m"].to_numpy(), [0.495, 0.495])
+
+
+def test_plot_posterior_kappa_reports_hdi_not_equal_tailed_interval():
+    kappa = np.array([[1.0, 2.0, 3.0, 4.0, 100.0]])
+    _fig, df_plot, df_query = plot_posterior_kappa(
+        X_plot=np.array([12.0]),
+        kappa_plot=kappa,
+        X_query=np.array([12.0]),
+        kappa_query=kappa,
+        n_trials=800,
+        hdi_prob=0.60,
+    )
+
+    # The 60% HDI excludes the far outlier; the equal-tailed 60% upper bound would
+    # be much larger for this deliberately skewed sample.
+    assert df_plot.loc[0, "kappa_hi"] < 10.0
+    assert df_query.loc[0, "kappa_hi"] < 10.0
 
 
 @pytest.mark.parametrize("n", [5, 7, 15, 21, 100])


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Codex/GPT-5).

## Summary

This PR fixes the Python best-practice review findings from the repository pass:

- preserves duplicate observations in the DuckDB `vocab_combined` view by switching the data-prep SQL to `UNION ALL`
- makes bivariate subject-random-effect posterior predictive trajectories coherent by drawing one new subject intercept per posterior draw
- changes comprehension-equivalent-age inversion to use first-crossing logic rather than assuming monotone GP trajectories
- includes VG15 `nz_01` produced-cell likelihoods in posterior predictive checks and adds the corresponding PPC plot
- prevents posterior predictive PMF tails from being folded into endpoint bins
- reports actual HDIs for posterior kappa summaries
- configures Ruff to allow intentional Jupytext notebook display expressions

## Validation

- `ruff check src/ scripts/ tests/ notebooks/001-vocab-data-variables.py`
- `env PYTENSOR_FLAGS=base_compiledir=/private/tmp/pytensor NUMBA_CACHE_DIR=/private/tmp/numba-cache conda run -n dse-vocab-growth pytest`
- `conda run -n dse-vocab-growth python scripts/prepare_data.py`

The PyTensor/Numba cache variables are needed in the sandbox so compiled files are written under `/private/tmp` rather than `~/.pytensor`.