### PR TITLE
chore(audit): non-fit-changing #128/#131 follow-ups (docs, diagnostics, hygiene)

### DIFF
--- a/docs/models/PRIORS.md
+++ b/docs/models/PRIORS.md
@@ -89,14 +89,14 @@ the model machinery is shared:
 The main TD/DS differences are concentrated in the anchor ages and in a few
 anchor distributions:
 
-| Prior area            | DS                                                                                      | TD                                                                                | Interpretation                                                                                                     |
-| --------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Anchor ages           | Usually 24 and 84 months.                                                               | Usually 12 and 26 months; VG13 uses 10 and 16 months.                             | Priors are placed over different developmental windows.                                                            |
-| Spoken low anchor     | `Beta(1, 15)` at 24 months in VG01.                                                     | `Beta(1, 15)` at 12 months in VG03/VG11.                                          | Same distributional shape, different age.                                                                          |
-| Understood low anchor | `Beta(1, 10)` at 24 months in DS understood and joint models.                           | `Beta(1, 20)` at 12 months in VG04/VG06/VG12; `Beta(1, 15)` at 10 months in VG13. | TD early-understanding priors are more tightly concentrated near the floor.                                        |
-| High anchor           | Usually `Beta(1.1, 1.1)` at 84 months.                                                  | Usually `Beta(1.5, 1.1)` at 26 months; VG13 uses `Beta(2, 2)` at 16 months.       | TD high-age priors lean more toward larger vocabulary by the older anchor; DS high-age priors remain much broader. |
-| Baseline `q` anchors  | `Beta(1, 1.5)` low and `Beta(2, 1.2)` high in VG05-VG09 and VG14; tighter in VG10/VG15. | Same broad defaults in VG06/VG13.                                                 | Mostly shared, except for posterior-informed DS stabilisation models.                                              |
-| Signing priors        | DS-only in VG14/VG15.                                                                   | Not modelled.                                                                     | There is no TD signing counterpart.                                                                                |
+| Prior area            | DS                                                                                      | TD                                                                           | Interpretation                                                                                                     |
+| --------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Anchor ages           | Usually 24 and 84 months.                                                               | Usually 12 and 26 months; VG13 uses 10 and 16 months.                        | Priors are placed over different developmental windows.                                                            |
+| Spoken low anchor     | `Beta(1, 15)` at 24 months in VG01.                                                     | `Beta(1, 15)` at 12 months in VG03/VG11.                                     | Same distributional shape, different age.                                                                          |
+| Understood low anchor | `Beta(1, 10)` at 24 months in DS understood and joint models.                           | `Beta(1, 20)` at 12 months in VG04/VG12; `Beta(1, 15)` at 10 months in VG13. | TD early-understanding priors are more tightly concentrated near the floor.                                        |
+| High anchor           | Usually `Beta(1.1, 1.1)` at 84 months.                                                  | Usually `Beta(1.5, 1.1)` at 26 months; VG13 uses `Beta(2, 2)` at 16 months.  | TD high-age priors lean more toward larger vocabulary by the older anchor; DS high-age priors remain much broader. |
+| Baseline `q` anchors  | `Beta(1, 1.5)` low and `Beta(2, 1.2)` high in VG05-VG09 and VG14; tighter in VG10/VG15. | Same broad defaults in VG13.                                                 | Mostly shared, except for posterior-informed DS stabilisation models.                                              |
+| Signing priors        | DS-only in VG14/VG15.                                                                   | Not modelled.                                                                | There is no TD signing counterpart.                                                                                |
 
 Review notes:
 
@@ -125,10 +125,10 @@ as a direct word count without also considering `p_U(a)`.
 | -------------------------------------- | --------------------------------------- | ---------------- | ---------------------------------------------------------------------- |
 | Low-age spoken anchor                  | VG01, VG03, VG11                        | `Beta(1, 15)`    | Median 0.045, 5-95% 0.003-0.181, or about 36 words median out of 800.  |
 | Low-age DS understood anchor           | VG02, VG05, VG07-VG10, VG14, VG15       | `Beta(1, 10)`    | Median 0.067, 5-95% 0.005-0.259, or about 54 words median out of 800.  |
