### PR TITLE
fix(sensitivity): coerce mixed bool/None HDI column before inverting

### DIFF
--- a/src/vocab_growth/sensitivity/compare.py
+++ b/src/vocab_growth/sensitivity/compare.py
@@ -132,11 +132,13 @@ def summarise(comparison: pd.DataFrame, variant_dir: str, label: str) -> dict:
     """One-row robustness verdict for a variant (feeds the §7 matrix)."""
     converged, max_rhat, min_ess = diagnostics_gate(variant_dir)
     checked = comparison.dropna(subset=["within_baseline_hdi"])
-    n_within = int(checked["within_baseline_hdi"].sum())
+    # The column mixes Python bools with None (Ey_any / P_psi_gt_1 rows), so it
+    # is object dtype even after dropna; ~ on object bools yields -2/-1, not a
+    # mask. Coerce before inverting.
+    within = checked["within_baseline_hdi"].astype(bool)
+    n_within = int(within.sum())
     n_checked = int(len(checked))
-    outside = sorted(
-        checked.loc[~checked["within_baseline_hdi"], "quantity"].unique().tolist()
-    )
+    outside = sorted(checked.loc[~within, "quantity"].unique().tolist())
     max_abs_delta = float(comparison["delta"].abs().max()) if len(comparison) else 0.0
     if converged is False:
         verdict = "NON-CONVERGED (not assessed)"

