### PR TITLE
chore(audit): composite-marginal likelihood note + §3 hygiene (#128/#131)

### DIFF
--- a/docs/report/methods-models.qmd
+++ b/docs/report/methods-models.qmd
@@ -126,6 +126,8 @@ $$
 
 The signed mean $g_{\text{sign}}$ is **intercept-only** (no age slope) plus a GP: a free age slope extrapolates the signed ratio below the data floor at young ages, so the GP alone carries the empirical rise-then-fall hump. Each marginal outcome has its own Beta-Binomial likelihood with its own age-varying dispersion (@sec-betabinomial, @sec-kappa).
 
+The outcomes share the latent means $p_U$, $q$ and $r$, but each enters the likelihood as its own marginal Beta-Binomial, so the joint likelihood is a **composite (pseudo-)likelihood**: it couples the outcomes only through those shared means and treats the marginal *counts* as conditionally independent given them. It does not model the item-level joint distribution — which specific understood words a child also speaks or signs — and so mildly over-counts the information that shared words contribute across marginals. The one place item-level structure is modelled directly is the uk_02 four-cell cross-tabulation in VG15 (the Plackett $\psi$ and Dirichlet-Multinomial, below), which identifies the sign–speech overlap within understood words. Elsewhere the composite marginal likelihood is a deliberate simplification — appropriate because most sources report only marginal totals — and LOO comparisons and interval widths should be read with this mild between-marginal dependence in mind.
+
 ### Study and subject random intercepts {#sec-randomeffects}
 
 To separate the population age curves from differences in study composition and from repeated measurements on the same child, we add random intercepts on the logit-scale predictors at the observation level. For a predictor $f_\bullet \in \{f_U, h, g_{\text{sign}}\}$,

--- a/scripts/compare_ds_td_re.py
+++ b/scripts/compare_ds_td_re.py
@@ -119,6 +119,10 @@ def _merge(grid: np.ndarray, grid_name: str, **frames: pd.DataFrame) -> pd.DataF
 def _at_age(frame: pd.DataFrame, age: float, col: str) -> float:
     """Nearest-grid-point value of ``col`` at ``age`` (for console summaries)."""
     i = int((frame["age_months"] - age).abs().idxmin())
+    nearest = float(frame.loc[i, "age_months"])
+    if abs(nearest - age) > 1.0:
+        print(f"    [warn] no grid point near {age:g} mo for '{col}'; "
+              f"snapped to {nearest:g} mo")
     return float(frame.loc[i, col])
 
 

--- a/scripts/regenerate_vg09_marginal_predictive.py
+++ b/scripts/regenerate_vg09_marginal_predictive.py
@@ -35,11 +35,10 @@ from scipy.stats import betabinom
 import vocab_growth.data_utils as data_utils
 import vocab_growth.plotting as plotting
 from vocab_growth import environment as env
+from vocab_growth.models.definitions import VG09
 
 VG09_DIR = os.path.join(env.models_output_dir(), "VG09-age-understood-spoken-ds-re-subj-uq")
-# TODO(#131): derive from definition.n_trials (this script post-processes a
-# saved trace and has no model definition object in scope).
-N_TRIALS = 800
+N_TRIALS = VG09.n_trials  # trial count from the model this script post-processes
 EPSILON = 1e-12
 SEED = 47
 


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

The two discrete remaining audit items that are safe to action now — companion to the merged #139. Refs #128, #131 (neither fully closes; see below).

## Changes

- **`docs/report/methods-models.qmd`** — #128 "reassess the likelihood description": added a paragraph documenting that the joint models use a **composite (pseudo-)likelihood** — separate marginal Beta-Binomials on understood / spoken / signed, coupled only through the shared latent means `p_U` / `q` / `r`, *not* a joint item-level likelihood. It notes that uk_02's four-cell cross-tab in VG15 (the Plackett `ψ` / Dirichlet-Multinomial) is the one place the item-level joint is modelled, and that the mild between-marginal dependence should be borne in mind when reading LOO comparisons and interval widths.
- **`scripts/regenerate_vg09_marginal_predictive.py`** — #131 §3: derive `N_TRIALS` from `VG09.n_trials` (this script post-processes the VG09 trace) instead of the hard-coded literal.
- **`scripts/compare_ds_td_re.py`** — #131 §3: `_at_age` now warns when a requested key age has no nearby grid point, instead of silently snapping (console summaries only).

## Deliberately left for triage (not in this PR)

The rest of #131 §3 isn't safe "hygiene": it's **fit-touching** (the numerically-fragile Plackett `switch` near `ψ = 1`; adding VG15 new-child predictive intervals), a **data-pipeline decision** (`vocab_data_merged.csv` diverging from the `vocab_combined` view), or **out of scope** (the two remaining `N_TRIALS` literals are in model-agnostic CV scripts with no single model in view; the unseeded prior-spaghetti plot lives in `dse_research_utils`). Flagged for triage rather than guessed at.

Also deferred (research/data judgment, per #128): the per-row-denominator sensitivity analysis and the `us_01` production-cap threshold revalidation.

## Verification

- `ruff check src/ scripts/`, `npm run spellcheck`, `npm run format:check` all pass.
- `pytest tests/test_comparison.py` — 14 passed; `regenerate_vg09` imports cleanly and `N_TRIALS` resolves to 800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