-| Low-age TD understood anchor           | VG04, VG06, VG12                        | `Beta(1, 20)`    | Median 0.034, 5-95% 0.003-0.139, or about 27 words median out of 800.  |
+| Low-age TD understood anchor           | VG04, VG12                              | `Beta(1, 20)`    | Median 0.034, 5-95% 0.003-0.139, or about 27 words median out of 800.  |
 | Low-age young-TD understood anchor     | VG13                                    | `Beta(1, 15)`    | Median 0.045, 5-95% 0.003-0.181, or about 36 words median out of 800.  |
 | High-age DS single/U anchor            | VG01, VG02, VG05, VG07-VG10, VG14, VG15 | `Beta(1.1, 1.1)` | Median 0.500, 5-95% 0.060-0.940, or about 400 words median out of 800. |
-| High-age TD single/U anchor            | VG03, VG04, VG06, VG11, VG12            | `Beta(1.5, 1.1)` | Median 0.599, 5-95% 0.126-0.955, or about 479 words median out of 800. |
+| High-age TD single/U anchor            | VG03, VG04, VG11, VG12                  | `Beta(1.5, 1.1)` | Median 0.599, 5-95% 0.126-0.955, or about 479 words median out of 800. |
 | High-age young-TD understood anchor    | VG13                                    | `Beta(2, 2)`     | Median 0.500, 5-95% 0.135-0.865, or about 400 words median out of 800. |
 | Baseline low-age `q` anchor            | VG05-VG09, VG13, VG14                   | `Beta(1, 1.5)`   | Median 0.370, 5-95% 0.034-0.864 of understood words.                   |
 | Baseline high-age `q` anchor           | VG05-VG09, VG13, VG14                   | `Beta(2, 1.2)`   | Median 0.654, 5-95% 0.197-0.956 of understood words.                   |
@@ -353,14 +353,14 @@ Wordbank US-English, typically-developing, monolingual, cross-sectional deciles
 column flags where the prior _centre_ departs from the normative median at the
 anchor age:
 
-| Anchor (models)                        | Prior            | Prior median (words/800) | Wordbank median | Prior ÷ empirical                   |
-| -------------------------------------- | ---------------- | -----------------------: | --------------: | ----------------------------------- |
-| Spoken low @12mo (VG03/VG11)           | `Beta(1, 15)`    |               0.045 (36) |      0.013 (11) | 3.4× high                           |
-| Understood low @12mo (VG04/VG06/VG12)  | `Beta(1, 20)`    |               0.034 (27) |      0.104 (83) | 0.33× low                           |
-| Spoken high @26mo (VG03/VG06/VG11)     | `Beta(1.5, 1.1)` |              0.599 (479) |     0.436 (349) | 1.4× (broad, covers)                |
-| Young-TD understood low @10mo (VG13)   | `Beta(1, 15)`    |               0.045 (36) |      0.062 (50) | 0.73×                               |
-| Young-TD understood high @16mo (VG13)  | `Beta(2, 2)`     |              0.500 (400) |     0.222 (177) | 2.3× high (at the WG ceiling)       |
-| Understood high @26mo (VG04/VG06/VG12) | `Beta(1.5, 1.1)` |              0.599 (479) |               — | no CDI norm (WS is production-only) |
+| Anchor (models)                       | Prior            | Prior median (words/800) | Wordbank median | Prior ÷ empirical                   |
+| ------------------------------------- | ---------------- | -----------------------: | --------------: | ----------------------------------- |
+| Spoken low @12mo (VG03/VG11)          | `Beta(1, 15)`    |               0.045 (36) |      0.013 (11) | 3.4× high                           |
+| Understood low @12mo (VG04/VG12)      | `Beta(1, 20)`    |               0.034 (27) |      0.104 (83) | 0.33× low                           |
+| Spoken high @26mo (VG03/VG11)         | `Beta(1.5, 1.1)` |              0.599 (479) |     0.436 (349) | 1.4× (broad, covers)                |
+| Young-TD understood low @10mo (VG13)  | `Beta(1, 15)`    |               0.045 (36) |      0.062 (50) | 0.73×                               |
+| Young-TD understood high @16mo (VG13) | `Beta(2, 2)`     |              0.500 (400) |     0.222 (177) | 2.3× high (at the WG ceiling)       |
+| Understood high @26mo (VG04/VG12)     | `Beta(1.5, 1.1)` |              0.599 (479) |               — | no CDI norm (WS is production-only) |
 
 Every prior's 5–95% band still covers the empirical median, so none is
 inconsistent with the norms — but several are off-centre. The low-age anchors

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -77,6 +77,8 @@ The association $\psi$ is deliberately kept **decoupled** from the subject rando
 - **spoken / signed marginals** (uk_01/04/05/06 + uk_02 marginal-only rows): $\text{BetaBinomial}(800, p_U q, \kappa_S)$ and $\text{BetaBinomial}(800, p_U r, \kappa_\text{sign})$.
 - **uk_02 four cells** (the only cross-tab source): $\text{DirichletMultinomial}(\text{total}, \text{conc}\cdot[\pi_\text{neither}, \pi_\text{sign-only}, \pi_\text{speak-only}, \pi_\text{both}])$. For rows with complete four-cell data, `total` is the four-cell sum and is also used as the understood count for that assessment occasion, so the marginal understood likelihood and the four-cell likelihood share one authoritative total. **This is what identifies $\psi$.**
 
