### PR TITLE
docs(vg10,vg15): correct stale q-anchor prior descriptions after #155

### DIFF
--- a/docs/models/OUTPUT_TEMPLATE_REVIEW.md
+++ b/docs/models/OUTPUT_TEMPLATE_REVIEW.md
@@ -177,12 +177,16 @@ templates for rendered model outputs.
 
 ### VG10: DS joint with VG09 hierarchy plus stabilisation
 
-- Model description is good. Add a clear "what changed from VG09" block:
-  posterior-informed `q` anchors and per-draw GP anchors at 54 months.
-- Priors need stronger labelling: the tightened `q` priors are informed by VG07
-  posterior evidence and are not independent external priors.
-- Prior predictive checks should demonstrate that tightened `q` priors still
-  allow plausible spoken trajectories and gaps over 12-90 months.
+- Model description is good. Add a clear "what changed from VG09" block: the
+  per-draw GP anchor at 54 months (the `q` anchors now match VG09).
+- Priors need accurate labelling: the `q` anchors are the shared
+  weakly-informative DS-joint priors, not posterior-informed regularisation.
+  #155 broadened the earlier VG07-posterior-derived anchors to remove the
+  prior-data double-dipping; stabilisation now comes from the tightened GP
+  amplitude `eta_q` and the GP anchor.
+- Prior predictive checks should demonstrate that the weakly-informative `q`
+  anchors with the tightened `eta_q` still allow plausible spoken trajectories
+  and gaps over 12-90 months.
 - Diagnostics should explicitly report whether the VG09 geometry issue is
   resolved: R-hat/ESS for `q` hyperparameters, random-effect scales, and pair
   plots around the anchored GP components.

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -54,7 +54,7 @@ The three axes that distinguish the models:
 | [VG07](vg07/index.qmd) | DS         | Understood + spoken (joint)  | VG05 + study random intercepts.                                                                                                                                                                                           |
 | [VG08](vg08/index.qmd) | DS         | Understood + spoken (joint)  | VG07 + subject random intercepts on understood.                                                                                                                                                                           |
 | [VG09](vg09/index.qmd) | DS         | Understood + spoken (joint)  | VG08 + subject random intercepts on the production ratio `q`.                                                                                                                                                             |
-| [VG10](vg10/index.qmd) | DS         | Understood + spoken (joint)  | VG09 + tighter `q`-anchor priors + per-draw GP anchor at 54 months (stabilisation).                                                                                                                                       |
+| [VG10](vg10/index.qmd) | DS         | Understood + spoken (joint)  | VG09 + per-draw GP anchor at 54 months (stabilisation); `q` anchors match VG09.                                                                                                                                           |
 | [VG11](vg11/index.qmd) | TD         | Spoken                       | VG03 + dataset-level study random intercepts + GP anchor at 19 months (uses full data instead of subsampling).                                                                                                            |
 | [VG12](vg12/index.qmd) | TD         | Understood                   | VG04 + dataset-level study random intercepts + GP anchor at 19 months (uses full data instead of subsampling).                                                                                                            |
 | [VG13](vg13/index.qmd) | TD         | Understood + spoken (joint)  | Young TD joint model, ages 8–18 months only; study random intercepts + GP anchor at 13 months.                                                                                                                            |
@@ -133,10 +133,13 @@ model:
 - **VG08** — adds **subject random intercepts on understood**.
 - **VG09** — extends subject random intercepts to the **production ratio `q`** as
   well.
