### PR TITLE
fix(vg01,vg02): recalibrate young-age trajectory priors from prior-predictive checks

### DIFF
--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -486,9 +486,21 @@ VG01 = UnivariateModelDefinition(
     slope_anchors=(24, 84),
     ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
     p_slope_low_alpha=1.0,
-    p_slope_low_beta=15.0,
-    p_slope_hi_alpha=1.1,
-    p_slope_hi_beta=1.1,
+    # Tightened from 15.0: the prior mean-trajectory band centred the 24 mo
+    # spoken level at ~37 words, but DS speech onset is delayed — empirical mean
+    # is ~15 and even the individual p90 is ~37. Beta(1, 25) pulls the 24 mo
+    # centre down to ~22, respecting the near-zero early-speech floor without
+    # excluding the occasional early talker.
+    p_slope_low_beta=25.0,
+    # Nudged from the near-uniform Beta(1.1, 1.1) (same rationale as VG02): the
+    # 84 mo anchor was maximally vague, producing implausible flat-near-zero
+    # spoken curves out to 9 years. Beta(2, 1.5) lifts the 7-year level and
+    # curbs both tails while staying broad.
+    p_slope_hi_alpha=2.0,
+    p_slope_hi_beta=1.5,
+    # Raised from 0.4 to offset the p_slope_low pull-down: lets the HSGP add
+    # mid-range curvature so the steep 36-60 mo rise stays covered.
+    eta_sigma=0.5,
 )
 
 VG02 = UnivariateModelDefinition(
@@ -501,9 +513,20 @@ VG02 = UnivariateModelDefinition(
     slope_anchors=(24, 84),
     ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
     p_slope_low_alpha=1.0,
-    p_slope_low_beta=10.0,
-    p_slope_hi_alpha=1.1,
-    p_slope_hi_beta=1.1,
+    # Loosened from 10.0: the prior mean-trajectory band under-covered the
+    # 30-48 mo data centre (empirical median sat at the prior's 90th
+    # percentile). A fatter upper tail at the 24 mo anchor lifts the young-age
+    # band toward the observed central trend. Paired with eta_sigma=0.6 below,
+    # which widens the range of early growth rates the HSGP can express.
+    p_slope_low_beta=7.0,
+    # Nudged from the near-uniform Beta(1.1, 1.1): the 84 mo anchor was
+    # maximally vague, placing ~10% of prior mass below 80 understood words at
+    # age 7 (implausibly low for DS) and ~10% above 720. Beta(2, 1.5) is mildly
+    # informative (mean ~0.57, still spanning ~0.1-0.95), curbing the
+    # flat-near-zero and rocket-to-800 tails without over-committing the level.
+    p_slope_hi_alpha=2.0,
+    p_slope_hi_beta=1.5,
+    eta_sigma=0.6,
 )
 
 VG03 = UnivariateModelDefinition(


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Why

A prior-predictive check on the two single-outcome Down syndrome models — **VG01** (words spoken) and **VG02** (words understood) — showed the population **mean-trajectory** prior was miscalibrated in the younger years, in *opposite* directions for the two outcomes. Because the plotted prior sample curves are draws of the population mean trajectory, they can be compared directly against where the data actually sit. Separately, both models shared a maximally-vague 84-month upper anchor that produced implausible flat-near-zero curves running out to nine years of age.

The recalibration follows the project's iterative Bayesian workflow: adjust priors so the prior predictive comfortably *covers* domain-plausible trajectories (rather than fighting them), then confirm with a refit. The dispersion (`kappa`) and lengthscale (`ell`) priors were reviewed as part of this and left unchanged — the observation-level spread they govern is orthogonal to the mean-trajectory issue.

## VG02 (understood) — prior too pessimistic at 30–48 months

The prior mean-trajectory band under-covered the observed central trend. The empirical median child (≈205 words at 30 mo, ≈260 at 36 mo) sat at the prior band's **90th percentile**, so fewer than ~10% of prior mean curves even passed through the centre of the 30–36-month data. Equivalently, the empirical median growth rate over 24→36 mo (≈16 words/mo) landed at the prior's **99th** percentile. The two-anchor logit-linear trend was too shallow for the observed early rise, and the GP amplitude was too small to add the needed curvature.

- `p_slope_low`: `Beta(1, 10)` → `Beta(1, 7)` — lifts and fattens the 24-month anchor so the young-age band reaches the observed central trend.
- `eta_sigma`: `0.4` → `0.6` — widens the range of early growth rates the HSGP can express.

## VG01 (spoken) — prior too optimistic at 18–30 months

The mirror-image problem. The prior centred the 24-month spoken level at ≈37 words, but DS speech onset is delayed: empirical mean ≈15 and even the individual p90 is only ≈37. A band of prior curves cruised at 100–400 words by 20–30 months, where essentially every real child is still non-verbal.

- `p_slope_low`: `Beta(1, 15)` → `Beta(1, 25)` — pulls the 24-month centre down to ≈22 words, respecting the near-zero early-speech floor without excluding the occasional early talker.
- `eta_sigma`: `0.4` → `0.5` — offsets the pull-down so the steep 36–60-month rise stays covered.

## Both — drop the maximally-vague upper anchor

`p_slope_hi`: `Beta(1.1, 1.1)` → `Beta(2, 1.5)`. The near-uniform 84-month anchor placed ~10% of prior mass below 80 words and ~10% above 720 at age 7. The low tail is what produced the flat-near-zero curves out to nine years (implausible for DS). `Beta(2, 1.5)` (mean ≈0.57, still spanning ~0.1–0.95) curbs both the flat-zero and rocket-to-800 tails and gives a plausible seven-year level while staying broad.

## Summary of changes

| Parameter | VG01 (spoken) | VG02 (understood) |
| --- | --- | --- |
| `p_slope_low` (24 mo anchor) | `Beta(1, 15)` → `Beta(1, 25)` (down) | `Beta(1, 10)` → `Beta(1, 7)` (up) |
| `p_slope_hi` (84 mo anchor) | `Beta(1.1, 1.1)` → `Beta(2, 1.5)` | `Beta(1.1, 1.1)` → `Beta(2, 1.5)` |
| `eta_sigma` (GP amplitude) | `0.4` → `0.5` | `0.4` → `0.6` |

The young-age anchors move in opposite directions by design — comprehension emerges before production, so the understood prior was too low where the spoken prior was too high.

## Validation

Dev refits (`--config dev`, 500 draws × 2 chains) are stable: **R-hat 1.00** and healthy **BFMI** for both; **VG02 divergence-free**, **VG01 3/1000 divergences** (expected to clear at the higher `rep` `target_accept`). ESS is draw-count-limited by the dev config and is not a concern here. The posterior-predictive medians now track the data through the adjusted windows — VG02's steep early rise and VG01's delayed-then-steep onset.

A reporting-quality refit (`--config rep`) and `sync_report_figures.py` should follow before the model reports are regenerated from these priors.