+The Dirichlet-Multinomial four-cell likelihood is excluded from LOO-CV by design: it is not a per-observation Beta-Binomial like the three marginal word-count likelihoods, so LOO-CV is reported for words understood, spoken and signed only, matching every other model's scope.
+
 ::: {.callout-important title="psi rests almost entirely on uk_02 — descriptive / exploratory"}
 
 The association $\psi$ is identified by the ~60 uk_02 rows with the four-cell cross-tab (19–56 months). It is a **single scalar** (the data do not support an age-varying association at this sample size) and is **descriptive/exploratory**. The four-cell composition outside ~19–56 months, and $p_\text{any}$ there, lean on the marginal trajectories plus scalar-$\psi$ extrapolation. uk_06 contributes marginal signed/spoken counts only (no cross-tab).

--- a/docs/report/methods-data.qmd
+++ b/docs/report/methods-data.qmd
@@ -1,6 +1,6 @@
 ---
 title: "Data and measures"
-abstract: "*TODO*"
+abstract: "This chapter describes the data behind the analyses: parent-report vocabulary assessments of children with Down syndrome pooled from several international studies and harmonised onto a common 800-item reference inventory. For each study we tabulate the numbers of words understood and spoken — and, for the signing sub-set, words signed — by age, alongside the observation and child counts, age range, and per-measure summaries. It then documents the measurement decisions that shape those counts: the common 800-item scale and its relationship to each source form's native checklist ceiling, the production-only treatment of Wordbank Words & Sentences records, and the study-specific inclusion rules applied when loading the data."
 ---
 
 ::: {.callout-note}
@@ -39,4 +39,8 @@ _ds_summary
 
 The models report vocabulary counts on a common 800-item reference scale ($N_{\text{trials}} = 800$). This is a reference-inventory scale rather than the native denominator for every source checklist: some source forms have lower ceilings, including Wordbank Words & Gestures (about 396 items) and Oxford CDI (about 418 items). The common scale keeps estimates comparable across DS and TD instruments, but it remains a modelling approximation, so source-form ceilings and near-ceiling observations should be checked when interpreting high-count regions.
 
