### PR TITLE
[codex] Align VG13 data and VG16 lag handling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,7 +68,7 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload] [--output-dir <dir>]
 ```
 
-- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, or `all`.
+- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, `vg16`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
@@ -104,7 +104,7 @@ Each model is a self-contained module in `src/vocab_growth/models/model_vgNN.py`
 
 The full, canonical list of models -- each model's population, outcome, structure, and purpose -- is maintained in `docs/models/README.md`. Treat that inventory as the single source of truth: consult it for the current set of models, and update it whenever a model is added, removed, or changed.
 
-There are currently fifteen models (`VG01`-`VG15`), spanning the Down syndrome and typically-developing populations across single-outcome, joint (understood + spoken), and signing (understood + spoken + signed) structures.
+There are currently sixteen models (`VG01`-`VG16`), spanning the Down syndrome and typically-developing populations across single-outcome, joint (understood + spoken), signing (understood + spoken + signed), and cross-lag structures.
 
 ### Shared utilities (`dse_research_utils`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload] [--output-dir <dir>]
 ```
 
-- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, or `all`.
+- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, `vg16`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
@@ -104,7 +104,7 @@ Each model is a self-contained module in `src/vocab_growth/models/model_vgNN.py`
 
 The full, canonical list of models -- each model's population, outcome, structure, and purpose -- is maintained in `docs/models/README.md`. Treat that inventory as the single source of truth: consult it for the current set of models, and update it whenever a model is added, removed, or changed.
 
