### PR TITLE
fix(vg03,vg04,vg11,vg12): recalibrate TD young-age trajectory priors from prior-predictive checks

### DIFF
--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -517,10 +517,18 @@ VG03 = UnivariateModelDefinition(
     n_trials=800,
     slope_anchors=(12, 26),
     ages_query=[9, 12, 15, 18, 21, 24, 27, 30],
+    # Prior-predictive recalibration (mirrors VG01): TD production is delayed, so
+    # the old prior mean-trajectory band overshot the near-zero young floor
+    # (median ~38 words at 12 mo against an empirical mean of ~10) and ran above
+    # the data mean at every age. Lower the 12 mo anchor (Beta(1,15) -> Beta(1,30),
+    # ~26 words), soften the near-uniform 26 mo anchor (Beta(1.5,1.1) -> Beta(1.3,
+    # 1.3)), and widen eta (0.4 -> 0.5) so the median band tracks the empirical
+    # mean through the dense 16-26 mo region.
     p_slope_low_alpha=1.0,
-    p_slope_low_beta=15.0,
-    p_slope_hi_alpha=1.5,
-    p_slope_hi_beta=1.1,
+    p_slope_low_beta=30.0,
+    p_slope_hi_alpha=1.3,
+    p_slope_hi_beta=1.3,
+    eta_sigma=0.5,
     # Bumped from 0.1: total TD pool shrank from 16,552 to 6,134
     # after the WS exclusion; this keeps the effective training set
     # (~1,500 rows) close to the previous VG03 fit.
@@ -538,10 +546,17 @@ VG04 = UnivariateModelDefinition(
     n_trials=800,
     slope_anchors=(12, 26),
     ages_query=[9, 12, 15, 18, 21, 24, 27, 30],
-    p_slope_low_alpha=1.0,
-    p_slope_low_beta=20.0,
-    p_slope_hi_alpha=1.5,
-    p_slope_hi_beta=1.1,
+    # Prior-predictive recalibration (mirrors VG02): TD comprehension is already
+    # substantial at 12 mo (empirical mean ~82 words), but the old prior centred
+    # it at ~28 (the data mean sat near the prior's 85th percentile young) then
+    # overshot by 24 mo. Raise and firm up the 12 mo anchor (Beta(1,20) ->
+    # Beta(1.2,8), ~90 words, mode off zero), soften the 26 mo anchor
+    # (Beta(1.5,1.1) -> Beta(1.3,1.3)), and widen eta (0.4 -> 0.5).
+    p_slope_low_alpha=1.2,
+    p_slope_low_beta=8.0,
+    p_slope_hi_alpha=1.3,
+    p_slope_hi_beta=1.3,
+    eta_sigma=0.5,
     # Bumped from 0.1: total comprehension pool shrank from 16,552 to 6,134
     # after the WS exclusion; this keeps the effective training set
     # (~1,500 rows) close to the previous VG04 fit.
@@ -672,10 +687,13 @@ VG11 = UnivariateModelDefinition(
     n_trials=800,
     slope_anchors=(12, 26),
     ages_query=[9, 12, 15, 18, 21, 24, 27, 30],
+    # Spoken trajectory priors shared with VG03 (see the note there): lower the
+    # 12 mo anchor for delayed TD production, soften the 26 mo anchor, widen eta.
     p_slope_low_alpha=1.0,
-    p_slope_low_beta=15.0,
-    p_slope_hi_alpha=1.5,
-    p_slope_hi_beta=1.1,
+    p_slope_low_beta=30.0,
+    p_slope_hi_alpha=1.3,
+    p_slope_hi_beta=1.3,
+    eta_sigma=0.5,
     # Use all bivariate-capable rows (WG + Oxford CDI) plus WS production rows.
     # Study REs absorb between-lab variation, so subsampling is not needed.
     sample_fraction=1.0,
@@ -702,10 +720,14 @@ VG12 = UnivariateModelDefinition(
     n_trials=800,
     slope_anchors=(12, 26),
     ages_query=[9, 12, 15, 18, 21, 24, 27, 30],
-    p_slope_low_alpha=1.0,
-    p_slope_low_beta=20.0,
-    p_slope_hi_alpha=1.5,
-    p_slope_hi_beta=1.1,
+    # Understood trajectory priors shared with VG04 (see the note there): raise
+    # and firm up the 12 mo anchor for high early TD comprehension, soften the
+    # 26 mo anchor, widen eta.
+    p_slope_low_alpha=1.2,
+    p_slope_low_beta=8.0,
+    p_slope_hi_alpha=1.3,
+    p_slope_hi_beta=1.3,
+    eta_sigma=0.5,
     # WG + Oxford CDI only (WS comprehension is a production proxy).
     # Study REs absorb between-lab variation, so subsampling is not needed.
     sample_fraction=1.0,


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Why

Prior-predictive checks on the four typically-developing single-outcome models revealed the **same young-age miscalibration as the DS pair (#135), in the mirrored directions** — comprehension precedes production, so the understood prior sat too low young while the spoken prior sat too high. Both outcomes also shared the near-uniform 26-month upper anchor that the DS models had at 84 months.

Comparing each prior mean-trajectory band (p50 / p90) to the empirical **mean** curve (the population-mean curve should track the data mean; individual dispersion via `kappa` adds the spread):

**Understood (VG04, VG12) — too pessimistic young**

| Age | Prior p50 / p90 | Empirical mean |
| --- | --- | --- |
| 12 mo | **28** / 97 | **82** |
| 16 mo | 75 / 201 | 178 |
| 24 mo | 374 / 666 | 305 |

TD comprehension is already substantial at 12 months (~82 words), but the prior centred it at 28 — the data mean sat near the prior's 85th percentile through 12–16 months — then overshot by 24 months.

**Spoken (VG03, VG11) — too optimistic young**

| Age | Prior p50 / p90 | Empirical mean |
| --- | --- | --- |
| 12 mo | **38** / 124 | **10** |
| 16 mo | 92 / 233 | 48 |
| 26 mo | 483 / 735 | 319 |

TD production starts near zero (~10 words at 12 mo) and the prior median curve overshot at every age, worst at the young end (38 vs 10) where it ignored the delayed-onset floor.

## Changes

| | `p_slope_low` | `p_slope_hi` | `eta_sigma` |
| --- | --- | --- | --- |
| VG03 / VG11 (spoken) | `Beta(1,15)` → `Beta(1,30)` (down) | `Beta(1.5,1.1)` → `Beta(1.3,1.3)` | 0.4 → 0.5 |
| VG04 / VG12 (understood) | `Beta(1,20)` → `Beta(1.2,8)` (up, mode off zero) | `Beta(1.5,1.1)` → `Beta(1.3,1.3)` | 0.4 → 0.5 |

The subsampled baselines (VG03/VG04) and the full-data study-RE + GP-anchored versions (VG11/VG12) share the per-outcome priors and were changed identically. Same recipe as the DS pair: raise the understood young anchor, lower the spoken young anchor, soften the upper anchor, widen `eta`. Dispersion (`kappa`) and lengthscale (`ell`) priors reviewed and left unchanged.

## Validation

Prior-predictive regeneration for all four confirms the median band now tracks the empirical mean through the dense 12–26-month region: the understood band lifts into the early-comprehension cloud while still spanning near-zero and high individuals; the spoken band hugs the delayed-onset floor to ~15 months then fans up to cover the full 0–680 spread. The GP-anchored study-RE structure in VG11/VG12 carries it through cleanly. `ruff` clean.

## Scope

Independent of #135 (DS priors), #136 (ie_02 data exclusion), and #137 (plotting) — different models/files, no overlap. The TD models do not use `ie_02`, so they are unaffected by the data exclusion. VG13 (young TD joint) has a different `q`-ratio structure and is reviewed separately.
