### PR TITLE
fix(data): exclude anomalous ie_02 subject from the data build

### DIFF
--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -58,6 +58,21 @@ key_value_table(
 
 vocab_ie_01_df = _loaded["vocab_ie_01"]
 vocab_ie_02_df = _loaded["vocab_ie_02"]
+
+# Exclude ie_02 subject ID_79C464EF367C4D5B: an evident data-entry error. Both of
+# its rows report near-ceiling counts implausible for the recorded ages (spoken/
+# understood 432/477 at 13 mo and 456/477 at 16 mo, versus 0-38 spoken for every
+# other ie_02 child under 24 mo), with the imitates/spoken/says_clearly columns
+# byte-identical at both visits and understood pinned at 477 across the 3-month
+# gap — the signature of one value propagated across the production columns. It is
+# the sole source of the anomalous >400-words-before-20-months points in the
+# spoken (VG01) and understood (VG02) trajectories. Dropped here at load so it is
+# absent from both the merged CSV and the DuckDB vocab_ie_02 table (and hence the
+# vocab_combined view the models read). Excluded pending source verification with
+# the ie_02 data provider.
+vocab_ie_02_df = vocab_ie_02_df[
+    vocab_ie_02_df["subject_id"] != "ID_79C464EF367C4D5B"
+].copy()
 vocab_it_01_df = _loaded["vocab_it_01"]
 vocab_uk_01_df = _loaded["vocab_uk_01"]
 vocab_uk_02_df = _loaded["vocab_uk_02"]
@@ -135,6 +150,9 @@ vocab_uk_06_to_merge["study"] = 9
 # (one row per timepoint t1/t2), carrying understood/spoken/signed counts. The
 # instruments measure English vocabulary, so non-English-speaking children are
 # excluded (english_speaking == 'yes'). Both recruitment groups are pooled as DS.
+# (Subject ID_79C464EF367C4D5B was dropped at load — see the exclusion note where
+# vocab_ie_02_df is read — so it is absent from both the merged CSV and the
+# DuckDB vocab_ie_02 table / vocab_combined view.)
 ireland_2_to_merge = (
     vocab_ie_02_df.loc[
         vocab_ie_02_df["english_speaking"] == "yes",


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## What

Excludes a single anomalous subject — `ID_79C464EF367C4D5B` in study `ie_02` (Ireland 2) — from the data-preparation build.

## Why it's a data error, not a real observation

The subject has two rows whose counts are implausible for the recorded ages:

| timepoint | age (mo) | understood | imitates | spoken | says_clearly |
| --- | --- | --- | --- | --- | --- |
| t1 | 13 | 477 | 432 | 432 | 432 |
| t2 | 16 | 477 | 456 | 456 | 456 |

Three independent red flags mark this as a coding error:

1. **Age-implausible.** 432 spoken words at 13 months for a child with Down syndrome is not credible — every other `ie_02` child under 24 months has 0–38 spoken words (mostly 0). This subject is a 10×+ outlier at that age.
2. **Three distinct columns are byte-identical.** `imitates = spoken = says_clearly = 432` at t1 and `= 456` at t2. These are conceptually different measures; being exactly equal at both visits is the signature of one value propagated across the production columns. Only 4 of 116 `ie_02` rows show that equality, and two are this subject.
3. **`understood = 477` is identical at both timepoints** — comprehension essentially never stays pinned at exactly the same value across a 3-month gap.

This one subject is the **sole source of the anomalous >400-words-before-20-months points in both the spoken (VG01) and understood (VG02) trajectories** — the two ≈477 dots hovering above everything else at the young end of both plots are these records.

## How

The drop is applied where `vocab_ie_02_df` is loaded in `scripts/prepare_data.py`, i.e. **before** the row feeds either downstream path — so the subject is absent from the merged CSV *and* from the DuckDB `vocab_ie_02` table (and hence the `vocab_combined` view the models read via `load_combined_data`). Verified: 0 rows for the subject in the `vocab_ie_02` table, the `vocab_combined` view, the merged CSV, and the loader; 0 rows remaining with `spoken > 400 & age < 20` or `understood > 400 & age < 20`.

The two derived artifacts (`data/vocab_data_merged.csv`, `data/vocabulary.duckdb`) are gitignored, so this PR is a single-file change to `scripts/prepare_data.py`. Regenerate them with `python scripts/prepare_data.py`.

## Status

Excluded **pending source verification** with the `ie_02` data provider — the exclusion is documented in-code with a comment so it can be revisited (corrected and reinstated) if the provider confirms the true age/values.

## Relationship to other work

Independent of, and complementary to, the young-age prior recalibration in #135: that PR tuned the VG01/VG02 priors to respect the near-zero early-speech floor and the observed early rise; this PR removes the bad data point that most directly contradicted both. Models should be refit after this lands so the posteriors reflect the cleaned data.
