### PR TITLE
fix(vg05-vg16): align DS joint/signing priors — stale understood anchors + loose q defaults

### DIFF
--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -375,11 +375,11 @@ class JointModelDefinition:
     slope_anchors: tuple[float, float]
     ages_query: list[int]
 
-    # -- Understood (U) slope priors (seeded from VG05/VG14) --
+    # -- Understood (U) slope priors (aligned with the recalibrated VG02 / VG05) --
     p_slope_low_u_alpha: float = 1.0
-    p_slope_low_u_beta: float = 10.0
-    p_slope_hi_u_alpha: float = 1.1
-    p_slope_hi_u_beta: float = 1.1
+    p_slope_low_u_beta: float = 7.0
+    p_slope_hi_u_alpha: float = 2.0
+    p_slope_hi_u_beta: float = 1.5
 
     # -- Speak-given-understood (q) slope priors (bivariate defaults) --
     p_slope_low_q_alpha: float = 1.0
@@ -400,7 +400,7 @@ class JointModelDefinition:
     # -- Shared GP / amplitude priors (sign GP looser + shorter, per VG14) --
     ell_unit_u_alpha: float = 3.0
     ell_unit_u_beta: float = 3.0
-    eta_u_sigma: float = 0.4
+    eta_u_sigma: float = 0.6  # aligned with the recalibrated VG02 understood trajectory
     ell_unit_q_alpha: float = 3.0
     ell_unit_q_beta: float = 3.0
     eta_q_sigma: float = 0.4