-There are currently fifteen models (`VG01`-`VG15`), spanning the Down syndrome and typically-developing populations across single-outcome, joint (understood + spoken), and signing (understood + spoken + signed) structures.
+There are currently sixteen models (`VG01`-`VG16`), spanning the Down syndrome and typically-developing populations across single-outcome, joint (understood + spoken), signing (understood + spoken + signed), and cross-lag structures.
 
 ### Shared utilities (`dse_research_utils`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ This merges CSV datasets from `data/` into `data/vocab_data_merged.csv` and a Du
 python scripts/fit_model.py <model_id> [--config <config>] [--render] [--upload] [--output-dir <dir>]
 ```
 
-- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, or `all`.
+- `model_id`: one of `vg01`, `vg02`, `vg03`, `vg04`, `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg11`, `vg12`, `vg13`, `vg14`, `vg15`, `vg16`, or `all`.
 - `--config`: sampling configuration — `dev` (fast, for development), `test`, or `rep` (full reporting quality). Defaults to `dev`.
 - `--render`: render the Quarto model output after fitting.
 - `--upload`: upload model output to Azure Blob Storage via AzCopy. Requires `DSERESEARCH_BLOB_CONTAINER_URL` environment variable set to the target container URL.
@@ -104,7 +104,7 @@ Each model is a self-contained module in `src/vocab_growth/models/model_vgNN.py`
 
 The full, canonical list of models -- each model's population, outcome, structure, and purpose -- is maintained in `docs/models/README.md`. Treat that inventory as the single source of truth: consult it for the current set of models, and update it whenever a model is added, removed, or changed.
 
-There are currently fifteen models (`VG01`-`VG15`), spanning the Down syndrome and typically-developing populations across single-outcome, joint (understood + spoken), and signing (understood + spoken + signed) structures.
+There are currently sixteen models (`VG01`-`VG16`), spanning the Down syndrome and typically-developing populations across single-outcome, joint (understood + spoken), signing (understood + spoken + signed), and cross-lag structures.
 
 ### Shared utilities (`dse_research_utils`)
 

--- a/docs/models/PRIORS.md
+++ b/docs/models/PRIORS.md
@@ -52,23 +52,24 @@ which models this review must cover.
 
 ## Model coverage
 
-| Model | Population | Outcomes                     | Prior features to review                                                                                    |
-| ----- | ---------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| VG01  | DS         | spoken                       | Single-outcome spoken anchors, GP, kappa.                                                                   |
-| VG02  | DS         | understood                   | Single-outcome understood anchors, GP, kappa.                                                               |
-| VG03  | TD         | spoken                       | TD spoken anchors, GP, kappa, subsampling.                                                                  |
-| VG04  | TD         | understood                   | TD understood anchors, GP, kappa, subsampling.                                                              |
-| VG05  | DS         | understood + spoken          | Understood anchors, production-ratio `q` anchors, GP, kappa.                                                |
-| VG06  | TD         | understood + spoken          | TD understood anchors, `q` anchors, GP, kappa, subsampling.                                                 |
-| VG07  | DS         | understood + spoken          | VG05 plus study random-effect scales.                                                                       |
-| VG08  | DS         | understood + spoken          | VG07 plus subject random effects on understood.                                                             |
-| VG09  | DS         | understood + spoken          | VG08 plus subject random effects on `q`; diagnostic ridge motivates VG10.                                   |
-| VG10  | DS         | understood + spoken          | VG09 plus posterior-informed `q` anchors and GP anchoring.                                                  |
-| VG11  | TD         | spoken                       | VG03 plus study random effects, full TD data, GP anchoring.                                                 |
-| VG12  | TD         | understood                   | VG04 plus study random effects, full TD data, GP anchoring.                                                 |
-| VG13  | TD         | understood + spoken          | Young TD bivariate model, study random effects, GP anchoring.                                               |
-| VG14  | DS         | understood + spoken + signed | Adds signed ratio `r`, sign GP, sign kappa, signing-data decisions.                                         |
-| VG15  | DS         | understood + spoken + signed | VG14 plus `psi`, Dirichlet-Multinomial concentration, study and subject random effects, VG10 stabilisation. |
+| Model            | Population | Outcomes                     | Prior features to review                                                                                           |
+| ---------------- | ---------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| VG01             | DS         | spoken                       | Single-outcome spoken anchors, GP, kappa.                                                                          |
+| VG02             | DS         | understood                   | Single-outcome understood anchors, GP, kappa.                                                                      |
+| VG03             | TD         | spoken                       | TD spoken anchors, GP, kappa, subsampling.                                                                         |
+| VG04             | TD         | understood                   | TD understood anchors, GP, kappa, subsampling.                                                                     |
+| VG05             | DS         | understood + spoken          | Understood anchors, production-ratio `q` anchors, GP, kappa.                                                       |
+| VG06 _(retired)_ | TD         | understood + spoken          | TD understood anchors, `q` anchors, GP, kappa, subsampling; retained here only as historical prior context.        |
+| VG07             | DS         | understood + spoken          | VG05 plus study random-effect scales.                                                                              |
+| VG08             | DS         | understood + spoken          | VG07 plus subject random effects on understood.                                                                    |
+| VG09             | DS         | understood + spoken          | VG08 plus subject random effects on `q`; diagnostic ridge motivates VG10.                                          |
+| VG10             | DS         | understood + spoken          | VG09 plus posterior-informed `q` anchors and GP anchoring.                                                         |
+| VG11             | TD         | spoken                       | VG03 plus study random effects, full TD data, GP anchoring.                                                        |
+| VG12             | TD         | understood                   | VG04 plus study random effects, full TD data, GP anchoring.                                                        |
+| VG13             | TD         | understood + spoken          | Young TD bivariate model, study random effects, GP anchoring.                                                      |
+| VG14             | DS         | understood + spoken + signed | Adds signed ratio `r`, sign GP, sign kappa, signing-data decisions.                                                |
+| VG15             | DS         | understood + spoken + signed | VG14 plus `psi`, Dirichlet-Multinomial concentration, study and subject random effects, VG10 stabilisation.        |
+| VG16             | DS         | understood + spoken          | VG09 plus prior-understood cross-lag coefficient `beta_lag`; uses the same main prior families plus the lag prior. |
 
 ## Prior families
 

--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -26,7 +26,7 @@ This model output is preliminary and likely to change as the model evolves and f
 If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
 :::
 
-This model fits a joint bivariate model of words understood and spoken in typically developing children aged 8–18 months. It extends VG06 with dataset-level study random intercepts and restricts the age range to 8–18 months, where Wordbank WG and Oxford CDI data are dense and cover multiple labs. Above 18 months only a single dataset (Floccia/Oxford CDI) contributes bivariate observations, making inference unreliable. The production-ratio reparameterisation enforces $p_S \leq p_U$ by construction.
+This model fits a joint bivariate model of words understood and spoken in typically developing children aged 8–18 months. It supersedes the retired VG06 model with dataset-level study random intercepts and restricts the age range to 8–18 months, where Wordbank WG and Oxford CDI data are dense and cover multiple labs. Wordbank Words & Sentences rows are not used in this bivariate model because their comprehension field is a production proxy. Above 18 months only a single dataset (Floccia/Oxford CDI) contributes bivariate observations, making inference unreliable. The production-ratio reparameterisation enforces $p_S \leq p_U$ by construction.
 
 ```{python}
 import matplotlib.pyplot as plt