-- **VG10** — the same structure as VG09, plus **tighter `q`-anchor priors**
-  (informed by the VG07 posterior) and a **per-draw GP anchor at 54 months**.
-  These changes were introduced to resolve sampling diagnostics on the
-  `q`-trajectory hyperparameters by removing the trend/GP/intercept redundancy.
+- **VG10** — the same structure as VG09, plus a **per-draw GP anchor at 54
+  months**, introduced to resolve sampling diagnostics on the `q`-trajectory
+  hyperparameters by removing the trend/GP/intercept redundancy. (VG10 was
+  originally also given tighter, VG07-posterior-informed `q` anchors; #155
+  broadened those back to the shared weakly-informative DS-joint values to remove
+  the prior-data double-dipping, so the `q` anchors now match VG09 and the GP
+  anchor is the only structural difference.)
 
 ### Joint understood + spoken, typically developing (VG13; VG06 retired)
 
@@ -169,6 +172,7 @@ qualifying observations can contribute.
   **within-understood sign–speech association** (`psi`, a scalar Plackett odds
   ratio identified from the four-cell sign/speak cross-tabulation in the `uk_02`
   dataset). It adds **study and subject random intercepts on all three
-  trajectories** and carries VG10's stabilisation (tighter `q` anchors + GP
-  anchoring at 54 months), yielding a **data-identified** total expressive
-  vocabulary rather than VG14's independence-based bound.
+  trajectories** and carries VG10's stabilisation (per-draw GP anchor at 54
+  months with the tightened `q`-GP amplitude `eta_q`), yielding a
+  **data-identified** total expressive vocabulary rather than VG14's
+  independence-based bound.

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -16,7 +16,7 @@ format:
 ---
 
 ::: {.callout-note}
-Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5; VG10 `q`-anchor reference corrected by Claude Code/Opus 4.8).
 :::
 
 ```{python}
@@ -199,7 +199,7 @@ _style_diagnostics(diagnostics)
 
 ::: {.callout-note title="Diagnostic focus"}
 
-VG09 is ridge-prone. Focus on the `q` GP length-scale and amplitude, `tau_q`, `tau_subj_q`, and `kappa_s`. Weak diagnostics here are the reason VG10 adds tighter `q` anchors and GP anchoring.
+VG09 is ridge-prone. Focus on the `q` GP length-scale and amplitude, `tau_q`, `tau_subj_q`, and `kappa_s`. Weak diagnostics here are the reason VG10 adds the per-draw GP anchoring (and why the DS-joint family tightened the `q`-GP amplitude `eta_q`).
 
 :::
 

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Model VG10: VG09 + tighter q anchor priors + GP anchored at reference age - children with Down syndrome"
+title: "Model VG10: VG09 + GP anchored at reference age - children with Down syndrome"
 
 date: now
 date-format: "YYYY-MM-DD HH:mm:ss Z"
@@ -16,7 +16,7 @@ format:
 ---
 
 ::: {.callout-note}
-Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5; `q`-anchor prior descriptions corrected by Claude Code/Opus 4.8).
 :::
 
 ```{python}
@@ -64,10 +64,9 @@ print(":::")
 
 VG10 is a structural variant of VG09 introduced to test whether the marginal `r_hat` / `ess_tail` issues observed on the q-trajectory hyperparameters under VG09 reflect a redundancy between the linear mean trend, the HSGP correction, and the subject random intercepts.
 
-Two changes relative to VG09:
+The one structural change relative to VG09 is the **GP anchor constraint (Option D).** Both `g_u` and `g_q` are reparameterised as `eta · (g_unit − g_unit(a_ref))` so that every posterior draw of the GP passes through zero at the reference age `a_ref = 54` months. This removes the per-draw redundancy between the linear intercept and a constant component of the GP.
 
