### PR TITLE
fix(data): form-ceiling guard — drop counts above their source form's ceiling

### DIFF
--- a/src/vocab_growth/data_utils.py
+++ b/src/vocab_growth/data_utils.py
@@ -96,6 +96,22 @@ def _sql_string_list(values: tuple[str, ...]) -> str:
     return ", ".join(f"'{v}'" for v in values)
 
 
+# Form-ceiling guard (issues #128/#131): exclude rows whose word count exceeds
+# the native item ceiling of the checklist form they came from
+# (``survey_vocab_max``). Such counts are impossible — a data-entry error, e.g.
+# an it_01 row recording 461 words understood on a 408-item form — and must not
+# reach any model. Rows with an unknown ceiling (``survey_vocab_max`` NULL) are
+# kept, as are counts at the ceiling (a legitimate ceiling observation); only a
+# count strictly above its form's ceiling is dropped.
+_CEILING_GUARD_KEEP = (
+    "survey_vocab_max IS NULL OR ("
+    "(understood IS NULL OR understood <= survey_vocab_max) AND "
+    "(spoken IS NULL OR spoken <= survey_vocab_max) AND "
+    "(signed IS NULL OR signed <= survey_vocab_max) AND "
+    "(produced IS NULL OR produced <= survey_vocab_max))"
+)
+
+
 def vocab_combined_view_sql() -> str:
     """Return the ``CREATE VIEW vocab_combined`` statement.
 
@@ -113,6 +129,7 @@ def vocab_combined_view_sql() -> str:
     bivariate_forms_sql_list = _sql_string_list(WORDBANK_BIVARIATE_FORMS)
     return f"""
     CREATE VIEW vocab_combined AS
+    SELECT * FROM (
     SELECT 'uk_01' as study,
            vuk1.subject_id,
            vuk1.sex,
@@ -287,6 +304,8 @@ def vocab_combined_view_sql() -> str:
         vnz01.spoken + vnz01.signed + vnz01.spoken_signed as produced,
         675                                               as survey_vocab_max
     FROM vocab_nz_01 as vnz01
+    ) vc
+    WHERE {_CEILING_GUARD_KEEP}
     """
 
 

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -108,6 +108,29 @@ def test_ds_us01_production_cap_excludes_rows_above_100(tmp_path, monkeypatch):
     assert sorted(us01["spoken"].tolist()) == [12, 77]
 
 
+def test_form_ceiling_guard_drops_counts_above_survey_vocab_max(tmp_path, monkeypatch):
+    # issue #131: a count above its source form's native ceiling is impossible
+    # (a data-entry error) and must be dropped. it_01 carries a per-row ceiling
+    # (form_max_spoken); a row with understood=461 on a 408-item form is
+    # excluded, while a count at the ceiling is a legitimate observation kept.
+    db_path = _create_vocab_db(tmp_path)
+    with duckdb.connect(str(db_path)) as con:
+        con.executemany(
+            "INSERT INTO vocab_it_01 VALUES (?, ?, ?, ?, ?)",
+            [
+                ("it_ok", 30.0, 408, 100, 408),  # understood == ceiling: kept
+                ("it_bad", 47.0, 461, 12, 408),  # understood 461 > 408: dropped
+            ],
+        )
+    monkeypatch.setattr(data_utils, "VOCABULARY_DATA_PATH", str(db_path))
+
+    it01 = data_utils.load_combined_data()
+    it01 = it01[it01["study"] == "it_01"]
+
+    assert it01["understood"].tolist() == [408]  # only the valid (at-ceiling) row survives
+    assert 461 not in it01["understood"].tolist()
+
+
 def _study_frame():
     # Studies A (3 rows), B (1 row), C (5 rows); index intentionally non-trivial.
     studies = ["A", "A", "A", "B", "C", "C", "C", "C", "C"]


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

Adds a **form-ceiling guard** to the `vocab_combined` view so a word count that exceeds its own source checklist's native item ceiling — an impossible, data-entry-error value — never reaches a model. Addresses the per-form-ceiling gap from the methodology/code audit (#131 §1 adjacent; #128).

**This is a data-frame change** — the fit-changing companion to the docs-only #139. The DS models that read `it_01` (VG02, VG05, VG07–VG10, VG14–VG16) will differ slightly on a re-fit.

## The problem

Nothing validated counts against each form's native ceiling — only against the common 800-item reference scale. So a row could claim more words than its form physically contains: `it_01` subject `ID_677D…`, age 47, records **understood = 461 on a 408-item form**, and it silently entered the DS comprehension trajectory.

## The fix

The view now wraps its union in a guard that drops any row whose `understood`/`spoken`/`signed`/`produced` count **strictly exceeds** its own `survey_vocab_max`. Kept: rows with an unknown ceiling (`survey_vocab_max` NULL), and counts **at** the ceiling (a legitimate ceiling observation). It is also a standing guard against any future such error, not just this one row.

On the current data this drops **exactly one row** (the it_01 461-on-408 error); I verified **0 ceiling violations remain** afterwards and the view goes **1190 → 1189**.

## Verification

- Rebuilt the view from this branch: the 461 row is gone, 0 violations remain, exactly one row dropped.
- `tests/test_data_utils.py`: new regression test — an over-ceiling `it_01` row is dropped while an at-ceiling row is kept.
- `ruff check src/ scripts/ tests/`, `npm run spellcheck`, `npm run format:check` pass; `pytest tests/test_data_utils.py` — 14 passed.

## Note

Independent of #138 (Frank's TD-prior recalibration) and #139 (audit docs/diagnostics). Together, **#138 + this** are the two data/prior corrections that should land before the next reporting-tier (`rep`) re-fit, so the sweep runs on clean data and priors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