--- a/docs/report/methods-data.qmd
+++ b/docs/report/methods-data.qmd
@@ -37,6 +37,6 @@ _ds_summary
 
 ## Measures
 
-**TODO**: explain harmonisation onto a common 800-item reference scale ($N_{\text{trials}} = 800$); why this gives an inventory-comparable scale across DS and TD instruments even where native checklist ceilings differ (e.g. WG ≈ 396, Oxford CDI ≈ 418 items).
+The models report vocabulary counts on a common 800-item reference scale ($N_{\text{trials}} = 800$). This is a reference-inventory scale rather than the native denominator for every source checklist: some source forms have lower ceilings, including Wordbank Words & Gestures (about 396 items) and Oxford CDI (about 418 items). The common scale keeps estimates comparable across DS and TD instruments, but it remains a modelling approximation, so source-form ceilings and near-ceiling observations should be checked when interpreting high-count regions.
 
-**TODO**: Words & Sentences (WS) records **production only** - therefore TD understood and the comprehension–production gap are reported only in the young window (~8–18 months)
+Wordbank Words & Sentences (WS) records are treated as **production-only** because the WS comprehension field is a production proxy rather than an independent comprehension measurement. TD spoken-only models can use WS production counts, but TD bivariate models that estimate both understood and spoken vocabulary exclude WS rows and rely on WG and Oxford CDI observations for the comprehension-production gap.

--- a/docs/report/methods-models.qmd
+++ b/docs/report/methods-models.qmd
@@ -3,11 +3,15 @@ title: "Statistical models"
 abstract: "*TODO*"
 ---
 
-Our goal is to estimate the **total age-associated change** in a vocabulary outcome — not to disentangle the specific causal pathways through which age acts. Many factors influence a child's opportunities to learn and produce words (word meanings already learned, exposure, explicit teaching and therapy, hearing, and so on). Age does not act on the outcome directly, but it influences these mediating factors and therefore acts on the outcome indirectly.
+::: {.callout-note}
+Drafted by an LLM-based AI tool (Codex/GPT-5).
+:::
 
-In the simple causal model below, $A$ is age, $O$ collects the unmeasured mediating factors, and $Y$ is the vocabulary outcome. Because the effect of $A$ on $Y$ is entirely mediated through $O$, and $A$ is exogenous (it has no parents), there are no open backdoor paths. We can therefore identify the total effect of age on the outcome by conditioning on age alone.
+Our goal is to estimate **age-associated change** in a vocabulary outcome, not to claim that age alone causally determines vocabulary growth. Many factors influence a child's opportunities to learn and produce words, including exposure, explicit teaching and therapy, hearing, and words already learned. Age is a useful ordering variable because these opportunities accumulate over time, but the pooled observational data also vary by study, instrument, recruitment, cohort, and sample selection.
 
