### PR TITLE
fix(reports): show render time and actual sampling config in reports

### DIFF
--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -45,6 +45,7 @@ Lewandowsky
 LLM
 logit
 LOSO
+matplotlib
 McElreath
 MCMC
 Mervis
@@ -63,6 +64,7 @@ orcid
 overfitting
 parameterisation
 preliz
+pyplot
 pytest
 rankdir
 recomputation

--- a/docs/comparison/index.qmd
+++ b/docs/comparison/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Down syndrome vs typically developing: vocabulary growth comparison"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:

--- a/docs/descriptive/index.qmd
+++ b/docs/descriptive/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Descriptive report: pooled Down syndrome vocabulary data"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:

--- a/docs/models/vg01/index.qmd
+++ b/docs/models/vg01/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG01: Influence of age on words spoken - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model examines how age (a proxy for things that happen over time) influences spoken words ($A \rightarrow S$).
 

--- a/docs/models/vg02/index.qmd
+++ b/docs/models/vg02/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG02: Influence of age on words understood - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model examines how age (a proxy for things that happen over time) influences words understood ($A \rightarrow U$).
 

--- a/docs/models/vg03/index.qmd
+++ b/docs/models/vg03/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG03: Influence of age on words spoken - typically developing children"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model examines how age (a proxy for things that happen over time) influences spoken words ($A \rightarrow S$).
 

--- a/docs/models/vg04/index.qmd
+++ b/docs/models/vg04/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG04: Influence of age on words understood - typically developing children"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than when additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model examines how age (a proxy for things that happen over time) influences words understood ($A \rightarrow U$).
 

--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG05: Joint model of words understood and spoken - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model jointly examines how age influences words understood and words spoken ($A \rightarrow U$, $A \rightarrow S$, $U \rightarrow S$), using a production-ratio reparameterization that enforces $p_S \leq p_U$ by construction.
 

--- a/docs/models/vg07/index.qmd
+++ b/docs/models/vg07/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG07: Joint model with study random intercepts - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model extends VG05 by adding study-level random intercepts on both the understood trajectory and the production ratio, to account for systematic differences between contributing studies. The production-ratio reparameterization enforces $p_S \leq p_U$ by construction.
 

--- a/docs/models/vg08/index.qmd
+++ b/docs/models/vg08/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG08: Joint model with study + subject random intercepts on understood - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model extends VG07 by adding subject-level random intercepts on the understood trajectory. The motivation is to partition between-child variability from within-child repeated-measures correlation: 288 of the 510 subjects in the combined Down-syndrome dataset are observed more than once, and treating those repeated observations as independent inflates the dispersion parameter and understates uncertainty around the population mean.
 

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG09: Joint model with study + subject random intercepts on understood and on production ratio - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model extends VG08 by adding subject-level random intercepts on the production ratio $q$ in addition to the existing subject REs on the understood logit. The motivation is symmetry: if between-subject differences justify a subject RE on the understood trajectory, the same logic applies to how much of each child's understood vocabulary they actually speak. With both subject REs in place, the residual Beta-Binomial dispersion on both outcomes should reflect within-occasion measurement noise rather than between-subject heterogeneity.
 

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG10: VG09 + tighter q anchor priors + GP anchored at reference age - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 VG10 is a structural variant of VG09 introduced to test whether the marginal `r_hat` / `ess_tail` issues observed on the q-trajectory hyperparameters under VG09 reflect a redundancy between the linear mean trend, the HSGP correction, and the subject random intercepts.
 

--- a/docs/models/vg11/index.qmd
+++ b/docs/models/vg11/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG11: Words spoken (TD) with dataset-level study random intercepts"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model examines how age influences spoken words ($A \rightarrow S$) in typically developing children, extending VG03 with dataset-level study random intercepts to account for between-lab variation in the Wordbank data.
 

--- a/docs/models/vg12/index.qmd
+++ b/docs/models/vg12/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG12: Words understood (TD) with dataset-level study random intercepts"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model examines how age influences words understood ($A \rightarrow U$) in typically developing children, extending VG04 with dataset-level study random intercepts to account for between-lab variation in the Wordbank data.
 

--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG13: Joint words understood + spoken (TD, 8–18 months) with study random intercepts"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model fits a joint bivariate model of words understood and spoken in typically developing children aged 8–18 months. It supersedes the retired VG06 model with dataset-level study random intercepts and restricts the age range to 8–18 months, where Wordbank WG and Oxford CDI data are dense and cover multiple labs. Wordbank Words & Sentences rows are not used in this bivariate model because their comprehension field is a production proxy. Above 18 months only a single dataset (Floccia/Oxford CDI) contributes bivariate observations, making inference unreliable. The production-ratio reparameterisation enforces $p_S \leq p_U$ by construction.
 

