### PR TITLE
fix(data): guard WS comprehension in the us_01/Edgin DS block

### DIFF
--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -19,6 +19,7 @@ dataclass
 Deckers
 dexp
 duckdb
+Edgin
 elpd
 empiricalmodelling
 estimand

--- a/notes/202605151630-vg06-ws-comprehension-issue.md
+++ b/notes/202605151630-vg06-ws-comprehension-issue.md
@@ -59,6 +59,8 @@ All downstream DS-vs-TD comparison scripts have been rerun (latency, q-overlap, 
 | **VG06**  | **TD bivariate**  | **yes**                     | **refit completed 2026-05-15**                                             |
 | VG07–VG09 | DS bivariate      | n/a (DS)                    | unaffected                                                                 |
 
+**Update (2026-07-06):** the "unaffected" verdicts for the DS models above were wrong. The us_01/Edgin block of the `vocab_combined` view had the same defect — WS `comprehension` passed through as `understood` unguarded — so VG02 and all DS joint models did train on WS proxy rows. See `notes/202607061200-us01-edgin-ws-comprehension-issue.md` for the DS-side fix and refit list.
+
 ## Reproducing the discovery
 
 ```python

--- a/notes/202607061200-us01-edgin-ws-comprehension-issue.md
+++ b/notes/202607061200-us01-edgin-ws-comprehension-issue.md
@@ -15,10 +15,10 @@ The view has now been fixed to null out `understood` for non-bivariate forms whi
 
 In the English Down syndrome subset of the Wordbank export (`dataset_name = 'Edgin'`, `lower(health_conditions) = 'down syndrome'`), counting rows where `comprehension == production`:
 
-| Form | n   | U == S      | After `production <= 100` cap | Ages (used rows) | Median "understood" (used rows) |
-| ---- | --- | ----------- | ----------------------------- | ---------------- | ------------------------------- |
-| WG   | 87  | 5 (5.7%)    | 79                            | 11–18 months     | 33                              |
-| WS   | 109 | 109 (100%)  | 85                            | 17–27 months     | 7 (== median spoken)            |
+| Form | n   | U == S     | After `production <= 100` cap | Ages (used rows) | Median "understood" (used rows) |
+| ---- | --- | ---------- | ----------------------------- | ---------------- | ------------------------------- |
+| WG   | 87  | 5 (5.7%)   | 79                            | 11–18 months     | 33                              |
+| WS   | 109 | 109 (100%) | 85                            | 17–27 months     | 7 (== median spoken)            |
 
 The WS rows are production-only measurements wearing a comprehension label. The contrast at the age overlap makes the distortion concrete: WG rows at 17–18 months have median understood 46.5 (n = 46), while the WS rows spanning 17–27 months report median "understood" 7 — because that is their median production.
 
@@ -42,17 +42,17 @@ While fixing the block we documented the `AND production <= 100` filter, which h
 
 ## Models requiring attention
 
-| Model     | Population | Outcome(s)                   | Affected?                        | Action                              |
-| --------- | ---------- | ---------------------------- | -------------------------------- | ----------------------------------- |
-| VG01      | DS         | Spoken                       | no — WS production is valid      | none                                |
-| **VG02**  | **DS**     | **Understood**               | **yes**                          | **refit**                           |
-| VG03/VG04 | TD         | Spoken / understood          | no — TD loader guarded 2026-05-15 | none                                |
-| **VG05**  | **DS**     | **Joint U + S**              | **yes**                          | **refit**                           |
-| **VG07–VG10** | **DS** | **Joint U + S (+ REs)**      | **yes**                          | **refit**                           |
-| VG11–VG13 | TD         | Various                      | no                               | none                                |
-| **VG14**  | **DS**     | **U + S + signed**           | **yes** (us_01 U/S marginals)    | **refit**                           |
-| **VG15**  | **DS**     | **Joint modality**           | **yes** (us_01 in merged marginals) | **refit**                        |
-| **VG16**  | **DS**     | **Cross-lag (U → q)**        | **yes**                          | **refit**                           |
+| Model         | Population | Outcome(s)              | Affected?                           | Action    |
+| ------------- | ---------- | ----------------------- | ----------------------------------- | --------- |
+| VG01          | DS         | Spoken                  | no — WS production is valid         | none      |
+| **VG02**      | **DS**     | **Understood**          | **yes**                             | **refit** |
+| VG03/VG04     | TD         | Spoken / understood     | no — TD loader guarded 2026-05-15   | none      |
+| **VG05**      | **DS**     | **Joint U + S**         | **yes**                             | **refit** |
+| **VG07–VG10** | **DS**     | **Joint U + S (+ REs)** | **yes**                             | **refit** |
+| VG11–VG13     | TD         | Various                 | no                                  | none      |
+| **VG14**      | **DS**     | **U + S + signed**      | **yes** (us_01 U/S marginals)       | **refit** |
+| **VG15**      | **DS**     | **Joint modality**      | **yes** (us_01 in merged marginals) | **refit** |
+| **VG16**      | **DS**     | **Cross-lag (U → q)**   | **yes**                             | **refit** |
 
 Downstream DS-vs-TD comparisons and report chapters that consume these posteriors (comprehension–production gap, joint trajectory, latency, `q` overlap) need regenerating after the refits.
 

--- a/notes/202607061200-us01-edgin-ws-comprehension-issue.md
+++ b/notes/202607061200-us01-edgin-ws-comprehension-issue.md
@@ -1,0 +1,75 @@
+# us_01 (Edgin, DS): WS comprehension was passed through as understood
+
+Date: 2026-07-06
+
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Claude Code/Fable 5).
+
+## Summary
+
+The us_01/Edgin block of the `vocab_combined` view in `scripts/prepare_data.py` selected `comprehension as understood` from `wordbank_child` with no filter on `form`. Wordbank's CDI: Words & Sentences (WS) form records `comprehension` as a production proxy (`comprehension == production` by data convention), so every WS row entered the DS models claiming the child understood exactly as many words as they produced. This is the same defect that retired VG06 on the TD side (see `notes/202605151630-vg06-ws-comprehension-issue.md`); the 2026-05-15 fix guarded the TD loader (`load_data`) but not the DS path, and that note's "unaffected" verdicts for the DS models were therefore wrong.
+
+The view has now been fixed to null out `understood` for non-bivariate forms while keeping the (valid) production counts. **VG02 and all DS joint models (VG05, VG07–VG10, VG14, VG15, VG16) trained on the corrupted rows and need refitting** after `python scripts/prepare_data.py` rebuilds the local database.
+
+## Empirical evidence
+
+In the English Down syndrome subset of the Wordbank export (`dataset_name = 'Edgin'`, `lower(health_conditions) = 'down syndrome'`), counting rows where `comprehension == production`:
+
+| Form | n   | U == S      | After `production <= 100` cap | Ages (used rows) | Median "understood" (used rows) |
+| ---- | --- | ----------- | ----------------------------- | ---------------- | ------------------------------- |
+| WG   | 87  | 5 (5.7%)    | 79                            | 11–18 months     | 33                              |
+| WS   | 109 | 109 (100%)  | 85                            | 17–27 months     | 7 (== median spoken)            |
+
+The WS rows are production-only measurements wearing a comprehension label. The contrast at the age overlap makes the distortion concrete: WG rows at 17–18 months have median understood 46.5 (n = 46), while the WS rows spanning 17–27 months report median "understood" 7 — because that is their median production.
+
+## Impact on the DS models
+
+- The 85 corrupted rows were 85/819 ≈ 10% of the DS `understood` pool, and 48 of them sit above 18 months, precisely the window where the DS comprehension–production gap is of interest.
+- Every model consuming DS `understood` via `load_combined_data` trained on them: the univariate comprehension model (VG02) had its trajectory dragged down in the 17–27-month window, and the joint models (VG05, VG07–VG10, VG14–VG16) were additionally told `U = S` exactly on those rows, biasing the comprehension–production gap and the production ratio `q` toward 1 — the same artefact class that produced VG06's spurious "gap closes by 30 months" finding on the TD side.
+- `data/vocab_data_merged.csv` is unaffected: the pandas merge never included us_01, which only enters via the DuckDB view.
+- DS production observations are unaffected: WS production counts are valid and are retained (as `spoken`/`produced`).
+
+## Fix applied (2026-07-06)
+
+1. **`src/vocab_growth/data_utils.py`** — the `vocab_combined` view definition moved out of `scripts/prepare_data.py` into `vocab_combined_view_sql()` so it is importable and regression-tested. The us_01/Edgin block now takes `understood` only from forms in `WORDBANK_BIVARIATE_FORMS` (renamed from `TD_BIVARIATE_FORMS` — the bivariate property belongs to the instrument, not the population) and both the TD and DS guards are built from that one constant.
+2. **`tests/test_data_utils.py`** — the fixture now builds the full `vocab_combined` view over a miniature `wordbank_child`, and four DS regression tests assert that WS rows contribute `spoken` but never `understood`, that WG rows keep independent comprehension, that no surviving us_01 row carries the `understood == spoken` proxy, and that the production cap behaves as documented.
+
+Rebuilding the database changes no us_01 row counts (164 rows: 79 WG + 85 WS); the 85 WS rows simply have `understood` NULL instead of the production proxy.
+
+## The `production <= 100` cap
+
+While fixing the block we documented the `AND production <= 100` filter, which has been in place since the initial import with no recorded rationale. In the current export it drops the highest-production administrations: 8/87 WG and 24/109 WS English DS rows. It is retained as-is (removing it would confound the refit that this fix already requires) but should be reviewed: either record a rationale (e.g. an early-vocabulary scope decision) or remove it and let the Beta-Binomial ceiling handle the full range.
+
+## Models requiring attention
+
+| Model     | Population | Outcome(s)                   | Affected?                        | Action                              |
+| --------- | ---------- | ---------------------------- | -------------------------------- | ----------------------------------- |
+| VG01      | DS         | Spoken                       | no — WS production is valid      | none                                |
+| **VG02**  | **DS**     | **Understood**               | **yes**                          | **refit**                           |
+| VG03/VG04 | TD         | Spoken / understood          | no — TD loader guarded 2026-05-15 | none                                |
+| **VG05**  | **DS**     | **Joint U + S**              | **yes**                          | **refit**                           |
+| **VG07–VG10** | **DS** | **Joint U + S (+ REs)**      | **yes**                          | **refit**                           |
+| VG11–VG13 | TD         | Various                      | no                               | none                                |
+| **VG14**  | **DS**     | **U + S + signed**           | **yes** (us_01 U/S marginals)    | **refit**                           |
+| **VG15**  | **DS**     | **Joint modality**           | **yes** (us_01 in merged marginals) | **refit**                        |
+| **VG16**  | **DS**     | **Cross-lag (U → q)**        | **yes**                          | **refit**                           |
+
+Downstream DS-vs-TD comparisons and report chapters that consume these posteriors (comprehension–production gap, joint trajectory, latency, `q` overlap) need regenerating after the refits.
+
+## Reproducing the discovery
+
+```python
+import pandas as pd
+
+from vocab_growth.data_utils import ENGLISH_LANGUAGES
+
+df = pd.read_csv("data/wordbank_administration_data.csv", low_memory=False)
+edgin_ds = df[
+    (df["dataset_name"] == "Edgin")
+    & (df["language"].isin(ENGLISH_LANGUAGES))
+    & (df["health_conditions"].str.lower() == "down syndrome")
+]
+for form, rows in edgin_ds.groupby("form"):
+    eq = (rows["comprehension"] == rows["production"]).sum()
+    print(f"{form}: n={len(rows)}, U==S on {eq} ({100 * eq / len(rows):.1f}%)")
+```

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -9,17 +9,13 @@ import time
 import duckdb
 import pandas as pd
 
-from vocab_growth.data_utils import ENGLISH_LANGUAGES
+from vocab_growth.data_utils import vocab_combined_view_sql
 from vocab_growth.reporting import (
     console,
     format_duration,
     heading,
     key_value_table,
 )
-
-# SQL list literal of English Wordbank ``language`` values. The Wordbank export
-# now contains all languages; the DS (Edgin) subset is restricted to English.
-_ENGLISH_SQL_LIST = ", ".join(f"'{lang}'" for lang in ENGLISH_LANGUAGES)
 
 _started = time.perf_counter()
 heading("Preparing vocabulary data")
@@ -298,174 +294,10 @@ con.execute(
     """
 )
 
-con.execute(
-    f"""
-    CREATE VIEW vocab_combined AS
-    SELECT 'uk_01' as study,
-           vuk1.subject_id,
-           vuk1.sex,
-           vuk1.age,
-           vuk1.understood,
-           vuk1.spoken,
-           vuk1.signed,
-           vuk1.produced,
-           vuk1.survey_vocab_max
-    FROM vocab_uk_01 as vuk1
-    UNION ALL
-    SELECT 'uk_02'          as study,
-           vuk2.subject_id,
-           CASE
-               WHEN vuk2.gender = 0 THEN 'M'
-               WHEN vuk2.gender = 1 THEN 'F'
-               ELSE NULL
-           END            as sex,
-           vuk2.age age,
-           vuk2.comprehension as understood,
-           vuk2.spoken,
-           vuk2.signed,
-           vuk2.production as produced,
-           CASE
-               WHEN vuk2.form = 'DSE' THEN 800
-               WHEN vuk2.form = 'Oxford_CDI' THEN 428
-               ELSE NULL
-           END                as survey_vocab_max
-    FROM vocab_uk_02 as vuk2
-    UNION ALL
-    SELECT 'ie_01'                                                   as study,
-           vie.subject_id,
-           NULL                                                        as sex,
-           vie.age_months_start                                        as age,
-           GREATEST(vie.says_total_start, vie.understands_total_start) as understood,
-           vie.says_total_start                                        as spoken,
-           null                                                        as signed,
-           null                                                        as produced,
-           800                                                         as survey_vocab_max
-    FROM vocab_ie_01 as vie
-    UNION ALL
-    SELECT 'ie_01'                                               as study,
-           vie.subject_id,
-           NULL                                                    as sex,
-           vie.age_months_end                                      as age,
-           GREATEST(vie.says_total_end, vie.understands_total_end) as understood,
-           vie.says_total_end                                      as spoken,
-           null                                                    as signed,
-           vie.says_total_end                                      as produced,
-           800                                                     as survey_vocab_max
-    FROM vocab_ie_01 as vie
-    UNION ALL
-    SELECT 'us_01'                          as study,
-           concat('id_', hex(hash(child_id))) as subject_id,
-           sex,
-           age,
-           comprehension                      as understood,
-           production                         as spoken,
-           null                               as signed,
-           production                         as produced,
-           CASE form
-               WHEN 'WG' THEN 396
-               WHEN 'WS' THEN 690
-               ELSE NULL
-               END                            as survey_vocab_max
-    FROM wordbank_child
-    WHERE dataset_name = 'Edgin'
-      AND language IN ({_ENGLISH_SQL_LIST})
-      AND lower(health_conditions) = 'down syndrome'
-      AND production <= 100
-    UNION ALL
-    SELECT 'uk_03'                           as study,
-           vuk2025.subject_id,
-           NULL                                as sex,
-           vuk2025.age,
-           vuk2025.comprehension               as understood,
-           vuk2025.production                  as spoken,
-           null                                as signed,
-           vuk2025.production                  as produced,
-           418                                 as survey_vocab_max
-    FROM vocab_uk_03 as vuk2025
-    UNION ALL
-    SELECT 'it_01'                           as study,
-           vit2013.subject_id,
-           NULL                                as sex,
-           vit2013.age,
-           vit2013.understood,
-           vit2013.spoken,
-           null                                as signed,
-           vit2013.spoken                      as produced,
-           vit2013.form_max_spoken             as survey_vocab_max
-    FROM vocab_it_01 as vit2013
-    UNION ALL
-    SELECT 'uk_04'                           as study,
-        vuk2013.subject_id,
-        NULL                                as sex,
-        vuk2013.age,
-        vuk2013.understood,
-        vuk2013.spoken,
-        vuk2013.signed,
-        vuk2013.spoken                      as produced,
-        418                                 as survey_vocab_max
-    FROM vocab_uk_04 as vuk2013
-        UNION ALL
-    SELECT 'uk_05'                           as study,
-        vuk05.subject_id,
-        NULL                                as sex,
-        vuk05.age,
-        vuk05.understood,
-        vuk05.spoken,
-        vuk05.signed,
-        vuk05.spoken                      as produced,
-        418                                 as survey_vocab_max
-    FROM vocab_uk_05 as vuk05
-        UNION ALL
-    SELECT 'us_02'                           as study,
-        vus02.subject_id,
-        NULL                                as sex,
-        vus02.age,
-        vus02.understood,
-        vus02.spoken,
-        NULL                                as signed,
-        vus02.spoken                     as produced,
-        418                                 as survey_vocab_max
-    FROM vocab_us_02 as vus02
-        UNION ALL
-    SELECT 'uk_06'                           as study,
-        vuk06.subject_id,
-        NULL                                as sex,
-        vuk06.age,
-        vuk06.understood,
-        vuk06.spoken,
-        vuk06.signed                                as signed,
-        vuk06.spoken                      as produced,
-        800                                 as survey_vocab_max
-    FROM vocab_uk_06 as vuk06
-        UNION ALL
-    SELECT 'ie_02'                           as study,
-        vie2.subject_id,
-        NULL                                as sex,
-        vie2.age,
-        vie2.understood,
-        vie2.spoken,
-        vie2.signed                         as signed,
-        vie2.spoken                         as produced,
-        800                                 as survey_vocab_max
-    FROM vocab_ie_02 as vie2
-    WHERE vie2.english_speaking = 'yes'
-    UNION ALL
-    -- nz_01 (Foster-Cohen): production-only, no comprehension. The CSV columns are
-    -- modality-exclusive, so any-modality spoken = spoken + spoken_signed (a + c)
-    -- and signed = signed + spoken_signed (b + c). 675-item NZCDI ceiling.
-    SELECT 'nz_01'                                        as study,
-        vnz01.subject_id,
-        NULL                                              as sex,
-        vnz01.age,
-        NULL                                              as understood,
-        vnz01.spoken + vnz01.spoken_signed                as spoken,
-        vnz01.signed + vnz01.spoken_signed                as signed,
-        vnz01.spoken + vnz01.signed + vnz01.spoken_signed as produced,
-        675                                               as survey_vocab_max
-    FROM vocab_nz_01 as vnz01
-
-    """
-)
+# The view definition lives in vocab_growth.data_utils so the per-study
+# transformations (notably the us_01/Edgin Wordbank form guard) are importable
+# and regression-tested alongside load_combined_data.
+con.execute(vocab_combined_view_sql())
 
 con.close()
 

--- a/src/vocab_growth/data_utils.py
+++ b/src/vocab_growth/data_utils.py
@@ -13,11 +13,22 @@ from vocab_growth.models.definitions import Population
 
 VOCABULARY_DATA_PATH = os.path.join(local_env.DATA_DIR, "vocabulary.duckdb")
 
-TD_BIVARIATE_FORMS = ("Oxford CDI", "WG")
-"""Wordbank TD forms with independent comprehension and production measures."""
+WORDBANK_BIVARIATE_FORMS = ("Oxford CDI", "WG")
+"""Wordbank forms whose comprehension is an independent measurement.
 
-TD_SPOKEN_ONLY_FORMS = ("WS",)
-"""Wordbank TD forms that contribute production observations only."""
+On the other English forms (WS, WSShort, TEDS Twos/Threes) the
+``comprehension`` column is a production proxy (``comprehension ==
+production`` by data convention), so only these forms may contribute
+``understood`` observations. This is a property of the instrument, not the
+population: the guard applies both to the TD loader (:func:`load_data`) and
+to the us_01/Edgin DS block of the ``vocab_combined`` view
+(:func:`vocab_combined_view_sql`). See
+``notes/202605151630-vg06-ws-comprehension-issue.md`` (TD) and
+``notes/202607061200-us01-edgin-ws-comprehension-issue.md`` (DS).
+"""
+
+WORDBANK_SPOKEN_ONLY_FORMS = ("WS",)
+"""Wordbank forms that contribute production observations only."""
 
 ENGLISH_LANGUAGES = (
     "English (American)",
@@ -68,6 +79,207 @@ def filter_studies_by_min_obs(
     dropped = sorted(set(sizes.index) - set(keep))
     filtered = df[df[study_col].isin(keep)].reset_index(drop=True)
     return filtered, dropped
+
+
+def _sql_string_list(values: tuple[str, ...]) -> str:
+    """Render a tuple of strings as a quoted SQL ``IN``-list body."""
+    return ", ".join(f"'{v}'" for v in values)
+
+
+def vocab_combined_view_sql() -> str:
+    """Return the ``CREATE VIEW vocab_combined`` statement.
+
+    The view unions the per-study tables built by ``scripts/prepare_data.py``
+    into the single DS analysis relation read by :func:`load_combined_data`.
+    It is defined here rather than inline in the script so the per-study
+    transformations — in particular the us_01/Edgin Wordbank form guard,
+    which must stay in lockstep with the TD guard in :func:`load_data` — are
+    importable and regression-tested (see ``tests/test_data_utils.py``).
+
+    The Wordbank export contains all languages; the DS (Edgin) subset is
+    restricted to English via :data:`ENGLISH_LANGUAGES`.
+    """
+    english_sql_list = _sql_string_list(ENGLISH_LANGUAGES)
+    bivariate_forms_sql_list = _sql_string_list(WORDBANK_BIVARIATE_FORMS)
+    return f"""
+    CREATE VIEW vocab_combined AS
+    SELECT 'uk_01' as study,
+           vuk1.subject_id,
+           vuk1.sex,
+           vuk1.age,
+           vuk1.understood,
+           vuk1.spoken,
+           vuk1.signed,
+           vuk1.produced,
+           vuk1.survey_vocab_max
+    FROM vocab_uk_01 as vuk1
+    UNION ALL
+    SELECT 'uk_02'          as study,
+           vuk2.subject_id,
+           CASE
+               WHEN vuk2.gender = 0 THEN 'M'
+               WHEN vuk2.gender = 1 THEN 'F'
+               ELSE NULL
+           END            as sex,
+           vuk2.age age,
+           vuk2.comprehension as understood,
+           vuk2.spoken,
+           vuk2.signed,
+           vuk2.production as produced,
+           CASE
+               WHEN vuk2.form = 'DSE' THEN 800
+               WHEN vuk2.form = 'Oxford_CDI' THEN 428
+               ELSE NULL
+           END                as survey_vocab_max
+    FROM vocab_uk_02 as vuk2
+    UNION ALL
+    SELECT 'ie_01'                                                   as study,
+           vie.subject_id,
+           NULL                                                        as sex,
+           vie.age_months_start                                        as age,
+           GREATEST(vie.says_total_start, vie.understands_total_start) as understood,
+           vie.says_total_start                                        as spoken,
+           null                                                        as signed,
+           null                                                        as produced,
+           800                                                         as survey_vocab_max
+    FROM vocab_ie_01 as vie
+    UNION ALL
+    SELECT 'ie_01'                                               as study,
+           vie.subject_id,
+           NULL                                                    as sex,
+           vie.age_months_end                                      as age,
+           GREATEST(vie.says_total_end, vie.understands_total_end) as understood,
+           vie.says_total_end                                      as spoken,
+           null                                                    as signed,
+           vie.says_total_end                                      as produced,
+           800                                                     as survey_vocab_max
+    FROM vocab_ie_01 as vie
+    UNION ALL
+    -- us_01 (Edgin): the English Down syndrome subset of the Wordbank export.
+    -- Wordbank's CDI: Words & Sentences (WS) form records comprehension as a
+    -- production proxy (comprehension == production by data convention), so
+    -- understood is taken only from the genuinely bivariate forms — the same
+    -- guard load_data applies on the TD side. WS rows still contribute
+    -- production (spoken/produced). See
+    -- notes/202607061200-us01-edgin-ws-comprehension-issue.md.
+    SELECT 'us_01'                          as study,
+           concat('id_', hex(hash(child_id))) as subject_id,
+           sex,
+           age,
+           CASE
+               WHEN form IN ({bivariate_forms_sql_list}) THEN comprehension
+               ELSE NULL
+           END                                as understood,
+           production                         as spoken,
+           null                               as signed,
+           production                         as produced,
+           CASE form
+               WHEN 'WG' THEN 396
+               WHEN 'WS' THEN 690
+               ELSE NULL
+               END                            as survey_vocab_max
+    FROM wordbank_child
+    WHERE dataset_name = 'Edgin'
+      AND language IN ({english_sql_list})
+      AND lower(health_conditions) = 'down syndrome'
+      -- Production cap inherited from the initial import with no recorded
+      -- rationale (in the 2026-07 export it drops the highest-production
+      -- administrations: 8/87 WG and 24/109 WS English DS rows). Kept as-is
+      -- pending review; see the 2026-07-06 note above.
+      AND production <= 100
+    UNION ALL
+    SELECT 'uk_03'                           as study,
+           vuk2025.subject_id,
+           NULL                                as sex,
+           vuk2025.age,
+           vuk2025.comprehension               as understood,
+           vuk2025.production                  as spoken,
+           null                                as signed,
+           vuk2025.production                  as produced,
+           418                                 as survey_vocab_max
+    FROM vocab_uk_03 as vuk2025
+    UNION ALL
+    SELECT 'it_01'                           as study,
+           vit2013.subject_id,
+           NULL                                as sex,
+           vit2013.age,
+           vit2013.understood,
+           vit2013.spoken,
+           null                                as signed,
+           vit2013.spoken                      as produced,
+           vit2013.form_max_spoken             as survey_vocab_max
+    FROM vocab_it_01 as vit2013
+    UNION ALL
+    SELECT 'uk_04'                           as study,
+        vuk2013.subject_id,
+        NULL                                as sex,
+        vuk2013.age,
+        vuk2013.understood,
+        vuk2013.spoken,
+        vuk2013.signed,
+        vuk2013.spoken                      as produced,
+        418                                 as survey_vocab_max
+    FROM vocab_uk_04 as vuk2013
+        UNION ALL
+    SELECT 'uk_05'                           as study,
+        vuk05.subject_id,
+        NULL                                as sex,
+        vuk05.age,
+        vuk05.understood,
+        vuk05.spoken,
+        vuk05.signed,
+        vuk05.spoken                      as produced,
+        418                                 as survey_vocab_max
+    FROM vocab_uk_05 as vuk05
+        UNION ALL
+    SELECT 'us_02'                           as study,
+        vus02.subject_id,
+        NULL                                as sex,
+        vus02.age,
+        vus02.understood,
+        vus02.spoken,
+        NULL                                as signed,
+        vus02.spoken                     as produced,
+        418                                 as survey_vocab_max
+    FROM vocab_us_02 as vus02
+        UNION ALL
+    SELECT 'uk_06'                           as study,
+        vuk06.subject_id,
+        NULL                                as sex,
+        vuk06.age,
+        vuk06.understood,
+        vuk06.spoken,
+        vuk06.signed                                as signed,
+        vuk06.spoken                      as produced,
+        800                                 as survey_vocab_max
+    FROM vocab_uk_06 as vuk06
+        UNION ALL
+    SELECT 'ie_02'                           as study,
+        vie2.subject_id,
+        NULL                                as sex,
+        vie2.age,
+        vie2.understood,
+        vie2.spoken,
+        vie2.signed                         as signed,
+        vie2.spoken                         as produced,
+        800                                 as survey_vocab_max
+    FROM vocab_ie_02 as vie2
+    WHERE vie2.english_speaking = 'yes'
+    UNION ALL
+    -- nz_01 (Foster-Cohen): production-only, no comprehension. The CSV columns are
+    -- modality-exclusive, so any-modality spoken = spoken + spoken_signed (a + c)
+    -- and signed = signed + spoken_signed (b + c). 675-item NZCDI ceiling.
+    SELECT 'nz_01'                                        as study,
+        vnz01.subject_id,
+        NULL                                              as sex,
+        vnz01.age,
+        NULL                                              as understood,
+        vnz01.spoken + vnz01.spoken_signed                as spoken,
+        vnz01.signed + vnz01.spoken_signed                as signed,
+        vnz01.spoken + vnz01.signed + vnz01.spoken_signed as produced,
+        675                                               as survey_vocab_max
+    FROM vocab_nz_01 as vnz01
+    """
 
 
 def load_combined_data(max_age_months=None):
@@ -156,9 +368,9 @@ def load_data(
     needs_understood = "understood" in columns
     needs_spoken = "spoken" in columns
 
-    td_forms = list(TD_BIVARIATE_FORMS)
+    td_forms = list(WORDBANK_BIVARIATE_FORMS)
     if needs_spoken or not needs_understood:
-        td_forms.extend(TD_SPOKEN_ONLY_FORMS)
+        td_forms.extend(WORDBANK_SPOKEN_ONLY_FORMS)
 
     age_upper = max_age_months if max_age_months is not None else 30
 
@@ -179,7 +391,7 @@ def load_data(
                 concat('id_', hex(hash(child_id))) as subject_id,
                 age,
                 CASE
-                    WHEN form IN ('Oxford CDI', 'WG') THEN comprehension
+                    WHEN form IN ({_sql_string_list(WORDBANK_BIVARIATE_FORMS)}) THEN comprehension
                     ELSE NULL
                 END                                as understood,
                 production                         as spoken,

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -9,7 +9,7 @@ from vocab_growth.models.definitions import Population
 
 
 def test_td_load_data_keeps_ws_as_spoken_only(tmp_path, monkeypatch):
-    db_path = _create_wordbank_db(tmp_path)
+    db_path = _create_vocab_db(tmp_path)
     monkeypatch.setattr(data_utils, "VOCABULARY_DATA_PATH", str(db_path))
 
     df = data_utils.load_data(
@@ -26,7 +26,7 @@ def test_td_load_data_keeps_ws_as_spoken_only(tmp_path, monkeypatch):
 
 
 def test_td_understood_data_excludes_ws_before_sampling(tmp_path, monkeypatch):
-    db_path = _create_wordbank_db(tmp_path)
+    db_path = _create_vocab_db(tmp_path)
     monkeypatch.setattr(data_utils, "VOCABULARY_DATA_PATH", str(db_path))
 
     df = data_utils.load_data(
@@ -38,7 +38,7 @@ def test_td_understood_data_excludes_ws_before_sampling(tmp_path, monkeypatch):
 
 
 def test_td_spoken_data_includes_ws_and_bivariate_forms(tmp_path, monkeypatch):
-    db_path = _create_wordbank_db(tmp_path)
+    db_path = _create_vocab_db(tmp_path)
     monkeypatch.setattr(data_utils, "VOCABULARY_DATA_PATH", str(db_path))
 
     df = data_utils.load_data(
@@ -50,7 +50,7 @@ def test_td_spoken_data_includes_ws_and_bivariate_forms(tmp_path, monkeypatch):
 
 
 def test_td_load_data_defaults_to_english_only(tmp_path, monkeypatch):
-    db_path = _create_wordbank_db(tmp_path)
+    db_path = _create_vocab_db(tmp_path)
     monkeypatch.setattr(data_utils, "VOCABULARY_DATA_PATH", str(db_path))
 
     df = data_utils.load_data(
@@ -62,7 +62,7 @@ def test_td_load_data_defaults_to_english_only(tmp_path, monkeypatch):
 
 
 def test_td_load_data_can_widen_languages(tmp_path, monkeypatch):
-    db_path = _create_wordbank_db(tmp_path)
+    db_path = _create_vocab_db(tmp_path)
     monkeypatch.setattr(data_utils, "VOCABULARY_DATA_PATH", str(db_path))
 
     df = data_utils.load_data(
@@ -72,6 +72,44 @@ def test_td_load_data_can_widen_languages(tmp_path, monkeypatch):
     )
 
     assert "Norwegian" in df["language"].tolist()
+
+
+def _load_us01(tmp_path, monkeypatch):
+    db_path = _create_vocab_db(tmp_path)
+    monkeypatch.setattr(data_utils, "VOCABULARY_DATA_PATH", str(db_path))
+    df = data_utils.load_combined_data()
+    return df[df["study"] == "us_01"]
+
+
+def test_ds_us01_ws_form_contributes_spoken_but_not_understood(tmp_path, monkeypatch):
+    us01 = _load_us01(tmp_path, monkeypatch)
+
+    ws_rows = us01[us01["spoken"] == 77]
+    assert len(ws_rows) == 1
+    assert ws_rows["understood"].isna().all()
+
+
+def test_ds_us01_wg_form_keeps_independent_comprehension(tmp_path, monkeypatch):
+    us01 = _load_us01(tmp_path, monkeypatch)
+
+    wg_rows = us01[us01["spoken"] == 12]
+    assert wg_rows["understood"].tolist() == [40]
+
+
+def test_ds_us01_no_row_carries_the_ws_production_proxy_as_understood(
+    tmp_path, monkeypatch
+):
+    us01 = _load_us01(tmp_path, monkeypatch)
+
+    bivariate = us01.dropna(subset=["understood"])
+    assert not bivariate.empty  # the WG row is retained
+    assert not (bivariate["understood"] == bivariate["spoken"]).any()
+
+
+def test_ds_us01_production_cap_excludes_rows_above_100(tmp_path, monkeypatch):
+    us01 = _load_us01(tmp_path, monkeypatch)
+
+    assert sorted(us01["spoken"].tolist()) == [12, 77]
 
 
 def _study_frame():
@@ -111,7 +149,25 @@ def test_filter_studies_dropped_list_is_sorted():
     assert dropped == ["m", "z"]  # both singletons, sorted
 
 
-def _create_wordbank_db(tmp_path):
+# Minimal schemas for the per-study source tables referenced by the
+# vocab_combined view. The DS regression tests populate wordbank_child only,
+# so these stay empty; they exist so the view binds.
+_SOURCE_TABLE_SCHEMAS = {
+    "vocab_uk_01": "subject_id VARCHAR, sex VARCHAR, age DOUBLE, understood INTEGER, spoken INTEGER, signed INTEGER, produced INTEGER, survey_vocab_max INTEGER",
+    "vocab_uk_02": "subject_id VARCHAR, gender INTEGER, age DOUBLE, comprehension INTEGER, spoken INTEGER, signed INTEGER, production INTEGER, form VARCHAR",
+    "vocab_ie_01": "subject_id VARCHAR, age_months_start DOUBLE, understands_total_start INTEGER, says_total_start INTEGER, age_months_end DOUBLE, understands_total_end INTEGER, says_total_end INTEGER",
+    "vocab_uk_03": "subject_id VARCHAR, age DOUBLE, comprehension INTEGER, production INTEGER",
+    "vocab_it_01": "subject_id VARCHAR, age DOUBLE, understood INTEGER, spoken INTEGER, form_max_spoken INTEGER",
+    "vocab_uk_04": "subject_id VARCHAR, age DOUBLE, understood INTEGER, spoken INTEGER, signed INTEGER",
+    "vocab_uk_05": "subject_id VARCHAR, age DOUBLE, understood INTEGER, spoken INTEGER, signed INTEGER",
+    "vocab_us_02": "subject_id VARCHAR, age DOUBLE, understood INTEGER, spoken INTEGER",
+    "vocab_uk_06": "subject_id VARCHAR, age DOUBLE, understood INTEGER, spoken INTEGER, signed INTEGER",
+    "vocab_ie_02": "subject_id VARCHAR, age DOUBLE, understood INTEGER, spoken INTEGER, signed INTEGER, english_speaking VARCHAR",
+    "vocab_nz_01": "subject_id VARCHAR, age BIGINT, not_spoken_or_signed BIGINT, signed BIGINT, spoken_signed BIGINT, spoken BIGINT",
+}
+
+
+def _create_vocab_db(tmp_path):
     db_path = tmp_path / "vocabulary.duckdb"
     with duckdb.connect(str(db_path)) as con:
         con.execute(
@@ -121,6 +177,7 @@ def _create_wordbank_db(tmp_path):
                 language VARCHAR,
                 dataset_name VARCHAR,
                 child_id VARCHAR,
+                sex VARCHAR,
                 age DOUBLE,
                 comprehension INTEGER,
                 production INTEGER,
@@ -131,19 +188,31 @@ def _create_wordbank_db(tmp_path):
         )
         con.executemany(
             """
-            INSERT INTO wordbank_child VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO wordbank_child VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
-                ("WG",         "English (British)",  "Fenson (2007)",   "c01", 12.0,  40,  12, True,  None),
-                ("Oxford CDI", "English (British)",  "Hamilton (2000)", "c02", 24.0, 190,  80, True,  None),
-                ("WS",         "English (British)",  "Fenson (2007)",   "c03", 28.0,  51,  51, True,  None),
-                ("WSShort",    "English (British)",  "Fenson (2007)",   "c04", 22.0,  20,  20, True,  None),
-                ("TEDS Twos",  "English (British)",  "Fenson (2007)",   "c05", 24.0,  75,  75, True,  None),
-                ("WG",         "English (British)",  "Fenson (2007)",   "c06", 35.0, 100,  50, True,  None),
-                ("WG",         "English (British)",  "Fenson (2007)",   "c07", 18.0,  60,  20, True,  "premature"),
-                ("WG",         "English (British)",  "Fenson (2007)",   "c08", 18.0,  60,  20, False, None),
+                ("WG",         "English (British)",  "Fenson (2007)",   "c01", None, 12.0,  40,  12, True,  None),
+                ("Oxford CDI", "English (British)",  "Hamilton (2000)", "c02", None, 24.0, 190,  80, True,  None),
+                ("WS",         "English (British)",  "Fenson (2007)",   "c03", None, 28.0,  51,  51, True,  None),
+                ("WSShort",    "English (British)",  "Fenson (2007)",   "c04", None, 22.0,  20,  20, True,  None),
+                ("TEDS Twos",  "English (British)",  "Fenson (2007)",   "c05", None, 24.0,  75,  75, True,  None),
+                ("WG",         "English (British)",  "Fenson (2007)",   "c06", None, 35.0, 100,  50, True,  None),
+                ("WG",         "English (British)",  "Fenson (2007)",   "c07", None, 18.0,  60,  20, True,  "premature"),
+                ("WG",         "English (British)",  "Fenson (2007)",   "c08", None, 18.0,  60,  20, False, None),
                 # Non-English row that otherwise matches: excluded by the default English filter.
-                ("WG",         "Norwegian",           "Simonsen (2014)", "c09", 16.0,  55,  18, True,  None),
+                ("WG",         "Norwegian",           "Simonsen (2014)", "c09", None, 16.0,  55,  18, True,  None),
+                # us_01 / Edgin Down syndrome rows, feeding the vocab_combined
+                # view: WG comprehension is an independent measure; WS
+                # comprehension is a production proxy and must not become
+                # `understood`; production > 100 rows are excluded by the
+                # legacy cap in the view.
+                ("WG",         "English (American)",  "Edgin",           "d01", "F",  14.0,  40,  12, False, "Down syndrome"),
+                ("WS",         "English (American)",  "Edgin",           "d02", "M",  24.0,  77,  77, False, "Down syndrome"),
+                ("WS",         "English (American)",  "Edgin",           "d03", None, 29.0, 150, 150, False, "Down syndrome"),
+                ("WG",         "English (American)",  "Edgin",           "d04", "F",  18.0, 200, 120, False, "Down syndrome"),
             ],
         )
+        for table, table_schema in _SOURCE_TABLE_SCHEMAS.items():
+            con.execute(f"CREATE TABLE {table} ({table_schema})")
+        con.execute(data_utils.vocab_combined_view_sql())
     return db_path


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Fable 5).

## What

The us_01/Edgin block of the `vocab_combined` view selected `comprehension as understood` from `wordbank_child` with **no filter on `form`**. Wordbank's CDI: Words & Sentences (WS) form records `comprehension` as a production proxy (`comprehension == production` by data convention), so every WS row entered the DS models claiming the child understood exactly as many words as they produced. This is the same defect that retired VG06 on the TD side (see `notes/202605151630-vg06-ws-comprehension-issue.md`); the 2026-05-15 fix guarded the TD loader (`load_data`) but **not** the DS path, so that note's "unaffected" verdicts for the DS models were wrong.

## Evidence (real export)

In the English Edgin DS subset, all 109 WS rows have `comprehension == production`; 85 survive the `production <= 100` cap (ages 17–27 months, median "understood" of 7 == median spoken). At the age overlap, WG rows at 17–18 months have median understood 46.5. The 85 corrupted rows were ~10% of the DS `understood` pool, 48 of them above 18 months — precisely the window where the comprehension–production gap is of interest.

## Changes

- **`src/vocab_growth/data_utils.py`** — the `vocab_combined` view definition moves out of `scripts/prepare_data.py` into `vocab_combined_view_sql()` so it is importable and regression-tested. The Edgin block now takes `understood` only from `WORDBANK_BIVARIATE_FORMS` (renamed from `TD_BIVARIATE_FORMS` — the bivariate property belongs to the instrument, not the population), and both the TD and DS guards are built from that one constant so they cannot drift apart again. WS rows keep their valid production counts.
- **`scripts/prepare_data.py`** — executes the shared view definition instead of inline SQL.
- **`tests/test_data_utils.py`** — the fixture now builds the real `vocab_combined` view over a miniature `wordbank_child` plus empty source tables; four new DS regression tests assert WS contributes spoken but never understood, WG keeps independent comprehension, no us_01 row carries the `understood == spoken` proxy, and the production cap drops rows above 100.
- **`production <= 100` cap** — documented in the SQL and the incident note (dates from the initial commit with no recorded rationale; drops 8/87 WG and 24/109 WS rows). Kept as-is pending review, since removing it now would confound the refits this fix already requires.
- **New incident note** `notes/202607061200-us01-edgin-ws-comprehension-issue.md`; correction addendum added to the VG06 note.

## Verification

- All 13 `test_data_utils.py` tests pass (45 pass suite-wide; the 11 collection errors are pre-existing — those modules need the conda-only `arviz`/`dse_research_utils` stack).
- Rebuilt the view against the real CSVs: us_01 keeps 164 rows (79 WG + 85 WS), the 85 WS rows now have `understood` NULL, every other study unchanged. `vocab_data_merged.csv` is unaffected (us_01 only enters via the DuckDB view).
- `ruff`, `npm run spellcheck`, `npm run format:check` clean.

## Follow-up (not in this PR)

Run `python scripts/prepare_data.py` to rebuild the local DuckDB, then **refit VG02 and the DS joint models (VG05, VG07–VG10, VG14, VG15, VG16)** — all consume DS `understood` through the corrupted path. Downstream DS-vs-TD comparisons and report figures need regenerating after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)