### PR TITLE
fix(vg13): recalibrate young-TD joint priors — q-ratio was using the DS defaults

### DIFF
--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -736,10 +736,26 @@ VG13 = BivariateModelDefinition(
     max_age_months=18,
     slope_anchors=(10, 16),
     ages_query=[8, 10, 12, 14, 16, 18],
+    # Understood trajectory. The 10 mo anchor Beta(1,15) (~50 words) matches the
+    # empirical mean (~51). Prior-predictive checks showed the 16 mo anchor was
+    # too high: Beta(2,2) centres on 0.5 (~400 words) against an empirical mean
+    # of ~178, so the trajectory overshot ~2x by 16 mo. Lower it to Beta(2,6)
+    # (~0.25, ~200 words) so the median tracks the data at the anchor.
     p_slope_low_u_alpha=1.0,
     p_slope_low_u_beta=15.0,
     p_slope_hi_u_alpha=2.0,
-    p_slope_hi_u_beta=2.0,
+    p_slope_hi_u_beta=6.0,
+    # Production ratio q = P(speak | understood). The shared bivariate defaults
+    # (lo Beta(1,1.5)~0.4, hi Beta(2,1.2)~0.62) are tuned for the DS 24/84 mo
+    # window where a large fraction of understood words are spoken; in this young
+    # TD window (8-18 mo) production is just beginning and the empirical q is
+    # ~0.09 (10 mo) rising to ~0.23 (16 mo). The DS defaults centred q 3-4x too
+    # high, compounding with U to overshoot spoken ~5x. Set window-appropriate
+    # anchors: lo Beta(1,10) (~0.09), hi Beta(2,7) (~0.22).
+    p_slope_low_q_alpha=1.0,
+    p_slope_low_q_beta=10.0,
+    p_slope_hi_q_alpha=2.0,
+    p_slope_hi_q_beta=7.0,
     # Use all available bivariate rows in the 8–18 month window; study REs
     # absorb between-lab variation so no subsampling is required.
     sample_fraction=1.0,


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Why

Prior-predictive checks on VG13 (joint understood + spoken, TD, 8–18 months) showed a **compounded overshoot** on both components of the `q`-decomposition (`spoken = p_U · q`).

**Production ratio `q` — the headline.** VG13 inherited the shared `BivariateModelDefinition` `q` defaults (`lo Beta(1,1.5)` ≈ 0.40, `hi Beta(2,1.2)` ≈ 0.62), which are tuned for the **DS 24/84-month window** where a large fraction of understood words are spoken. In this young TD window production is only just beginning — the empirical `q` is ~0.09 at 10 months rising to ~0.23 at 16 months — so the DS defaults centred `q` **3–4× too high**:

| Age | Prior q p50 (old) | Empirical q |
| --- | --- | --- |
| 10 mo | 0.375 | 0.089 |
| 16 mo | 0.652 | 0.225 |

**Understood `p_U`.** The 10-month anchor `Beta(1,15)` (~50 words) already matched the empirical mean (~51), but the 16-month anchor `Beta(2,2)` centred on 0.5 (~400 words) against an empirical mean of ~178, so the trajectory overshot ~2×.

Compounded, the two overshoots put the implied **spoken** median ~5–6× above the data (e.g. 16 mo prior median 229 vs empirical mean 43).

## Changes

| Component | current | new | target |
| --- | --- | --- | --- |
| understood `hi` (16 mo) | `Beta(2,2)` (~0.50) | `Beta(2,6)` | ~0.25 (~200 words) |
| `q` `lo` (10 mo) | `Beta(1,1.5)` (~0.40) | `Beta(1,10)` | ~0.09 |
| `q` `hi` (16 mo) | `Beta(2,1.2)` (~0.62) | `Beta(2,7)` | ~0.22 |

The understood lower anchor and both `eta` are unchanged — the issue was level/anchors, not range.

## Validation

Prior-predictive regenerated via the **RE engine** (`common_bivariate_re`, the engine VG13 actually dispatches to — correct 8–18-month window, study intercepts, GP anchor at 13 months). With the fix:
- `q` tracks the empirical ratio across 10–18 months (16 mo 0.20 vs 0.23).
- understood sits on the 16-month data (median ~182 vs empirical ~178) instead of ~395.
- the implied **spoken** band hugs the delayed-onset floor to ~14 months then fans up over the observed 0–360 range, instead of overshooting ~5×.

`ruff` clean.

## Scope

Independent of #135/#136/#137/#138 — VG13-only, `definitions.py`. Completes the young-age prior-recalibration sweep (DS #135, TD single-outcome #138, TD joint here). VG13 uses TD data only, so it is unaffected by the `ie_02` exclusion (#136).