--- a/tests/test_sensitivity_compare.py
+++ b/tests/test_sensitivity_compare.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Unit tests for the prior-sensitivity baseline/variant comparison (issue #89 §7).
+
+Pure/fast (no sampling). The load-bearing regression here is the VG15 shape:
+``compare_dirs`` emits ``within_baseline_hdi = None`` for the HDI-less series
+(``Ey_any``, ``P_psi_gt_1``), which makes the column object dtype (mixed Python
+bools + None) even after ``dropna``. ``summarise`` must coerce before inverting
+the mask — on object dtype ``~True``/``~False`` are the ints -2/-1 and ``.loc``
+raises ``KeyError``, aborting ``scripts/compare_sensitivity.py`` for vg15.
+VG10/VG11 frames are pure bool and never hit this.
+"""
+
+import pandas as pd
+
+from vocab_growth.sensitivity.compare import compare_dirs, summarise
+
+
+def test_summarise_tolerates_mixed_bool_none_hdi_column(tmp_path):
+    # Hand-built frame in the VG15 shape: object-dtype within_baseline_hdi
+    # mixing True/False/None.
+    comparison = pd.DataFrame([
+        {"quantity": "q", "age_months": 30, "delta": -0.05, "within_baseline_hdi": True},
+        {"quantity": "psi", "age_months": -1, "delta": 0.4, "within_baseline_hdi": False},
+        {"quantity": "Ey_any", "age_months": 30, "delta": 20.0, "within_baseline_hdi": None},
+        {"quantity": "P_psi_gt_1", "age_months": -1, "delta": -0.01, "within_baseline_hdi": None},
+    ])
+    assert comparison["within_baseline_hdi"].dtype == object  # the failing shape
+
+    row = summarise(comparison, str(tmp_path), label="vg15-variant")
+    assert row["n_checked"] == 2
+    assert row["n_within_hdi"] == 1
+    assert row["quantities_outside_hdi"] == "psi"
+    assert row["verdict"] == "sensitive: psi"
+    # Unchecked (None) rows still count towards the magnitude summary.
+    assert row["max_abs_delta"] == 20.0
+
+
+def _write_vg15_outputs(dirpath, q_median, p_any_median, ey_any_median, psi_median, p_psi_gt_1):
+    pd.DataFrame({
+        "age_months": [30], "q_median": [q_median],
+        "q_hdi_lo": [0.4], "q_hdi_hi": [0.6],
+    }).to_csv(dirpath / "posterior_summary_q.csv", index=False)
+    pd.DataFrame({
+        "age_months": [30], "p_any_median": [p_any_median],
+        "p_any_hdi_lo": [0.2], "p_any_hdi_hi": [0.4],
+        "Ey_any_median": [ey_any_median],
+    }).to_csv(dirpath / "posterior_summary_p_any.csv", index=False)
+    pd.DataFrame({
+        "psi_median": [psi_median], "psi_hdi_lo": [1.2], "psi_hdi_hi": [1.9],
+        "P_psi_gt_1": [p_psi_gt_1],
+    }).to_csv(dirpath / "posterior_summary_psi.csv", index=False)
+
+
+def test_compare_dirs_then_summarise_vg15_shape(tmp_path):
+    base_dir, var_dir = tmp_path / "base", tmp_path / "var"
+    base_dir.mkdir(), var_dir.mkdir()
+    _write_vg15_outputs(base_dir, q_median=0.5, p_any_median=0.3,
+                        ey_any_median=100.0, psi_median=1.5, p_psi_gt_1=0.99)
+    # q shifts outside the baseline HDI; p_any and psi stay within.
+    _write_vg15_outputs(var_dir, q_median=0.7, p_any_median=0.35,
+                        ey_any_median=120.0, psi_median=1.6, p_psi_gt_1=0.98)
+    pd.DataFrame({
+        "r_hat": [1.005], "ess_bulk": [1000.0], "ess_tail": [900.0],
+    }).to_csv(var_dir / "diagnostics.csv", index=False)
+
+    comparison = compare_dirs(str(base_dir), str(var_dir))
+    by_qty = comparison.set_index("quantity")["within_baseline_hdi"]
+    # The HDI-less series carry None, so the column is object dtype.
+    assert by_qty["Ey_any"] is None
+    assert by_qty["P_psi_gt_1"] is None
+    assert by_qty["q"] is False
+    assert by_qty["p_any"] is True
+    assert by_qty["psi"] is True
+
+    row = summarise(comparison, str(var_dir), label="vg15-variant")
+    assert row["converged"] is True
+    assert row["n_checked"] == 3
+    assert row["n_within_hdi"] == 2
+    assert row["quantities_outside_hdi"] == "q"
+    assert row["verdict"] == "sensitive: q"


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Fable 5).

## What

Fix a `KeyError` in `summarise()` (`src/vocab_growth/sensitivity/compare.py`) that aborted `scripts/compare_sensitivity.py` for VG15 before the §7 robustness matrix was written, and add regression tests.

## Why

For VG15 comparisons the `within_baseline_hdi` column mixes Python `bool`s with `None`: `compare_dirs()` emits `None` for the HDI-less series (`Ey_any` at compare.py:105 and `P_psi_gt_1` at compare.py:126). After `dropna(subset=["within_baseline_hdi"])` the column is therefore still `object` dtype rather than `bool`.

`summarise()` then did `checked.loc[~checked["within_baseline_hdi"], "quantity"]`. On an object-dtype Series of Python bools, `~` dispatches to each value's integer `__invert__`, producing `-2`/`-1` instead of a boolean mask. `.loc` treats those as labels, finds none in the index, and raises `KeyError: "None of [Index([-2, -1], dtype='object')] are in the [index]"`. This aborts the vg15 run before any robustness output is written. VG10/VG11 are unaffected because their columns are pure `bool` (no HDI-less series).

## Fix

Coerce with `.astype(bool)` after the `dropna` and invert the coerced mask; `n_within` uses the same coerced series. On the pure-bool VG10/VG11 columns this is a no-op, so their behaviour is unchanged.

## Tests

New `tests/test_sensitivity_compare.py` (pure/fast, no sampling):

- `test_summarise_tolerates_mixed_bool_none_hdi_column` — runs `summarise()` on a hand-built frame in the exact failing shape (object-dtype column mixing `True`/`False`/`None`), asserting counts, the outside-HDI list, the verdict, and that `None` rows still contribute to `max_abs_delta`.
- `test_compare_dirs_then_summarise_vg15_shape` — writes VG15-shaped CSVs (`posterior_summary_q.csv`, `posterior_summary_p_any.csv` with `Ey_any_median`, `posterior_summary_psi.csv`, plus `diagnostics.csv`) to tmp baseline/variant dirs and runs `compare_dirs()` → `summarise()` end to end, pinning that `Ey_any`/`P_psi_gt_1` carry `None` while a shifted `q` is reported as `sensitive: q`.

Both tests fail (reproducing the original `KeyError`) against the unfixed code and pass with the fix. The full suite passes (8 skips, no failures); `ruff check` is clean on the changed files.