### PR TITLE
feat(plotting): individual per-age posterior-predictive plots (#123)

### DIFF
--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -2,6 +2,7 @@ approximator
 apraxia
 arrowsize
 ArviZ
+asis
 Bello
 Berglund
 BFMI

--- a/docs/models/vg01/index.qmd
+++ b/docs/models/vg01/index.qmd
@@ -179,7 +179,13 @@ The cumulative sum of the PMF: the probability that the count of words spoken is
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions")
+```
 
 ### Posterior predictive median trend with uncertainty intervals
 

--- a/docs/models/vg02/index.qmd
+++ b/docs/models/vg02/index.qmd
@@ -179,7 +179,13 @@ The cumulative sum of the PMF: the probability that the count of words understoo
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions")
+```
 
 ### Posterior predictive median trend with uncertainty intervals
 

--- a/docs/models/vg03/index.qmd
+++ b/docs/models/vg03/index.qmd
@@ -179,7 +179,13 @@ The cumulative sum of the PMF: the probability that the count of words spoken is
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions")
+```
 
 ### Posterior predictive median trend with uncertainty intervals
 

--- a/docs/models/vg04/index.qmd
+++ b/docs/models/vg04/index.qmd
@@ -179,7 +179,13 @@ The cumulative sum of the PMF: the probability that the count of words understoo
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions")
+```
 
 ### Posterior predictive median trend with uncertainty intervals
 

--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -225,7 +225,13 @@ posterior_summary_u
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_u")
+```
 
 ### Median trend
 
@@ -262,7 +268,13 @@ posterior_summary_s
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_s")
+```
 
 ### Median trend
 

--- a/docs/models/vg07/index.qmd
+++ b/docs/models/vg07/index.qmd
@@ -220,7 +220,13 @@ posterior_summary_u
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_u")
+```
 
 ### Median trend
 
@@ -257,7 +263,13 @@ posterior_summary_s
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_s")
+```
 
 ### Median trend
 

--- a/docs/models/vg08/index.qmd
+++ b/docs/models/vg08/index.qmd
@@ -236,7 +236,13 @@ posterior_summary_u
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_u")
+```
 
 ### Median trend
 
@@ -273,7 +279,13 @@ posterior_summary_s
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_s")
+```
 
 ### Median trend
 

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -234,7 +234,13 @@ posterior_summary_u
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_u")
+```
 
 ### Median trend
 
@@ -271,7 +277,13 @@ posterior_summary_s
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_s")
+```
 
 ### Median trend
 

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -249,7 +249,13 @@ posterior_summary_u
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_u")
+```
 
 ### Median trend
 
@@ -286,7 +292,13 @@ posterior_summary_s
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_s")
+```
 
 ### Median trend
 

--- a/docs/models/vg11/index.qmd
+++ b/docs/models/vg11/index.qmd
@@ -184,7 +184,13 @@ The cumulative sum of the PMF: the probability that the count of words spoken is
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions")
+```
 
 ### Posterior predictive median trend with uncertainty intervals
 

--- a/docs/models/vg12/index.qmd
+++ b/docs/models/vg12/index.qmd
@@ -184,7 +184,13 @@ The cumulative sum of the PMF: the probability that the count of words understoo
 
 ### Posterior predictive probability distributions for word counts, by age
 
-![posterior_predictive_count_distributions](posterior_predictive_count_distributions.png){#fig-posterior-predictive-count-distributions .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions")
+```
 
 ### Posterior predictive median trend with uncertainty intervals
 

--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -237,7 +237,13 @@ posterior_summary_u
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_u")
+```
 
 ### Median trend
 
@@ -272,7 +278,13 @@ posterior_summary_s
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_s")
+```
 
 ### Median trend
 

--- a/docs/models/vg14/index.qmd
+++ b/docs/models/vg14/index.qmd
@@ -301,7 +301,13 @@ posterior_summary_u
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_u](posterior_predictive_count_distributions_u.png){#fig-count-dist-u .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_u")
+```
 
 ### Median trend
 
@@ -338,7 +344,13 @@ posterior_summary_s
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_s](posterior_predictive_count_distributions_s.png){#fig-count-dist-s .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_s")
+```
 
 ### Median trend
 
@@ -375,7 +387,13 @@ posterior_summary_sign
 
 ### Count distributions by age
 
-![posterior_predictive_count_distributions_sign](posterior_predictive_count_distributions_sign.png){#fig-count-dist-sign .lightbox fig-align="left"}
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.plotting import ppc_count_distribution_gallery
+
+ppc_count_distribution_gallery("posterior_predictive_count_distributions_sign")
+```
 
 ### Median trend
 

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -159,6 +159,78 @@ def plot_prior_predictions(
     return plt.gcf()
 
 
+def _draw_ppc_count_distribution(
+    ax,
+    age: float,
+    draws: np.ndarray,
+    n_trials: int,
+    bin_width: int,
+    hdi_prob: float,
+    eti_prob: float | None,
+    q_lo: float,
+    q_hi: float,
+) -> None:
+    """Draw one query age's posterior predictive count distribution on ``ax``.
+
+    Shared by the combined grid figure and the individual per-age figures
+    (issue #123). Does not set the x-axis label — the caller owns that, so the
+    combined grid can label only its bottom row.
+    """
+    bins = np.arange(0, n_trials + bin_width + 1, bin_width)
+    centres = (bins[:-1] + bins[1:]) / 2
+    draws = draws.astype(int)
+
+    counts, _ = np.histogram(draws, bins=bins)
+    pmf_bins = counts / counts.sum()
+
+    med = np.median(draws)
+    hdi = az.hdi(draws, prob=hdi_prob)  # (lo, hi)
+
+    ylim_max = max(pmf_bins.max() * 1.08, 0.25)
+
+    # HDI
+    ax.fill_betweenx(
+        [0, ylim_max * 0.96], hdi[0], hdi[1], color=plot_styles.COLOUR_GREEN, alpha=0.10
+    )
+    ax.text(
+        hdi[1] + 150,
+        ylim_max * 0.9,
+        f"{int(hdi_prob*100)}% HPDI: {hdi[0]:.0f} to {hdi[1]:.0f}",
+        color=plot_styles.COLOUR_GREEN,
+        ha="center",
+    )
+
+    if eti_prob is not None:
+        eti_lo, eti_hi = np.quantile(draws, [q_lo, q_hi])
+        ax.fill_betweenx([0, ylim_max * 0.96], eti_lo, eti_hi, color=plot_styles.COLOUR_ORANGE, alpha=0.10)
+        ax.text(
+            eti_hi + 150,
+            ylim_max * 0.82,
+            f"{int(eti_prob*100)}% ETI: {eti_lo:.0f} to {eti_hi:.0f}",
+            color=plot_styles.COLOUR_ORANGE,
+            ha="center",
+        )
+
+    # PMF histogram
+    ax.bar(centres, pmf_bins, width=bin_width, color=plot_styles.COLOUR_BLUE, align="center")
+
+    # median
+    ax.axvline(med, lw=2, ls="--", color=plot_styles.COLOUR_RED)
+    ax.text(
+        med + 110,
+        ylim_max * 0.98,
+        f"median: {med:.0f}",
+        color=plot_styles.COLOUR_RED,
+        ha="center",
+    )
+
+    ax.set_title(f"{age:.1f} months")
+    ax.set_ylim(0, ylim_max)
+    ax.set_ylabel(f"Posterior predictive probability mass (bin width {bin_width})")
+    ax.set_xlim(0, n_trials)
+    ax.set_xticks(np.arange(0, n_trials + 1, 100))
+
+
 def plot_posterior_predictive_count_distributions_by_query_age(
     X_query: np.ndarray,
     y_query: np.ndarray,
@@ -173,14 +245,14 @@ def plot_posterior_predictive_count_distributions_by_query_age(
 ) -> Figure:
     """
     For each query age, plot the posterior predictive distribution of counts, as a histogram.
-    """
-    bins = np.arange(0, n_trials + bin_width + 1, bin_width)
-    centres = (bins[:-1] + bins[1:]) / 2
-    nq = len(X_query)
 
-    plot_rows = int(np.ceil(nq / plot_cols))
-    fig, axes = plt.subplots(plot_rows, plot_cols, figsize=(10, 3.8 * plot_rows), sharex=False)
-    axes = np.atleast_1d(axes).ravel()
+    Returns the combined grid figure (one subplot per query age). When
+    ``output_dir``/``filename`` are given, also writes each age as its own file
+    ``{filename}_{age}m.{png,svg}`` alongside the combined figure, so the
+    distributions can be embedded individually and flexibly in reports
+    (issue #123).
+    """
+    nq = len(X_query)
 
     # ETI quantile levels matching context.reporting.hdi mass (e.g., 0.90 -> [0.05, 0.95])
     if eti_prob is not None:
@@ -189,62 +261,14 @@ def plot_posterior_predictive_count_distributions_by_query_age(
     else:
         q_lo, q_hi = 0, 0
 
+    plot_rows = int(np.ceil(nq / plot_cols))
+    fig, axes = plt.subplots(plot_rows, plot_cols, figsize=(10, 3.8 * plot_rows), sharex=False)
+    axes = np.atleast_1d(axes).ravel()
+
     for j, age in enumerate(X_query):
-        ax = axes[j]
-        draws = y_query[j, :].astype(int)
-        counts, _ = np.histogram(draws, bins=bins)
-        pmf_bins = counts / counts.sum()
-
-        med = np.median(draws)
-        hdi = az.hdi(draws, prob=hdi_prob)  # (lo, hi)
-
-        if eti_prob is not None:
-            eti_lo, eti_hi = np.quantile(draws, [q_lo, q_hi])
-        else:
-            eti_lo, eti_hi = 0, 0
-
-        ylim_max = max(pmf_bins.max() * 1.08, 0.25)
-
-        # HDI
-        ax.fill_betweenx(
-            [0, ylim_max * 0.96], hdi[0], hdi[1], color=plot_styles.COLOUR_GREEN, alpha=0.10
+        _draw_ppc_count_distribution(
+            axes[j], age, y_query[j, :], n_trials, bin_width, hdi_prob, eti_prob, q_lo, q_hi
         )
-        ax.text(
-            hdi[1] + 150,
-            ylim_max * 0.9,
-            f"{int(hdi_prob*100)}% HPDI: {hdi[0]:.0f} to {hdi[1]:.0f}",
-            color=plot_styles.COLOUR_GREEN,
-            ha="center",
-        )
-
-        if eti_prob is not None:
-            ax.fill_betweenx([0, ylim_max * 0.96], eti_lo, eti_hi, color=plot_styles.COLOUR_ORANGE, alpha=0.10)
-            ax.text(
-                eti_hi + 150,
-                ylim_max * 0.82,
-                f"{int(eti_prob*100)}% ETI: {eti_lo:.0f} to {eti_hi:.0f}",
-                color=plot_styles.COLOUR_ORANGE,
-                ha="center",
-            )
-
-        # PMF histogram
-        ax.bar(centres, pmf_bins, width=bin_width, color=plot_styles.COLOUR_BLUE, align="center")
-
-        # median
-        ax.axvline(med, lw=2, ls="--", color=plot_styles.COLOUR_RED)
-        ax.text(
-            med + 110,
-            ylim_max * 0.98,
-            f"median: {med:.0f}",
-            color=plot_styles.COLOUR_RED,
-            ha="center",
-        )
-
-        ax.set_title(f"{age:.1f} months")
-        ax.set_ylim(0, ylim_max)
-        ax.set_ylabel(f"Posterior predictive probability mass (bin width {bin_width})")
-        ax.set_xlim(0, n_trials)
-        ax.set_xticks(np.arange(0, n_trials + 1, 100))
 
     for k in range(nq, len(axes)):
         axes[k].axis("off")
@@ -255,7 +279,18 @@ def plot_posterior_predictive_count_distributions_by_query_age(
     fig.suptitle("Posterior predictive distributions at query ages", y=1.02)
 
     if filename is not None and output_dir is not None:
-        _save_png_svg(plt.gcf(), output_dir, filename)
+        _save_png_svg(fig, output_dir, filename)
+
+        # Individual per-age figures, for flexible reuse in reports (issue #123).
+        for j, age in enumerate(X_query):
+            fig_i, ax_i = plt.subplots(figsize=(10, 3.8))
+            _draw_ppc_count_distribution(
+                ax_i, age, y_query[j, :], n_trials, bin_width, hdi_prob, eti_prob, q_lo, q_hi
+            )
+            ax_i.set_xlabel(f"{x_label} (bins of {bin_width})")
+            _save_png_svg(fig_i, output_dir, f"{filename}_{age:g}m")
+            plt.close(fig_i)
+
         rows = []
         for j, age in enumerate(X_query):
             draws = y_query[j, :].astype(int)
@@ -268,6 +303,40 @@ def plot_posterior_predictive_count_distributions_by_query_age(
         _save_csv(pd.DataFrame(rows), output_dir, filename)
 
     return fig
+
+
+def ppc_count_distribution_gallery(
+    prefix: str, *, ncol: int = 2, directory: str = "."
+) -> None:
+    """Emit a Quarto column layout of the individual per-age posterior predictive
+    count-distribution plots (issue #123).
+
+    Intended for a model report cell with ``#| output: asis``. Globs
+    ``{prefix}_<age>m.png`` in ``directory``, and prints one lightboxed image per
+    age, sorted by age. Falls back to the combined grid figure ``{prefix}.png``
+    when no per-age files are present (e.g. before a model is re-fit with the
+    individual plots), so the report section is never empty. Prints nothing if
+    neither is present.
+    """
+    import glob
+    import re
+
+    def _age(path: str) -> float:
+        m = re.search(r"_(\d+(?:\.\d+)?)m\.png$", os.path.basename(path))
+        return float(m.group(1)) if m else float("inf")
+
+    files = sorted(glob.glob(os.path.join(directory, f"{prefix}_*m.png")), key=_age)
+    if not files:
+        combined = os.path.join(directory, f"{prefix}.png")
+        if os.path.exists(combined):
+            print(f'![]({os.path.basename(combined)}){{.lightbox fig-align="left"}}')
+        return
+
+    print(f"::: {{layout-ncol={ncol}}}")
+    for path in files:
+        print(f"![{_age(path):g} months]({os.path.basename(path)}){{.lightbox}}")
+        print()
+    print(":::")
 
 def plot_posterior_predictive_pmf(
     X_query: np.ndarray,

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -325,7 +325,9 @@ def ppc_count_distribution_gallery(
         m = re.search(r"_(\d+(?:\.\d+)?)m\.png$", os.path.basename(path))
         return float(m.group(1)) if m else float("inf")
 
-    files = sorted(glob.glob(os.path.join(directory, f"{prefix}_*m.png")), key=_age)
+    candidates = glob.glob(os.path.join(directory, f"{prefix}_*m.png"))
+    files = [path for path in candidates if _age(path) != float("inf")]
+    files.sort(key=_age)
     if not files:
         combined = os.path.join(directory, f"{prefix}.png")
         if os.path.exists(combined):

--- a/tests/test_plotting_helpers.py
+++ b/tests/test_plotting_helpers.py
@@ -14,8 +14,10 @@ from vocab_growth.plotting import (
     _resolve_savgol_window_length,
     plot_comprehension_production_gap,
     plot_posterior_kappa,
+    plot_posterior_predictive_count_distributions_by_query_age,
     plot_posterior_predictive_pmf,
     plot_production_rate,
+    ppc_count_distribution_gallery,
 )
 
 
@@ -120,3 +122,50 @@ def test_maybe_savgol_passthrough_when_disabled():
     np.testing.assert_array_equal(out, y)
     # The returned array is always float (the smoothing path returns floats too).
     assert out.dtype == float
+
+
+def test_count_distributions_writes_combined_and_individual_files(tmp_path):
+    # issue #123: alongside the combined grid, one figure is written per query age.
+    rng = np.random.default_rng(0)
+    X_query = np.array([12.0, 24.0])
+    y_query = rng.integers(0, 800, size=(2, 200))
+    fig = plot_posterior_predictive_count_distributions_by_query_age(
+        X_query=X_query,
+        y_query=y_query,
+        n_trials=800,
+        output_dir=str(tmp_path),
+        filename="ppc",
+    )
+    assert isinstance(fig, Figure)
+    # combined figure + per-age summary table
+    for ext in ("png", "svg", "csv"):
+        assert os.path.exists(os.path.join(str(tmp_path), f"ppc.{ext}"))
+    # one figure per query age
+    for age in (12, 24):
+        for ext in ("png", "svg"):
+            assert os.path.exists(os.path.join(str(tmp_path), f"ppc_{age}m.{ext}"))
+
+
+def test_ppc_gallery_emits_layout_of_individual_files_sorted_by_age(tmp_path, capsys):
+    for age in (24, 12, 36):  # created out of order; helper must sort
+        (tmp_path / f"ppc_{age}m.png").write_bytes(b"")
+    ppc_count_distribution_gallery("ppc", directory=str(tmp_path))
+    out = capsys.readouterr().out
+    assert "layout-ncol=2" in out
+    assert out.index("ppc_12m.png") < out.index("ppc_24m.png") < out.index("ppc_36m.png")
+    assert out.count(".lightbox") == 3
+    assert "12 months" in out
+
+
+def test_ppc_gallery_falls_back_to_combined_figure(tmp_path, capsys):
+    (tmp_path / "ppc.png").write_bytes(b"")  # only the combined grid exists (pre re-fit)
+    ppc_count_distribution_gallery("ppc", directory=str(tmp_path))
+    out = capsys.readouterr().out
+    assert "layout-ncol" not in out
+    assert "ppc.png" in out
+    assert ".lightbox" in out
+
+
+def test_ppc_gallery_prints_nothing_when_no_files(tmp_path, capsys):
+    ppc_count_distribution_gallery("ppc", directory=str(tmp_path))
+    assert capsys.readouterr().out.strip() == ""


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

Splits the posterior-predictive word-count distributions into individual per-age plots so they can be embedded flexibly in reports, rather than only as one tall combined grid figure. **Closes #123.**

## What changed

- **`src/vocab_growth/plotting.py`** — `plot_posterior_predictive_count_distributions_by_query_age` now, in addition to the combined grid, writes each query age as its own file `{filename}_{age}m.{png,svg}`. The per-age drawing is factored into a shared helper so the combined and individual figures stay identical. A new `ppc_count_distribution_gallery(prefix)` helper emits a Quarto column layout of the per-age plots for the model templates.
- **Model output templates** (`docs/models/vg01`–`vg14`, 21 embeds across 13 models) — the "count distributions by age" sections now call `ppc_count_distribution_gallery(...)` in an `output: asis` cell instead of embedding the single combined image. The helper **falls back to the combined grid** when a model has not yet been re-fit with individual plots, so no report section is ever empty.
- **Tests** — `tests/test_plotting_helpers.py` covers the individual-file output and the gallery's layout / combined-fallback / empty-directory behaviour.
- Allow `asis` (a Quarto cell directive) in the spellcheck word list.

## Verification

- `pytest tests/test_plotting_helpers.py` — individual per-age files written; gallery emits the layout, falls back to the combined grid, and prints nothing when empty.
- Isolated `quarto render` of the gallery cell: the individual-files path emits a column layout of per-age images; the fallback path emits the combined grid with no layout panel.
- `ruff check src/ scripts/`, `npm run spellcheck`, `npm run format:check` all pass.

## Note on figures

The individual plots are produced on the next model fit; until a re-fit, the report gallery gracefully falls back to the existing combined figure. The coordinated reporting-tier (`rep`) re-fit already pending for the other open PRs will regenerate the individual plots across all models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