--- a/docs/models/vg14/index.qmd
+++ b/docs/models/vg14/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG14: Trivariate model of words understood, spoken and signed - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than when additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model adds **signing** as a third production modality alongside speaking. It jointly examines how age influences words understood, words spoken and words signed ($A \rightarrow U$, $A \rightarrow S$, $A \rightarrow \text{Sign}$; $U \rightarrow S$, $U \rightarrow \text{Sign}$), using a production-ratio reparameterization that enforces $p_S \leq p_U$ and $p_\text{Sign} \leq p_U$ by construction.
 

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG15: Joint sign/speech model with within-understood association - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than when additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model (issue #49, Option 3) estimates the **within-understood association** between signing and speaking, the overlap that VG14 assumed away. It adds study random intercepts, subject random intercepts on all three latent trajectories, and VG10-style GP anchoring, replacing VG14's independence-based `p_any` upper bound with a _data-identified_ total expressive vocabulary.
 

--- a/docs/models/vg16/index.qmd
+++ b/docs/models/vg16/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Model VG16: Within-child cross-lag (earlier receptive → later expressive) - children with Down syndrome"
 
-date: last-modified
+date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
 
 format:
@@ -19,12 +19,48 @@ format:
 Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
 :::
 
-::: {.callout-warning title="Warning: Preliminary model output"}
+```{python}
+#| echo: false
+#| output: asis
+# Report the sampling configuration this model was actually fitted at, read
+# from the trace header (chains x draws). rep / rep-lite are reporting-grade;
+# dev / test are flagged as approximate.
+import h5netcdf as _h5
 
-This model output is preliminary and likely to change as the model evolves and further data are received.
+with _h5.File("trace.nc", "r") as _f:
+    _post = _f["posterior"]
+    _n_chains = _post.dimensions["chain"].size
+    _n_draws = _post.dimensions["draw"].size
 
-If the model was not fitted in "reporting" mode, the results will be more approximate than where additional sampling has been performed.
-:::
+_CONFIGS = {
+    (6, 6000): ("reporting", False),
+    (4, 4000): ("reporting-lite", False),
+    (4, 2000): ("test", True),
+    (2, 500): ("development", True),
+}
+_cfg_name, _approximate = _CONFIGS.get(
+    (_n_chains, _n_draws), (f"{_n_chains} chains × {_n_draws} draws", True)
+)
+
+print('::: {.callout-warning title="Warning: Preliminary model output"}')
+print()
+print(
+    "This model output is preliminary and likely to change as the model "
+    "evolves and further data are received."
+)
+print()
+print(
+    f"This model was fitted in **{_cfg_name}** configuration "
+    f"({_n_chains} chains × {_n_draws:,} draws per chain)."
+)
+if _approximate:
+    print()
+    print(
+        "It was **not** fitted in reporting mode, so these results are more "
+        "approximate than a full reporting-quality fit."
+    )
+print(":::")
+```
 
 This model extends VG09 (joint understood + spoken with study and subject random intercepts) with a **cross-lag** (issue #113): a child's prior-wave words understood predicts their current production ratio $q$, testing whether *earlier receptive* vocabulary leads *later expressive* vocabulary **within a child**. Because the repeated-measures children are mostly two-wave, the pure within-child (RI-CLPM) baseline is biased by short-T / errors-in-variables mechanics; VG16 therefore **headlines the bias-robust population-relative baseline** and reports the within-child variant as a cautionary contrast. See `notes/202607031200-vg16-within-child-scoping.md`.
 


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

Two report-template fixes. Both made **reporting-grade output look provisional**, which caused real confusion when reviewing the latest full replication run.

## 1. `date: last-modified` → `date: now`

`last-modified` resolves to the **`.qmd` source file's mtime** — i.e. the checkout time — not when the report was rendered. So a report rendered today from today's data displayed a "Published" date of whenever the source file happened to land on disk (e.g. `2026-07-07 12:36`), reading as stale. `now` shows the actual render timestamp (the existing `date-format` already prints `YYYY-MM-DD HH:mm:ss Z`). Applied to all 17 dated report qmds (`comparison`, `descriptive`, `vg01`–`vg16`).

## 2. Dynamic sampling-config caveat

Every model report carried a **static** callout: *"If the model was not fitted in 'reporting' mode, the results will be more approximate…"*. It appeared unconditionally, so it neither confirmed the config nor distinguished `rep` / `rep-lite` / `dev`.

Replaced it with a block that reads the **actual** config from the trace header (`chains × draws`, a fast header-only read) and states it, e.g.:

> This model was fitted in **reporting** configuration (6 chains × 6,000 draws per chain).

`rep` and `rep-lite` are reporting-grade → no approximate-results warning; `dev` / `test` are flagged. So a reader now gets positive confirmation instead of a vague conditional.

## Verification

Re-rendered all 15 model reports + the comparison report:
- rep models → "**reporting** configuration (6 chains × 6,000 draws per chain)", no warning
- rep-lite (VG11, VG13) → "**reporting-lite** configuration (4 chains × 4,000 draws per chain)", no warning
- Published date now shows the render timestamp

Diff is limited to the 17 report qmds.