### PR TITLE
fix(vg15): numerically stable Plackett root (#131 §3 fit-touching)

### DIFF
--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -553,11 +553,20 @@ def _plackett_pi_both(r, q, psi):
     Closed-form root, falling back to independence at psi == 1, then clipped to
     the Frechet bounds [max(0, r+q-1), min(r, q)].
     """
+    # Numerically stable, branch-free form of the Plackett root. The textbook
+    # expression ``(S - disc) / (2 (psi - 1))`` needs a ``switch`` fallback to
+    # ``r*q`` at psi == 1 (0/0) and suffers catastrophic cancellation in the
+    # whole psi->1 neighbourhood (S ~ disc ~ 1 while the denominator ~ 0), which
+    # both distorts pi_both and destabilises the NUTS gradient. Rationalising by
+    # ``(S + disc)`` cancels the ``(psi - 1)`` factor exactly:
+    #     (S - disc) / (2 (psi - 1))  ==  2 psi r q / (S + disc),
+    # since ``S^2 - disc^2 = 4 psi (psi - 1) r q``. The right-hand side has no
+    # vanishing denominator (S + disc > 0 across the valid odds-ratio range) and
+    # is continuous at psi == 1, where it returns exactly ``r*q`` — so no switch
+    # is needed.
     S = 1.0 + (r + q) * (psi - 1.0)
     disc = pm.math.sqrt(pm.math.maximum(S * S - 4.0 * psi * (psi - 1.0) * r * q, 0.0))
-    denom = 2.0 * (psi - 1.0)
-    pi_root = (S - disc) / denom
-    pi_both = pm.math.switch(abs(psi - 1.0) < 1e-6, r * q, pi_root)
+    pi_both = 2.0 * psi * r * q / pm.math.maximum(S + disc, 1e-12)
     lo = pm.math.maximum(0.0, r + q - 1.0)
     hi = pm.math.minimum(r, q)
     return pm.math.clip(pi_both, lo, hi)

--- a/tests/test_joint_four_cell.py
+++ b/tests/test_joint_four_cell.py
@@ -117,3 +117,28 @@ def test_prepare_joint_data_uses_cell_total_and_drops_empty_rows(
     four_rows = analysis_df[analysis_df["signed_spoken"].notna()]
     np.testing.assert_array_equal(four_rows["understood"], four_rows["cell_total"])
     assert 22 not in set(four_rows["understood"])
+
+
+def test_plackett_pi_both_stable_and_correct_at_psi_one():
+    """The rationalised Plackett root is continuous and correctly-differentiable
+    at psi == 1 (issue #131 §3): it returns the independence value ``r*q`` with a
+    finite, non-zero gradient, where the old ``switch`` form returned a spurious
+    zero/NaN gradient in the psi->1 neighbourhood."""
+    import pytensor
+    import pytensor.tensor as pt
+
+    psi = pt.dscalar("psi")
+    r, q = 0.4, 0.6  # r + q - 1 = 0, so the Frechet lower bound is 0 here
+    expr = cjm._plackett_pi_both(r, q, psi)
+    f = pytensor.function([psi], [expr, pt.grad(expr, psi)])
+
+    val, grad = f(1.0)
+    assert np.isclose(val, r * q)  # independence at psi == 1
+    assert np.isfinite(grad) and abs(grad) > 1e-6  # not the old spurious 0
+
+    # Matches the textbook closed-form root away from psi == 1.
+    for p in (0.5, 2.0, 5.0):
+        S = 1.0 + (r + q) * (p - 1.0)
+        disc = np.sqrt(S * S - 4.0 * p * (p - 1.0) * r * q)
+        textbook = (S - disc) / (2.0 * (p - 1.0))
+        assert np.isclose(f(p)[0], textbook)


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Context

The fit-touching items from the #131 §3 tail. These change model numerics, so they batch with the deferred refits (#149). Companion to the non-fit-touching #150.

## Plackett ψ=1 numerical stability (done)

The VG15 sign–speech copula solved `pi_both` with the textbook `(S − disc) / (2(ψ − 1))` plus a `switch` fallback to `r·q` at ψ=1. That form is 0/0 at ψ=1 and suffers catastrophic cancellation across the whole ψ→1 neighbourhood; worse, the `switch` returned a spurious **zero** gradient in the ±1e-6 band around ψ=1 — flattening the NUTS gradient exactly at the independence hypothesis.

Rationalising by `(S + disc)` gives the algebraically-identical `2·ψ·r·q / (S + disc)`, which has no vanishing denominator, is continuous at ψ=1 (returns `r·q`), and needs no switch. Verified numerically: **identical forward values everywhere**, and a finite gradient at ψ=1 (0.0576, matching finite differences) where the old form returned 0. Regression test added.

Forward-value-identical, so this only improves gradient stability near ψ=1; VG15 should be refit to confirm mixing.

## VG15 new-child predictive intervals (not in this PR — see below)

The second selected item — adding new-child predictive-count intervals to VG15 (it currently reports only population-level expected-count uncertainty) — mirrors the existing `regenerate_vg09_marginal_predictive.py` post-processing pattern (draw fresh subject REs per draw → Beta-Binomial predictive counts). It **requires a VG15 trace to build against and validate**, and none is present (VG15 is the heaviest model and is part of the refit batch). Rather than commit an unvalidatable port into the delicate signing model, it's deferred to be implemented and validated against a VG15 trace during the refits. Tracked in #149.

Refs #131.