+Each source's native checklist ceiling is recorded in the data as `survey_vocab_max`, but the likelihoods do not use it: every count is modelled against the common 800-item denominator regardless of the form it came from. A count near a small form's ceiling is therefore effectively right-censored under the harmonisation — a child who checks every item on Words & Gestures (about 396 items) records 396, not the larger count they might reach on a fuller inventory, yet the model treats 396 as one of 800 possible words. High-count observations from small-ceiling forms should be read with this censoring in mind.
+
 Wordbank Words & Sentences (WS) records are treated as **production-only** because the WS comprehension field is a production proxy rather than an independent comprehension measurement. TD spoken-only models can use WS production counts, but TD bivariate models that estimate both understood and spoken vocabulary exclude WS rows and rely on WG and Oxford CDI observations for the comprehension-production gap.
+
+The us_01 Edgin Down syndrome Wordbank subset carries a further inclusion rule: rows are kept only where production is at most 100 words (`US_01_MAX_PRODUCTION`), a legacy cap retained pending review of its rationale. In the 2026-07 export this excludes 8 of 87 Words & Gestures rows and 24 of 109 Words & Sentences rows from that subset.

--- a/scripts/compare_ds_td.py
+++ b/scripts/compare_ds_td.py
@@ -4,7 +4,7 @@
 DEPRECATED — superseded by ``scripts/compare_models.py``.
 
 This one-off produced the early VG07-vs-VG06 ``ds_td_q_vs_understood`` overlay