-1. **Tighter q-anchor priors (Option A).** `p_slope_low_q ~ Beta(3, 22)` (mean ≈ 0.12) and `p_slope_hi_q ~ Beta(20, 4)` (mean ≈ 0.83), informed by the VG07 posterior (no subject REs on q).
-2. **GP anchor constraint (Option D).** Both `g_u` and `g_q` are reparameterised as `eta · (g_unit − g_unit(a_ref))` so that every posterior draw of the GP passes through zero at the reference age `a_ref = 54` months. This removes the per-draw redundancy between the linear intercept and a constant component of the GP.
+The `q(a)` anchors are the shared, weakly-informative DS-joint family priors — `p_slope_low_q ~ Beta(2, 12)` (median ≈ 0.13) and `p_slope_hi_q ~ Beta(3, 2)` (median ≈ 0.61) — identical to VG09, together with the tightened GP amplitude `eta_q ~ HalfNormal(0.20)`. (VG10 was originally introduced with additionally *tighter* `q` anchors read off the VG07 posterior — `Beta(3, 22)` / `Beta(20, 4)`, "Option A" — but [#155](https://github.com/dseinternational/vocabulary-growth/pull/155) broadened those back across the DS-joint family to remove the prior-data double-dipping, so the `q` anchors now match VG09 and the GP anchor is the sole distinction.)
 
 All other model components (study REs, subject REs on u and q, dispersion priors, likelihood) are identical to VG09. See `notes/202605131500-vg09-structural-options.md`.
 
@@ -78,7 +77,7 @@ import pandas as pd
 
 ## Statistical model
 
-We jointly model words understood and words spoken as bounded count outcomes out of 810 possible words. The structure follows VG09; the only differences are the tightened q-anchor priors and the GP anchor constraint:
+We jointly model words understood and words spoken as bounded count outcomes out of 810 possible words. The structure follows VG09; the only difference is the GP anchor constraint:
 
 $$f_U(a, s, i) = \text{intercept}_U + \text{slope}_U \cdot a_z + \tilde g_U(a) + \delta_U[s] + \delta^{\text{subj}}_U[i]$$
 $$h(a, s, i) = \text{intercept}_q + \text{slope}_q \cdot a_z + \tilde g_q(a) + \delta_q[s] + \delta^{\text{subj}}_q[i]$$
@@ -97,8 +96,8 @@ where $\tilde g_U(a) = \eta_U \cdot (\tilde u_U(a) - \tilde u_U(a_{\text{ref}}))
 
 ::: {.callout-note title="What changed from VG09"}
 
-- **Tighter `q` anchors:** posterior-informed regularisation from the VG07 fit.
-- **GP anchoring:** both GPs are constrained to be zero at 54 months on every draw.
+- **GP anchoring:** both GPs are constrained to be zero at 54 months on every draw — the one structural change from VG09.
+- **`q` anchors:** unchanged from VG09 (the shared weakly-informative `Beta(2, 12)` / `Beta(3, 2)` DS-joint priors).
 - **Hierarchy:** study and subject random intercepts remain on both understood and `q`.
 - **Purpose:** reduce the trend/GP/random-effect redundancy that made VG09 harder to sample.
 
@@ -114,7 +113,7 @@ For full details and discussion, please refer to the technical report.
 
 ## Priors
 
-The understood priors match VG09. The production-ratio anchors are intentionally tighter than the VG05-VG09 defaults: they are informed by the VG07 posterior and should be labelled as data-informed regularisation. They are used to stabilise the decomposition of spoken vocabulary into understood vocabulary times `q(a)`, not as independent prior evidence.
+The understood priors match VG09. The production-ratio (`q`) anchors are the shared, weakly-informative DS-joint family priors: `p_slope_low_q ~ Beta(2, 12)` (median ≈ 0.13) and `p_slope_hi_q ~ Beta(3, 2)` (median ≈ 0.61). `q_low` is centred on the independent TD `q(~12 mo) ≈ 0.12`; `q_high` has no independent DS source, so it is deliberately broad (5-95% ≈ 0.25-0.90) and lets the data set the 84-month level. These replaced the earlier `Beta(3, 22)` / `Beta(20, 4)` anchors, which had been read off the VG07 posterior — using a model's own posterior, fit to the same DS data, to set its prior — so they are weakly-informative rather than data-informed regularisation. Stabilisation of the `q` decomposition instead comes from the tightened GP amplitude `eta_q ~ HalfNormal(0.20)` and the GP anchor constraint, not from a data-informed anchor.
 
 ### Understood trajectory
 
@@ -154,7 +153,7 @@ The understood priors match VG09. The production-ratio anchors are intentionally
 
 ## Prior predictive checks
 
-These checks should demonstrate that the tightened `q` anchors still allow plausible spoken trajectories and comprehension-production gaps over 12-90 months. If the prior predictive spoken curves are too narrow, the stabilising prior may be doing too much substantive work.
+These checks should demonstrate that the weakly-informative `q` anchors together with the tightened GP amplitude `eta_q` and the GP anchor constraint still allow plausible spoken trajectories and comprehension-production gaps over 12-90 months. If the prior predictive spoken curves are too narrow, the stabilising priors may be doing too much substantive work.
 
 ### Prior samples -- words understood
 

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -16,7 +16,7 @@ format:
 ---
 
 ::: {.callout-note}
-Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
+Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5; `q`-anchor prior descriptions corrected by Claude Code/Opus 4.8).
 :::
 
 ```{python}
@@ -70,7 +70,7 @@ This model (issue #49, Option 3) estimates the **within-understood association**
 - **Outcomes:** words understood, spoken, signed, and four-cell sign/speech composition.
 - **Association:** scalar Plackett odds ratio `psi`, identified mainly from `uk_02`.
 - **Hierarchy:** study and subject random intercepts on understood, `q`, and signing.
-- **Stabilisation:** VG10-style tightened `q` anchors and GP anchors at 54 months.
+- **Stabilisation:** VG10-style GP anchors at 54 months, with the tightened `q`-GP amplitude `eta_q`.
 
 :::
 
@@ -103,7 +103,7 @@ which sits _below_ VG14's independence upper bound $p_U(1-(1-r)(1-q))$ whenever 
 
 **Study random intercepts** ($\delta_u, \delta_q, \delta_\text{sign} \sim \text{Normal}(0,\tau)$ per study, the VG07–VG10 pattern) sit on $f_U$, $g$, $h$ at the observation level, so the reported age curves (population level) are separated from study composition — which made VG14's signed peak unidentifiable.
 
-**Subject random intercepts** ($\delta_{u,\text{subj}}, \delta_{q,\text{subj}}, \delta_{\text{sign},\text{subj}}$, non-centred, also observation-level) are added on all three trajectories, so within-child repeated measurements are not treated as independent. They improve out-of-sample fit substantially (LOO ELPD; mostly understood and spoken, where repeats are dense). Signing is the sparsest modality but still carries repeated-subject structure (uk_01/02/04/05), so the sign-subject scale $\tau_{\text{subj,sign}}$ is strongly data-identified (it lands well above its prior — large between-child variation in signing). Adding a third level term to each predictor sharpens the **VG10 stabilisation** ported here: (A) the $q$ age anchors use the tighter VG10 priors, and (D) each GP is **anchored to pass through zero at the reference age (54 months) for every draw**, removing the GP↔intercept level redundancy that otherwise lets the linear/intercept term, the GP, and the random effects all encode the same global level. The signed intercept prior is left wide (it is already data-informed); Option D does the disambiguation. The reported population curves set every random effect to zero, so they are unchanged in interpretation.
+**Subject random intercepts** ($\delta_{u,\text{subj}}, \delta_{q,\text{subj}}, \delta_{\text{sign},\text{subj}}$, non-centred, also observation-level) are added on all three trajectories, so within-child repeated measurements are not treated as independent. They improve out-of-sample fit substantially (LOO ELPD; mostly understood and spoken, where repeats are dense). Signing is the sparsest modality but still carries repeated-subject structure (uk_01/02/04/05), so the sign-subject scale $\tau_{\text{subj,sign}}$ is strongly data-identified (it lands well above its prior — large between-child variation in signing). Adding a third level term to each predictor sharpens the **VG10 stabilisation** ported here: each GP is **anchored to pass through zero at the reference age (54 months) for every draw** (Option D), removing the GP↔intercept level redundancy that otherwise lets the linear/intercept term, the GP, and the random effects all encode the same global level, and the `q`-GP amplitude `eta_q` is tightened to `HalfNormal(0.20)` as a smoothness prior. The `q` age anchors themselves are the shared weakly-informative DS-joint priors (`Beta(2, 12)` / `Beta(3, 2)`), matching VG09 and VG10; VG10's original tighter, VG07-posterior-derived anchors were broadened by [#155](https://github.com/dseinternational/vocabulary-growth/pull/155) to remove the prior-data double-dipping. The signed intercept prior is left wide (it is already data-informed); Option D does the disambiguation. The reported population curves set every random effect to zero, so they are unchanged in interpretation.
 
 The association $\psi$ is deliberately kept **decoupled** from the subject random effects: the four-cell likelihood is fed the population+study marginals only. $\psi$ is identified from ~62 uk_02 cross-tab rows (≈34 children), and the per-child sign offset is co-identified with $\psi$ from those same rows; letting it into the four-cell composition would make the headline association pivot on a thinly-identified random effect (it rises from ≈1.8 to ≈2.8, driven almost entirely by the sign RE). $\psi$ here is therefore a **population-conditioned** within-understood odds ratio, comparable to the study-RE-only VG15.
 
@@ -125,7 +125,7 @@ The association $\psi$ is identified by the ~60 uk_02 rows with the four-cell cr
 
 ## Priors
 
-VG15 inherits the DS understood priors from the bivariate lineage, the signed-ratio prior from VG14, and the VG10 posterior-informed `q` anchors. The `q` anchors and the weakly positive `log_psi` prior are data-informed regularisation, not independent external evidence; they should be carried into sensitivity checks.
+VG15 inherits the DS understood priors from the bivariate lineage, the signed-ratio prior from VG14, and the shared, weakly-informative DS-joint `q` anchors (`Beta(2, 12)` low, `Beta(3, 2)` high). The weakly positive `log_psi` prior is data-informed regularisation, not independent external evidence, and should be carried into sensitivity checks.
 
 ### Understood trajectory
 
@@ -139,7 +139,7 @@ VG15 inherits the DS understood priors from the bivariate lineage, the signed-ra
 
 ### Production ratio
 
-The `q(a)` anchors are tightened relative to VG05-VG09 and VG14: the low-age anchor uses `Beta(3, 22)` and the high-age anchor uses `Beta(20, 4)`. These priors stabilise the same hierarchy and GP anchoring strategy used in VG10.
+The `q(a)` anchors are the shared, weakly-informative DS-joint family priors, common to VG05, VG07-VG10 and VG14-VG16: the low-age anchor uses `Beta(2, 12)` (median ≈ 0.13, centred on the independent TD `q(~12 mo) ≈ 0.12`) and the high-age anchor uses `Beta(3, 2)` (median ≈ 0.61, deliberately broad with no independent DS source, so the data set the 84-month level). Stabilisation of the `q` decomposition comes from the tightened GP amplitude `eta_q ~ HalfNormal(0.20)` and the per-draw GP anchor at 54 months (the VG10 strategy), not from a data-informed anchor.
 
 ![Lengthscale prior `ell_unit_q_dist`](ell_unit_q_dist.png){#fig-ell-q .lightbox fig-align="left"}
 
@@ -190,13 +190,13 @@ Study and subject random-intercept scales use HalfNormal(0.5) priors on the logi
 
 ::: {.callout-note title="Sensitivity targets"}
 
-Prior sensitivity should focus on the posterior-informed `q` anchors, signed GP amplitude and length-scale, signed intercept, random-effect scales, `log_psi`, and the Dirichlet-Multinomial concentration prior.
+Prior sensitivity should focus on the weakly-informative `q` anchors (especially the broad `q_high`), signed GP amplitude and length-scale, signed intercept, random-effect scales, `log_psi`, and the Dirichlet-Multinomial concentration prior.
 
 :::
 
 ## Prior predictive checks
 
-These checks should show that the model can generate plausible understood, spoken, signed, and total-expressive trajectories before seeing the data. The key VG15-specific questions are whether the prior allows a signing hump, whether `p_any` is not forced close to the independence bound, and whether `q(a)` remains plausible under the tightened VG10-style anchors.
+These checks should show that the model can generate plausible understood, spoken, signed, and total-expressive trajectories before seeing the data. The key VG15-specific questions are whether the prior allows a signing hump, whether `p_any` is not forced close to the independence bound, and whether `q(a)` remains plausible under the weakly-informative `q` anchors with the tightened `eta_q` and the VG10-style GP anchor.
 
 ### Prior samples -- words understood
 

--- a/notes/202605131500-vg09-structural-options.md
+++ b/notes/202605131500-vg09-structural-options.md
@@ -25,6 +25,8 @@ This is why the flagged parameters cluster on exactly the components that overla
 
 ## Options
 
+> **Correction (2026-07-12, Claude Code/Opus 4.8, re [#155](https://github.com/dseinternational/vocabulary-growth/pull/155)):** the specific values proposed below were superseded. The VG07-posterior-derived Option A anchors (`Beta(3, 22)` / `Beta(20, 4)`) were adopted in VG10 but later judged prior-data double-dipping and **broadened** across the DS-joint family to the weakly-informative, non-double-dipping `Beta(2, 12)` (low) / `Beta(3, 2)` (high). The Option B `eta_q` tightening was adopted at `HalfNormal(0.20)` (not the `HalfNormal(0.15)` floated below) to tame the `q`-GP ridge that broadening the anchors surfaced. Option D (the per-draw GP anchor) remains VG10's structural fix. The options below are preserved as the original proposal record; the current priors live in [`docs/models/PRIORS.md`](../docs/models/PRIORS.md) and `src/vocab_growth/models/definitions.py`.
+
 ### Option A — Tighten the anchor-Beta priors (smallest change)
 
 Current priors are essentially diffuse:

--- a/notes/202605141200-vg09b-findings.md
+++ b/notes/202605141200-vg09b-findings.md
@@ -18,6 +18,8 @@ VG09B implements the recommended first experiment from that note:
 
 All other components (study REs, subject REs on u and q, dispersion priors, likelihood) are identical to VG09.
 
+> **Correction (2026-07-12, Claude Code/Opus 4.8, re [#155](https://github.com/dseinternational/vocabulary-growth/pull/155)):** the Option A anchors used in this VG09B experiment (`Beta(3, 22)` / `Beta(20, 4)`) were later judged prior-data double-dipping and **broadened** across the DS-joint family to the weakly-informative `Beta(2, 12)` (low) / `Beta(3, 2)` (high), with `eta_q` tightened to `HalfNormal(0.20)` to tame the resulting `q`-GP ridge. Option D (the per-draw GP anchor) was carried through into VG10. The diagnostics and q-trajectory numbers below are the record of this specific VG09B fit under the old anchors and are not re-run here; current priors live in [`docs/models/PRIORS.md`](../docs/models/PRIORS.md) and `src/vocab_growth/models/definitions.py`.
+
 Both models were fitted in `rep` configuration. Comparison below.
 
 ## Diagnostics — every flagged parameter cleared

--- a/notes/202606171200-vg15-subject-re-stabilisation.md
+++ b/notes/202606171200-vg15-subject-re-stabilisation.md
@@ -20,6 +20,8 @@ Issue #59 asks for two things on the joint sign/speech engine
    the reference age (54 mo), applied to all three GPs, so the GP passes through
    zero there for every draw and no longer competes with the intercept/RE level.
 
+> **Correction (2026-07-12, Claude Code/Opus 4.8, re [#155](https://github.com/dseinternational/vocabulary-growth/pull/155)):** item 2(A) is superseded. The `Beta(3,22)` / `Beta(20,4)` $q$ anchors described here (the VG10 values at the time of this note) were later judged prior-data double-dipping and **broadened** across the DS-joint family (VG05, VG07–VG10, VG14–VG16) to the weakly-informative `Beta(2,12)` (low) / `Beta(3,2)` (high). The GP-vs-linear-trend ridge that broadening surfaced is now curbed by tightening `eta_q` to `HalfNormal(0.20)`; item 2(D) (the GP anchor) is unchanged. Current priors: [`docs/models/PRIORS.md`](../docs/models/PRIORS.md) and `src/vocab_growth/models/definitions.py`.
+
 All changes are gated by flags on `JointModelDefinition` (defaults off, so the
 engine reduces exactly to the merged VG15); `VG15` turns them on. A `holdout`
 column is honoured (K-fold LOSO ready); absent it, behaviour is unchanged.

--- a/notes/202606270930-ie02-refit-and-findings.md
+++ b/notes/202606270930-ie02-refit-and-findings.md
@@ -59,6 +59,8 @@ VG02 ~5 m, VG05 ~17 m, VG07 ~20 m, VG08 ~18 m, VG09 ~15 m, VG10 ~16 m, VG14
 | VG14     | trivariate (+signed)           |     1.001 |             0 |          6,628 |           0 |
 | VG15     | joint four-cell sign/speech    |     1.005 |             0 |            911 |           0 |
 
+> **Correction (2026-07-12, Claude Code/Opus 4.8, re [#155](https://github.com/dseinternational/vocabulary-growth/pull/155)):** the VG10 row's "+ tighter q anchors" label reflects the pre-#155 configuration fitted for this 2026-06-27 snapshot. #155 (2026-07-09) later broadened the DS-joint `q` anchors to the weakly-informative `Beta(2,12)` / `Beta(3,2)` and tightened `eta_q` to `HalfNormal(0.20)`; VG10 now differs from VG09 only by the GP anchor. The convergence numbers in this table are from the earlier rep fit and were not re-run here.
+
 **Zero divergences across all nine models.** Convergence is clean everywhere
 except **VG09**, which shows mild non-convergence (max R̂ 1.021 on 4 parameters,
 min ESS ~420) — consistent with its known sampler difficulty as the model

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -733,8 +733,8 @@ VG10 = BivariateModelDefinition(
     model_id="VG10",
     config_name="age-understood-spoken-ds-re-subj-uq-anchored",
     banner=(
-        "Fitting Model VG10: VG09 + tighter q anchor priors + GP anchored at"
-        " reference age (A -> U, A -> S, U -> S) - Down syndrome"
+        "Fitting Model VG10: VG09 + GP anchored at reference age"
+        " (A -> U, A -> S, U -> S) - Down syndrome"
     ),
     population=Population.DOWN_SYNDROME,
     n_trials=810,

--- a/src/vocab_growth/models/model_vg10.py
+++ b/src/vocab_growth/models/model_vg10.py
@@ -2,13 +2,17 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 """
-Model VG10: VG09 variant with tighter q-anchor priors (Option A) and the
-HSGP correction terms anchored to zero at a reference age (Option D).
+Model VG10: VG09 variant with the HSGP correction terms anchored to zero at a
+reference age (Option D).
 
 Variant of VG09 introduced to test whether the marginal r_hat / ess_tail
 issues observed on the q-trajectory hyperparameters under VG09 reflect a
 structural redundancy between the linear mean trend, the HSGP correction,
-and the subject random intercepts. See notes/202605131500-vg09-structural-options.md.
+and the subject random intercepts. (VG10 was originally also given tighter,
+VG07-posterior-derived q anchors -- "Option A" -- but #155 broadened those back
+across the DS-joint family to remove the prior-data double-dipping, so the q
+anchors now match VG09 and the GP anchor is the sole structural difference.)
+See notes/202605131500-vg09-structural-options.md.
 """
 
 from vocab_growth.models.common_bivariate_re import (

--- a/src/vocab_growth/sensitivity/registry.py
+++ b/src/vocab_growth/sensitivity/registry.py
@@ -37,7 +37,7 @@ def _logit(p: float) -> float:
 
 # (model_key, variant_name) -> {"suffix": str, "scalar"?: dict, "kappa"?: dict}
 VARIANTS: dict[tuple[str, str], dict] = {
-    # -- Target 1: VG10/VG15 posterior-informed q anchors --
+    # -- Target 1: VG10/VG15 DS-joint q anchors (weakly-informative, broadened off the VG07-posterior values by #155) --
     ("vg10", "q-broad"): {"suffix": "q-broad", "scalar": {
         "p_slope_low_q_alpha": 1.0, "p_slope_low_q_beta": 1.5,
         "p_slope_hi_q_alpha": 2.0, "p_slope_hi_q_beta": 1.2}},


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## What

The VG10 and VG15 report templates (`docs/models/vgNN/index.qmd`), the model inventory, two code files, and several notes still described the DS-joint production-ratio (`q`) anchors as `p_slope_low_q ~ Beta(3,22)` / `p_slope_hi_q ~ Beta(20,4)`, framed as "Option A, informed by the VG07 posterior". That is stale: commit b440cb4 (#155) broadened those to the weakly-informative, non-double-dipping `Beta(2,12)` / `Beta(3,2)` with `eta_q ~ HalfNormal(0.20)` compensating — but #155 only updated `PRIORS.md` and `definitions.py`, leaving the rest of the repo behind. This PR brings everything else into line.

## Why it's a reframe, not just a number swap

I verified against `src/vocab_growth/models/definitions.py`: the DS-joint configs (VG05, VG07–VG10, VG14–VG16) all use `Beta(2,12)` / `Beta(3,2)` and `eta_q ~ HalfNormal(0.20)`. Crucially, **VG09 and VG10 now carry byte-identical `q` anchors**, so VG10's only remaining structural difference from VG09 is the per-draw GP anchor (Option D) — exactly how PRIORS.md's inventory already describes it. The docs are reframed to match, and the prior-data double-dipping framing (the whole point of #155) is removed.

## Changes

- **vg10 / vg15 report templates** — corrected the `q`-anchor values and `eta_q`, dropped the "tighter / VG07-posterior / data-informed regularisation" framing, and reframed VG10 as "VG09 + GP anchor (Option D)". The weakly-positive `log_psi` prior is still labelled data-informed (only the `q` anchors changed).
- **Repo-wide consistency** — `docs/models/README.md`, the VG10 runtime banner in `definitions.py`, the `model_vg10.py` docstring, the sensitivity-registry Target 1 comment, a stale claim in the vg09 report, and the VG10 recommendations in `OUTPUT_TEMPLATE_REVIEW.md` — so nothing still asserts the old anchors as current.
- **Notes** — added dated correction pointers (rather than rewriting) to four dated notes: the structural-options proposal, the vg09b findings, the vg15 subject-RE stabilisation, and the ie_02 refit. These are point-in-time records whose fits actually used the old anchors, so their historical numbers are preserved and flagged as superseded.

## Notes for reviewers

- Quarto edits keep the AI-attribution callout per CLAUDE.md (updated to note the Claude Code/Opus 4.8 correction, following the multi-tool pattern already in PRIORS.md).
- `PRIORS.md` and the `definitions.py` `q`-anchor code comments were already correct from #155 and are untouched.
- Checks pass locally: `ruff check`, `npm run spellcheck` (0 issues), `npm run format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)