-![**The shared identification argument.** $A$: age; $O$: other unmeasured factors; $Y$: the vocabulary outcome. Conditioning on age identifies the total age-associated change.](diagrams/fig-core-dag){#fig-core-dag fig-align="left" width="2.5in"}
+In the simple organising diagram below, $A$ is age, $O$ collects the unmeasured mediating factors, and $Y$ is the vocabulary outcome. The models therefore estimate descriptive trajectories conditional on age and the model structure. Study and subject effects absorb some systematic differences, but they do not make age randomised or remove every possible cohort, instrument, or selection difference.
+
+![**The shared age-association argument.** $A$: age; $O$: other unmeasured factors; $Y$: the vocabulary outcome. Conditioning on age summarises the modelled age-associated change.](diagrams/fig-core-dag){#fig-core-dag fig-align="left" width="2.5in"}
 
 ## The outcome: a Beta-Binomial count {#sec-betabinomial}
 

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -21,6 +21,10 @@ from vocab_growth.reporting import (
 # now contains all languages; the DS (Edgin) subset is restricted to English.
 _ENGLISH_SQL_LIST = ", ".join(f"'{lang}'" for lang in ENGLISH_LANGUAGES)
 
+# Data-quality guard for the Edgin DS Wordbank subset. Rows above this threshold
+# are kept out until their source form and eligibility can be revalidated.
+US_01_MAX_PRODUCTION = 100
+
 _started = time.perf_counter()
 heading("Preparing vocabulary data")
 
@@ -370,7 +374,7 @@ con.execute(
     WHERE dataset_name = 'Edgin'
       AND language IN ({_ENGLISH_SQL_LIST})
       AND lower(health_conditions) = 'down syndrome'
-      AND production <= 100
+      AND production <= {US_01_MAX_PRODUCTION}
     UNION ALL
     SELECT 'uk_03'                           as study,
            vuk2025.subject_id,

--- a/src/vocab_growth/data_utils.py
+++ b/src/vocab_growth/data_utils.py
@@ -151,13 +151,13 @@ def load_data(
     #
     # Wordbank's CDI: Words & Sentences (WS) rows contain valid production
     # counts, but their comprehension column is a production proxy. Keep WG
-    # and Oxford CDI as bivariate observations, and include WS only when the
-    # requested model can use spoken observations.
+    # and Oxford CDI as bivariate observations, and include WS only for
+    # spoken-only models.
     needs_understood = "understood" in columns
     needs_spoken = "spoken" in columns
 
     td_forms = list(TD_BIVARIATE_FORMS)
-    if needs_spoken or not needs_understood:
+    if needs_spoken and not needs_understood:
         td_forms.extend(TD_SPOKEN_ONLY_FORMS)
 
     age_upper = max_age_months if max_age_months is not None else 30

--- a/src/vocab_growth/models/__init__.py
+++ b/src/vocab_growth/models/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""The vocabulary growth model family (VG01-VG15; see docs/models/README.md).
+"""The vocabulary growth model family (VG01-VG16; see docs/models/README.md).
 
 Each ``model_vgNN.py`` is a thin module selecting a definition from
 ``definitions.py`` and dispatching to one of six shared fitting engines:

--- a/src/vocab_growth/models/common_bivariate_re.py
+++ b/src/vocab_growth/models/common_bivariate_re.py
@@ -208,7 +208,7 @@ def _validate_cross_lag(lag_baseline: str, use_subject_re_u: bool) -> None:
 def _compute_prev_wave_lag(analysis_df, n_trials: int):
     """Per-observation prior-wave understood lag source for the VG16 cross-lag.
 
-    For each observation, locate the child's immediately-earlier observed wave
+    For each observation, locate the child's immediately-earlier age wave
     that carries an understood measure (the lag source). Returns
     ``(prev_idx, has_lag_f, y_u_prev_logit)`` as per-observation arrays:
     ``has_lag_f`` is 1.0 where such a prior wave exists and 0.0 otherwise (a
@@ -223,15 +223,16 @@ def _compute_prev_wave_lag(analysis_df, n_trials: int):
     subj = np.asarray(analysis_df["subject_code"], dtype=int)
     age = np.asarray(analysis_df["age"], dtype=float)
     und = analysis_df["understood"].to_numpy(dtype=float)
-    prev_subj, last = -1, -1
-    for pos in np.lexsort((age, subj)):  # walk each child in age order
+    row_order = np.arange(n)
+    prev_subj, last, last_age = -1, -1, np.nan
+    for pos in np.lexsort((row_order, age, subj)):  # walk each child in age order
         if subj[pos] != prev_subj:
-            prev_subj, last = subj[pos], -1
-        if last >= 0:
+            prev_subj, last, last_age = subj[pos], -1, np.nan
+        if last >= 0 and age[pos] > last_age:
             prev_idx[pos] = last
             has_lag_f[pos] = 1.0
         if not np.isnan(und[pos]):
-            last = pos
+            last, last_age = pos, age[pos]
     und_prev = np.where(has_lag_f > 0, und[prev_idx], n_trials * 0.5)
     p_prev = np.clip(und_prev / n_trials, 1e-4, 1 - 1e-4)
     y_u_prev_logit = np.where(has_lag_f > 0, np.log(p_prev) - np.log(1 - p_prev), 0.0)
@@ -290,11 +291,12 @@ def build_model_re(
         subject_codes = None
         n_subjects = 0
 
-    # Within-child cross-lag (VG16, issue #113): for each observation, the child's
-    # immediately-earlier observed understood wave is the lag source; x_lag = 0
-    # where there is no such prior wave (first wave, or every earlier wave lacks
-    # comprehension). prev_idx/has_lag_f/y_u_prev_logit are consumed below when
-    # injecting beta_lag * x_lag into the q logit.
+    # Cross-lag (VG16, issue #113): for each observation, the child's
+    # immediately-earlier age wave with understood data is the lag source;
+    # x_lag = 0 where there is no such prior wave (first wave, same-age
+    # duplicates, or every earlier wave lacks comprehension).
+    # prev_idx/has_lag_f/y_u_prev_logit are consumed below when injecting
+    # beta_lag * x_lag into the q logit.
     use_cross_lag = bool(definition.use_cross_lag)
     prev_idx = np.zeros(n, dtype=int)
     has_lag_f = np.zeros(n, dtype=float)
@@ -538,18 +540,18 @@ def build_model_re(
         # For diagnostics: population-level f at obs ages
         _ = pm.Deterministic("f_u_obs", f_u_all[i_obs0:i_obs1], dims=("obs_id",))
 
-        # Within-child cross-lag (VG16, issue #113): the child's prior-wave
-        # understood residual shifts their current production ratio q. With the
-        # subject intercepts as random intercepts this is a RI-CLPM within-child
-        # cross-lag; beta_lag > 0 means earlier receptive standing predicts later
-        # expressive conversion. x_lag is 0 for observations with no prior wave.
+        # Cross-lag (VG16, issue #113): the child's prior-wave understood
+        # residual shifts their current production ratio q. The configured
+        # baseline decides whether the residual is population-relative or
+        # within-child. beta_lag > 0 means earlier receptive standing predicts
+        # later expressive conversion; x_lag is 0 with no prior wave.
         if use_cross_lag:
             beta_lag = pm.Normal(
                 "beta_lag", mu=definition.beta_lag_mu, sigma=definition.beta_lag_sigma
             )
             lag_base = f_u_obs_re[prev_idx]  # child's own expected understood logit at prior wave
             if definition.lag_baseline == "population":
-                # subtract only population+study (add the subject intercept back)
+                # Use the population+study baseline by removing the subject shift.
                 lag_base = lag_base - subject_shift_u[prev_idx]
             x_lag = has_lag_f * (y_u_prev_logit - lag_base)
             q_lag_term = beta_lag * x_lag

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -728,8 +728,8 @@ VG13 = BivariateModelDefinition(
     ),
     population=Population.TYPICALLY_DEVELOPING,
     # Common 800-item reference inventory. Counts from WG (ceiling 396) and
-    # Oxford CDI (ceiling 418) are comfortably below the 800-item scale in the
-    # 8–18 month window, so no distortion is introduced.
+    # Oxford CDI (ceiling 418) are interpreted on this shared reference scale;
+    # source-form ceilings remain an interpretation caveat.
     n_trials=800,
     # Restrict to 8–18 months where WG/Oxford CDI data are dense and the WS
     # bias (production proxy comprehension) is avoided entirely.

--- a/src/vocab_growth/models/model_vg16.py
+++ b/src/vocab_growth/models/model_vg16.py
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 """
-Model VG16: VG09 + a within-child cross-lag (issue #113).
+Model VG16: VG09 + a prior-understood cross-lag (issue #113).
 
-Extends the bivariate + subject-random-intercept foundation with one population
-lead-lag coefficient: a child's prior-wave understood residual (relative to their
-own comprehension trajectory) predicts their current production ratio q, i.e.
-earlier receptive vocabulary -> later expressive vocabulary, within child. With
-the subject intercepts acting as random intercepts this is a random-intercept
-cross-lagged panel (RI-CLPM). See
-notes/202607031200-vg16-within-child-scoping.md.
+Extends the bivariate + subject-random-intercept foundation with one lead-lag
+coefficient: a child's prior-wave understood residual predicts their current
+production ratio q, i.e. earlier receptive vocabulary -> later expressive
+vocabulary. The model definition chooses whether that residual is
+population-relative or within-child; the headline VG16 definition uses the
+population-relative baseline. See notes/202607031200-vg16-within-child-scoping.md.
 """
 
 from vocab_growth.models.common_bivariate_re import (

--- a/tests/test_cross_lag.py
+++ b/tests/test_cross_lag.py
@@ -59,6 +59,27 @@ def test_compute_prev_wave_lag_logit_of_prior_understood():
     np.testing.assert_array_equal(y_u_prev_logit[[0, 3, 4, 5, 6]], 0.0)
 
 
+def test_compute_prev_wave_lag_ignores_same_age_duplicates():
+    df = pd.DataFrame(
+        {
+            "subject_code": [0, 0, 0],
+            "age": [12, 12, 24],
+            "understood": [100, 150, 300],
+        }
+    )
+
+    prev_idx, has_lag_f, y_u_prev_logit = _compute_prev_wave_lag(df, N_TRIALS)
+
+    np.testing.assert_array_equal(has_lag_f, [0, 0, 1])
+    assert prev_idx[2] == 1
+    assert y_u_prev_logit[1] == 0.0
+    np.testing.assert_allclose(
+        y_u_prev_logit[2],
+        np.log(150 / 800) - np.log(1 - 150 / 800),
+        rtol=1e-6,
+    )
+
+
 @pytest.mark.parametrize("baseline", ["population", "within"])
 def test_validate_cross_lag_accepts_valid_config(baseline):
     _validate_cross_lag(baseline, use_subject_re_u=True)  # no raise

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -8,7 +8,7 @@ import vocab_growth.data_utils as data_utils
 from vocab_growth.models.definitions import Population
 
 
-def test_td_load_data_keeps_ws_as_spoken_only(tmp_path, monkeypatch):
+def test_td_bivariate_data_excludes_ws_before_sampling(tmp_path, monkeypatch):
     db_path = _create_wordbank_db(tmp_path)
     monkeypatch.setattr(data_utils, "VOCABULARY_DATA_PATH", str(db_path))
 
@@ -18,11 +18,7 @@ def test_td_load_data_keeps_ws_as_spoken_only(tmp_path, monkeypatch):
     )
 
     df = df.sort_values("form").reset_index(drop=True)
-    assert df["form"].to_list() == ["Oxford CDI", "WG", "WS"]
-
-    ws_row = df.loc[df["form"] == "WS"].iloc[0]
-    assert pd.isna(ws_row["understood"])
-    assert ws_row["spoken"] == 51
+    assert df["form"].to_list() == ["Oxford CDI", "WG"]
 
 
 def test_td_understood_data_excludes_ws_before_sampling(tmp_path, monkeypatch):


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Codex/GPT-5).

## Summary

This PR implements the low-risk fixes from the model/methodology review in #128. It aligns VG13's TD bivariate data loading with the documented WS exclusion, tightens VG16 lag construction so same-age duplicate records are not treated as prior waves, and updates the surrounding documentation so the model inventory and methodology language match the code.

## Changes

- Exclude Wordbank Words & Sentences rows from TD bivariate loads while keeping WS available for TD spoken-only models.
- Add regression coverage for the VG13 loader behaviour and for VG16 same-age duplicate lag handling.
- Require VG16 lag sources to come from a strictly earlier age wave and clarify comments/docstrings around the population-relative versus within-child lag baseline.
- Replace report TODOs for the 800-item reference scale and WS production-only handling with explicit caveats.
- Temper the report's causal-identification wording to describe modelled age-associated trajectories rather than a causal total age effect.
- Sync the model inventory across AGENTS.md, CLAUDE.md, .github/copilot-instructions.md, package docstrings, and the prior review ledger.
- Name and comment the `us_01` Edgin production-threshold guard without changing its value.

## Notes

This PR does not attempt the larger modelling decisions from #128, such as replacing the marginal Beta-Binomial likelihoods with a true joint subset likelihood or adding VG15 cell-likelihood LOO/PPC coverage. Those require a deliberate modelling choice and probably fresh posterior checks.

## Validation

- `env NUMBA_CACHE_DIR=/private/tmp/numba-cache XDG_CACHE_HOME=/private/tmp/xdg-cache MPLCONFIGDIR=/private/tmp/mpl-cache conda run -n dse-vocab-growth python -m pytest tests/test_data_utils.py tests/test_cross_lag.py`
- `conda run -n dse-vocab-growth ruff check src/ scripts/ tests/`
- `npm run format:check`
- `npm run spellcheck`