-and ``ds_td_q_crossings.csv``. The canonical figure (DS VG09 vs TD VG06, with
+and ``ds_td_q_crossings.csv``. The canonical figure (DS VG09 vs TD VG13, with
 VG07 as a dashed reference) is now produced by
 ``compare_models.ds_td_q_vs_understood``. This shim delegates there so the
 output files stay in sync; please call ``compare_models.py`` directly.

--- a/scripts/compare_ds_td_trajectories.py
+++ b/scripts/compare_ds_td_trajectories.py
@@ -38,6 +38,8 @@ UNDERSTOOD_COLOUR = "C0"
 SPOKEN_COLOUR = "C1"
 
 X_MAX = 115.0
+# TODO(#131): derive from definition.n_trials (this script only reads the
+# per-model summary CSVs and has no model definition object in scope).
 N_TRIALS = 800
 
 

--- a/scripts/kfold_loso.py
+++ b/scripts/kfold_loso.py
@@ -58,7 +58,15 @@ from vocab_growth.models.common_bivariate import (
 from vocab_growth.models.common_bivariate_re import build_model_re
 from vocab_growth.models.definitions import VG07, VG08, VG09, BivariateModelDefinition
 
-N_TRIALS = 800
+# Derive the Beta-Binomial trial count from the model definitions rather than a
+# literal (issue #131). All three compared models share the common 800-item
+# reference scale; assert they agree so a future divergence surfaces here.
+_n_trials_set = {VG07.n_trials, VG08.n_trials, VG09.n_trials}
+assert len(_n_trials_set) == 1, (
+    f"VG07/VG08/VG09 disagree on n_trials ({sorted(_n_trials_set)}); "
+    "kfold_loso assumes a single common trial count."
+)
+N_TRIALS = _n_trials_set.pop()
 OUT_DIR = env.comparisons_output_dir()
 KFOLD_TMP_DIR = os.path.join(env.output_root(), "kfold_tmp")
 

--- a/scripts/loso_compare.py
+++ b/scripts/loso_compare.py
@@ -43,6 +43,8 @@ import vocab_growth.data_utils as data_utils
 from vocab_growth import environment as env
 
 EPSILON = 1e-12
+# TODO(#131): derive from definition.n_trials (this script keys off trace
+# folders via ModelSpec and has no model definition object in scope).
 N_TRIALS = 800
 
 MODELS_DIR = env.models_output_dir()
@@ -101,6 +103,20 @@ def aggregate_to_subject(
 
     ll_u = ll["y_u_obs"].values
     ll_s = ll["y_s_obs"].values
+    # The trace's per-observation log-likelihoods are aligned to the freshly
+    # re-queried frame purely by row position, and load_combined_data() has no
+    # ORDER BY. Guard against a frame/trace row-count mismatch before aligning
+    # (mirrors common_joint_modality.sample_posterior_predictive).
+    assert ll_u.shape[-1] == len(subj_u), (
+        f"understood log-likelihood obs dim ({ll_u.shape[-1]}) does not match "
+        f"the re-queried frame's understood-row count ({len(subj_u)}); the "
+        "trace and analysis frame are misaligned."
+    )
+    assert ll_s.shape[-1] == len(subj_s), (
+        f"spoken log-likelihood obs dim ({ll_s.shape[-1]}) does not match "
+        f"the re-queried frame's spoken-row count ({len(subj_s)}); the "
+        "trace and analysis frame are misaligned."
+    )
     n_chain, n_draw = ll_u.shape[:2]
     out = np.zeros((n_chain, n_draw, n_subjects), dtype=ll_u.dtype)
     np.add.at(out, (slice(None), slice(None), subj_u), ll_u)

--- a/scripts/regenerate_vg09_marginal_predictive.py
+++ b/scripts/regenerate_vg09_marginal_predictive.py
@@ -37,6 +37,8 @@ import vocab_growth.plotting as plotting
 from vocab_growth import environment as env
 
 VG09_DIR = os.path.join(env.models_output_dir(), "VG09-age-understood-spoken-ds-re-subj-uq")
+# TODO(#131): derive from definition.n_trials (this script post-processes a
+# saved trace and has no model definition object in scope).
 N_TRIALS = 800
 EPSILON = 1e-12
 SEED = 47
@@ -244,17 +246,19 @@ def main() -> None:
 
     def _augment_summary(summary_path: str, y_arr: np.ndarray) -> None:
         df = pd.read_csv(summary_path)
-        # y_arr: (N, n_query). Quantiles across draws per age.
-        y_median = np.median(y_arr, axis=0).astype(int)
-        y_lo = np.quantile(y_arr, 0.05, axis=0).astype(int)
-        y_hi = np.quantile(y_arr, 0.95, axis=0).astype(int)
+        # y_arr: (N, n_query). Quantiles across draws per age. Round to the
+        # nearest integer count rather than truncating (floor), which would
+        # bias every reported count downward.
+        y_median = np.rint(np.median(y_arr, axis=0)).astype(int)
+        y_lo = np.rint(np.quantile(y_arr, 0.05, axis=0)).astype(int)
+        y_hi = np.rint(np.quantile(y_arr, 0.95, axis=0)).astype(int)
         df["Y_median"] = y_median
         df["Y_hdi_lo"] = y_lo
         df["Y_hdi_hi"] = y_hi
         df["Y_p05"] = y_lo
         df["Y_p95"] = y_hi
-        df["Y_p25"] = np.quantile(y_arr, 0.25, axis=0).astype(int)
-        df["Y_p75"] = np.quantile(y_arr, 0.75, axis=0).astype(int)
+        df["Y_p25"] = np.rint(np.quantile(y_arr, 0.25, axis=0)).astype(int)
+        df["Y_p75"] = np.rint(np.quantile(y_arr, 0.75, axis=0)).astype(int)
         for c in cutoffs:
             col = f"P(Y={c})" if c == 0 else f"P(Y<={c})"
             df[col] = (y_arr <= c).mean(axis=0)

--- a/src/vocab_growth/comparison.py
+++ b/src/vocab_growth/comparison.py
@@ -230,27 +230,6 @@ def summarise_per_N(samples: np.ndarray, grid: np.ndarray) -> pd.DataFrame:
     return summarise_draws(samples, grid, "N")
 
 
-def prob_a_greater_b(
-    a: np.ndarray, b: np.ndarray, *, n_iter: int = 20000, rng=None
-) -> np.ndarray:
-    """Per-column MC estimate of P(a > b) treating columns as independent posteriors.
-
-    NaN-aware; NaN where either column is empty.
-    """
-    if rng is None:
-        rng = np.random.default_rng(0)
-    p = np.full(a.shape[1], np.nan)
-    for i in range(a.shape[1]):
-        a_i = a[~np.isnan(a[:, i]), i]
-        b_i = b[~np.isnan(b[:, i]), i]
-        if a_i.size == 0 or b_i.size == 0:
-            continue
-        a_s = rng.choice(a_i, size=n_iter, replace=True)
-        b_s = rng.choice(b_i, size=n_iter, replace=True)
-        p[i] = float(np.mean(a_s > b_s))
-    return p
-
-
 # ----------------------------------------------------------------------------
 # Analyses (per-draw, population-level)
 # ----------------------------------------------------------------------------

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -1087,7 +1087,10 @@ def _extract_produced_cell_observations(
 def sample_posterior_predictive(context: JointContext, definition=None):
     """Posterior predictive for the observed cell-count likelihoods."""
     with context.model:
-        var_names = ["cells_obs"]
+        # Include the three marginal word-count likelihoods alongside the
+        # four-cell composition likelihoods so they are posterior-predictively
+        # sampled too (they are unconditionally defined in the build above).
+        var_names = ["cells_obs", "y_u_obs", "y_s_obs", "y_sign_obs"]
         if "nz_prod_cells_obs" in context.model.named_vars:
             var_names.append("nz_prod_cells_obs")
         trace = pm.sample_posterior_predictive(


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

The **non-fit-changing** follow-ups from the methodology/code audit (#128, #131). None of these touch a model posterior, likelihood, or the analysis data frame — the two fit-changing items (drop the impossible `it_01` ceiling-violating row; fix the inverted TD anchor priors) are handled in a separate PR, since those gate the reporting-tier re-fit.

Refs #128, #131 — neither fully closes; the fit-changing items remain.

## Changes

**Docs**

- `docs/report/methods-data.qmd`: wrote the chapter abstract; documented the 800-item harmonisation vs each source form's native ceiling (`survey_vocab_max` is carried in the data but unused by the likelihoods, so counts near a small form's ceiling are effectively right-censored), and the `us_01`/Edgin `production <= 100` inclusion cap (`US_01_MAX_PRODUCTION`) and what it excludes (8/87 WG, 24/109 WS in the 2026-07 export).
- `docs/models/PRIORS.md`: dropped the retired **VG06** from the live-prior model groupings. **No prior values changed** (the `Beta(` count is 39 before and after; the remaining diff is Prettier table realignment).
- `docs/models/vg15/index.qmd`: noted the Dirichlet-Multinomial four-cell likelihood is excluded from LOO-CV by design (previously only in the code docstring).

**Diagnostics / code**

- VG15 PPC (`common_joint_modality.py`): also posterior-predictively sample the marginal word-count likelihoods (`y_u_obs`/`y_s_obs`/`y_sign_obs`), not just the four-cell counts. Additive — the PPC consumer reads `cells_obs`/`nz_prod_cells_obs` by name, so nothing downstream changes and the posterior is untouched.
- `scripts/loso_compare.py`: assert the trace's per-observation log-likelihood length matches the re-queried frame before the positional aggregation (guards the no-`ORDER BY` re-query; mirrors the existing guard in `common_joint_modality.py`).
- `scripts/kfold_loso.py`: derive `n_trials` from the VG07/VG08/VG09 definitions (with an agreement assertion) instead of a literal; the other CV scripts that have no definition object in scope get a `# TODO(#131)` marker rather than a fragile refactor.
- `scripts/regenerate_vg09_marginal_predictive.py`: round (not truncate) the predictive median/quantile count columns.
- Removed the unused `prob_a_greater_b` from `comparison.py`; fixed a stale VG06 docstring reference in `compare_ds_td.py`.

## Verification

- `ruff check src/ scripts/ tests/`, `npm run spellcheck`, and `npm run format:check` all pass.
- `pytest tests/test_comparison.py tests/test_data_utils.py tests/test_nz01_produced_cells.py` — 33 passed.
- The VG15 PPC change runs only during a VG15 fit; the three added names are confirmed to be real, unconditionally-defined observed RVs, and the PPC consumer accesses other variables by name, so it is additive and non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