@@ -597,10 +597,21 @@ VG05 = BivariateModelDefinition(
     n_trials=800,
     slope_anchors=(24, 84),
     ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
+    # Understood anchors aligned with the recalibrated VG02 (#135): raise the
+    # 24 mo anchor (Beta(1,10) -> Beta(1,7)) and soften the near-uniform 84 mo
+    # anchor (Beta(1.1,1.1) -> Beta(2,1.5)); widen eta_u (0.4 -> 0.6). The old
+    # joint U band sat ~2.5-3x below the empirical mean at 24-48 mo.
     p_slope_low_u_alpha=1.0,
-    p_slope_low_u_beta=10.0,
-    p_slope_hi_u_alpha=1.1,
-    p_slope_hi_u_beta=1.1,
+    p_slope_low_u_beta=7.0,
+    p_slope_hi_u_alpha=2.0,
+    p_slope_hi_u_beta=1.5,
+    eta_u_sigma=0.6,
+    # q anchors: adopt VG10/VG15's data-informed tight priors (the loose
+    # bivariate defaults centred q ~0.4 at 24 mo against an empirical ~0.09).
+    p_slope_low_q_alpha=3.0,
+    p_slope_low_q_beta=22.0,
+    p_slope_hi_q_alpha=20.0,
+    p_slope_hi_q_beta=4.0,
 )
 
 VG07 = BivariateModelDefinition(
@@ -614,10 +625,23 @@ VG07 = BivariateModelDefinition(
     n_trials=800,
     slope_anchors=(24, 84),
     ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
+    # Understood anchors aligned with the recalibrated VG02 (#135): raise the
+    # 24 mo anchor (Beta(1,10) -> Beta(1,7)) and soften the near-uniform 84 mo
+    # anchor (Beta(1.1,1.1) -> Beta(2,1.5)); widen eta_u (0.4 -> 0.6). The old
+    # joint U band sat ~2.5-3x below the empirical mean at 24-48 mo.
     p_slope_low_u_alpha=1.0,
-    p_slope_low_u_beta=10.0,
-    p_slope_hi_u_alpha=1.1,
-    p_slope_hi_u_beta=1.1,
+    p_slope_low_u_beta=7.0,
+    p_slope_hi_u_alpha=2.0,
+    p_slope_hi_u_beta=1.5,
+    eta_u_sigma=0.6,
+    # q anchors: adopt VG10/VG15's data-informed tight priors. The loose
+    # bivariate defaults centred q ~0.4 at 24 mo against an empirical ~0.09,
+    # compounding with U to overshoot spoken; the tight priors track the
+    # empirical q (~0.09 at 24 mo, ~0.83 by 84 mo).
+    p_slope_low_q_alpha=3.0,
+    p_slope_low_q_beta=22.0,
+    p_slope_hi_q_alpha=20.0,
+    p_slope_hi_q_beta=4.0,
     tau_u_sigma=0.5,
     tau_q_sigma=0.5,
 )
@@ -633,10 +657,23 @@ VG08 = BivariateModelDefinition(
     n_trials=800,
     slope_anchors=(24, 84),
     ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
+    # Understood anchors aligned with the recalibrated VG02 (#135): raise the
+    # 24 mo anchor (Beta(1,10) -> Beta(1,7)) and soften the near-uniform 84 mo
+    # anchor (Beta(1.1,1.1) -> Beta(2,1.5)); widen eta_u (0.4 -> 0.6). The old
+    # joint U band sat ~2.5-3x below the empirical mean at 24-48 mo.
     p_slope_low_u_alpha=1.0,
-    p_slope_low_u_beta=10.0,
-    p_slope_hi_u_alpha=1.1,
-    p_slope_hi_u_beta=1.1,
+    p_slope_low_u_beta=7.0,
+    p_slope_hi_u_alpha=2.0,
+    p_slope_hi_u_beta=1.5,
+    eta_u_sigma=0.6,
+    # q anchors: adopt VG10/VG15's data-informed tight priors. The loose
+    # bivariate defaults centred q ~0.4 at 24 mo against an empirical ~0.09,
+    # compounding with U to overshoot spoken; the tight priors track the
+    # empirical q (~0.09 at 24 mo, ~0.83 by 84 mo).
+    p_slope_low_q_alpha=3.0,
+    p_slope_low_q_beta=22.0,
+    p_slope_hi_q_alpha=20.0,
+    p_slope_hi_q_beta=4.0,
     tau_u_sigma=0.5,
     tau_q_sigma=0.5,
     use_subject_re_u=True,
@@ -654,10 +691,23 @@ VG09 = BivariateModelDefinition(
     n_trials=800,
     slope_anchors=(24, 84),
     ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
+    # Understood anchors aligned with the recalibrated VG02 (#135): raise the
+    # 24 mo anchor (Beta(1,10) -> Beta(1,7)) and soften the near-uniform 84 mo
+    # anchor (Beta(1.1,1.1) -> Beta(2,1.5)); widen eta_u (0.4 -> 0.6). The old
+    # joint U band sat ~2.5-3x below the empirical mean at 24-48 mo.
     p_slope_low_u_alpha=1.0,
-    p_slope_low_u_beta=10.0,
-    p_slope_hi_u_alpha=1.1,
-    p_slope_hi_u_beta=1.1,
+    p_slope_low_u_beta=7.0,
+    p_slope_hi_u_alpha=2.0,
+    p_slope_hi_u_beta=1.5,
+    eta_u_sigma=0.6,
+    # q anchors: adopt VG10/VG15's data-informed tight priors. The loose
+    # bivariate defaults centred q ~0.4 at 24 mo against an empirical ~0.09,
+    # compounding with U to overshoot spoken; the tight priors track the
+    # empirical q (~0.09 at 24 mo, ~0.83 by 84 mo).
+    p_slope_low_q_alpha=3.0,
+    p_slope_low_q_beta=22.0,
+    p_slope_hi_q_alpha=20.0,
+    p_slope_hi_q_beta=4.0,
     tau_u_sigma=0.5,
     tau_q_sigma=0.5,
     use_subject_re_u=True,
@@ -677,10 +727,15 @@ VG10 = BivariateModelDefinition(
     n_trials=800,
     slope_anchors=(24, 84),
     ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
+    # Understood anchors aligned with the recalibrated VG02 (#135): raise the
+    # 24 mo anchor (Beta(1,10) -> Beta(1,7)) and soften the near-uniform 84 mo
+    # anchor (Beta(1.1,1.1) -> Beta(2,1.5)); widen eta_u (0.4 -> 0.6). The old
+    # joint U band sat ~2.5-3x below the empirical mean at 24-48 mo.
     p_slope_low_u_alpha=1.0,
-    p_slope_low_u_beta=10.0,
-    p_slope_hi_u_alpha=1.1,
-    p_slope_hi_u_beta=1.1,
+    p_slope_low_u_beta=7.0,
+    p_slope_hi_u_alpha=2.0,
+    p_slope_hi_u_beta=1.5,
+    eta_u_sigma=0.6,
     # Tighter q-anchor priors (Option A) — informed by VG07 posterior
     p_slope_low_q_alpha=3.0,
     p_slope_low_q_beta=22.0,
@@ -827,12 +882,20 @@ VG14 = TrivariateModelDefinition(
     n_trials=800,
     slope_anchors=(24, 84),
     ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
-    # Understood trajectory: reuse VG05's understood slope priors.
+    # Understood trajectory: matches VG05 — anchors aligned with the recalibrated
+    # VG02 (#135): raise the 24 mo anchor (Beta(1,10) -> Beta(1,7)), soften the
+    # near-uniform 84 mo anchor (Beta(1.1,1.1) -> Beta(2,1.5)), widen eta_u to 0.6.
     p_slope_low_u_alpha=1.0,
-    p_slope_low_u_beta=10.0,
-    p_slope_hi_u_alpha=1.1,
-    p_slope_hi_u_beta=1.1,
-    # Spoken ratio q: bivariate defaults.
+    p_slope_low_u_beta=7.0,
+    p_slope_hi_u_alpha=2.0,
+    p_slope_hi_u_beta=1.5,
+    eta_u_sigma=0.6,
+    # Spoken ratio q: adopt VG10/VG15's data-informed tight priors (the loose
+    # bivariate defaults centred q ~0.4 at 24 mo against an empirical ~0.09).
+    p_slope_low_q_alpha=3.0,
+    p_slope_low_q_beta=22.0,
+    p_slope_hi_q_alpha=20.0,
+    p_slope_hi_q_beta=4.0,
     # Signed ratio r: intercept-only mean (data-set level) + loosened GP
     #   (eta_sign=1.0) carrying the rise-then-fall hump (see dataclass).
     # uk_06 signed included by default (include_uk06=True); kappa_sign default.
@@ -906,10 +969,23 @@ VG16 = BivariateModelDefinition(
     n_trials=800,
     slope_anchors=(24, 84),
     ages_query=[12, 18, 24, 30, 36, 42, 48, 54, 60, 66, 72, 78, 84, 90],
+    # Understood anchors aligned with the recalibrated VG02 (#135): raise the
+    # 24 mo anchor (Beta(1,10) -> Beta(1,7)) and soften the near-uniform 84 mo
+    # anchor (Beta(1.1,1.1) -> Beta(2,1.5)); widen eta_u (0.4 -> 0.6). The old
+    # joint U band sat ~2.5-3x below the empirical mean at 24-48 mo.
     p_slope_low_u_alpha=1.0,
-    p_slope_low_u_beta=10.0,
-    p_slope_hi_u_alpha=1.1,
-    p_slope_hi_u_beta=1.1,
+    p_slope_low_u_beta=7.0,
+    p_slope_hi_u_alpha=2.0,
+    p_slope_hi_u_beta=1.5,
+    eta_u_sigma=0.6,
+    # q anchors: adopt VG10/VG15's data-informed tight priors. The loose
+    # bivariate defaults centred q ~0.4 at 24 mo against an empirical ~0.09,
+    # compounding with U to overshoot spoken; the tight priors track the
+    # empirical q (~0.09 at 24 mo, ~0.83 by 84 mo).
+    p_slope_low_q_alpha=3.0,
+    p_slope_low_q_beta=22.0,
+    p_slope_hi_q_alpha=20.0,
+    p_slope_hi_q_beta=4.0,
     tau_u_sigma=0.5,
     tau_q_sigma=0.5,
     use_subject_re_u=True,


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Why

A prior-predictive review of the DS joint/signing lineage (VG05/07/08/09/10/14/15/16), against the current data (post `ie_02` exclusion #136 + form-ceiling guard #141), surfaced two issues.

### 1. The understood component was stale in all 8 models

Every joint model still carried VG02's **pre-#135** understood anchors (`Beta(1,10)`/`Beta(1.1,1.1)`) — so the joint understood trajectory kept the young-age pessimism that was recalibrated away in VG02, and was now inconsistent with the merged VG02. The prior median sat **2.5–3× below** the empirical understood mean through 24–48 months:

| Age | Prior U p50 | Empirical U mean |
| --- | --- | --- |
| 24 mo | 56 | 138 |
| 36 mo | 89 | 250 |
| 48 mo | 132 | 354 |

### 2. Six of the eight used the loose `q` defaults

VG05/07/08/09/14/16 inherited the shared bivariate `q` defaults (`lo Beta(1,1.5)` ≈ 0.40, `hi Beta(2,1.2)` ≈ 0.62), which centre the production ratio **~4× above** the empirical DS `q` at the 24-month anchor — compounding with the too-low understood to distort spoken:

| Age | Loose q p50 | **Tight q p50 (VG10/VG15)** | Empirical q |
| --- | --- | --- | --- |
| 24 mo | 0.375 | **0.108** | 0.085 |
| 36 mo | 0.435 | **0.205** | 0.221 |
| 72 mo | 0.600 | **0.718** | 0.694 |

VG10/VG15 already carry data-informed **tight** `q` priors (`Beta(3,22)`/`Beta(20,4)`) that track the empirical `q` closely.

## Changes

**A — understood, all 8 models:** `p_slope_low_u` `Beta(1,10)`→`Beta(1,7)`, `p_slope_hi_u` `Beta(1.1,1.1)`→`Beta(2,1.5)`, `eta_u` 0.4→0.6 (aligned with the merged VG02).

**B — production ratio, the six loose-`q` models (VG05/07/08/09/14/16):** adopt VG10/VG15's tight `q` priors `Beta(3,22)`/`Beta(20,4)`.

VG10 and VG15 already carried the tight `q` and are unchanged on `q`; **VG10 still stands apart via its 54-month GP anchor** (only its `q` distinction from VG09 is retired, which is now redundant since the calibrated `q` is the right prior everywhere).

## Validation

Prior-predictive regenerated for VG09 (full study + subject RE, a loose-`q` model that received both fixes) via the RE engine: the understood band now rises through the data cloud instead of sitting 2.5–3× below it, and the implied spoken band hugs the delayed-onset floor then covers the observed 0–760 spread without the loose-`q` overshoot. Dispersion (`kappa`), lengthscale (`ell`), and the signed-ratio priors are unchanged. `ruff` clean.

## Scope

Completes the young-age prior-recalibration sweep begun in #135 (DS single-outcome), #138 (TD single-outcome), #140 (VG13 joint). Independent branch, `definitions.py`-only. These are DS models; the ie_02 exclusion (#136) already merged and the local data were rebuilt before the review.
