### PR TITLE
Adopt shared dse-research-utils reporting helpers (v0.7.0)

### DIFF
--- a/docs/models/vg01/index.qmd
+++ b/docs/models/vg01/index.qmd
@@ -147,33 +147,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg02/index.qmd
+++ b/docs/models/vg02/index.qmd
@@ -147,33 +147,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg03/index.qmd
+++ b/docs/models/vg03/index.qmd
@@ -147,33 +147,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg04/index.qmd
+++ b/docs/models/vg04/index.qmd
@@ -147,33 +147,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -157,33 +157,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg07/index.qmd
+++ b/docs/models/vg07/index.qmd
@@ -162,33 +162,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg08/index.qmd
+++ b/docs/models/vg08/index.qmd
@@ -164,33 +164,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -162,33 +162,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -177,33 +177,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg11/index.qmd
+++ b/docs/models/vg11/index.qmd
@@ -152,33 +152,10 @@ study_counts
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg12/index.qmd
+++ b/docs/models/vg12/index.qmd
@@ -152,33 +152,10 @@ study_counts
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -164,33 +164,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg14/index.qmd
+++ b/docs/models/vg14/index.qmd
@@ -215,33 +215,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -232,33 +232,10 @@ descriptive_stats
 ## Diagnostics
 
 ```{python}
+from dse_research_utils.statistics.diagnostics import style_diagnostics_table
+
 diagnostics = pd.read_csv("diagnostics.csv", index_col=0)
-
-
-def _flag_red(v, threshold, *, above):
-    bad = v > threshold if above else v < threshold
-    return "color: #b00; font-weight: bold;" if bad else ""
-
-
-def _style_diagnostics(df):
-    styler = df.style.format(precision=3)
-    if "r_hat" in df.columns:
-        styler = styler.map(
-            lambda v: _flag_red(v, 1.01, above=True), subset=["r_hat"]
-        )
-    ess_cols = [c for c in ("ess_bulk", "ess_tail") if c in df.columns]
-    if ess_cols:
-        styler = styler.map(
-            lambda v: _flag_red(v, 400, above=False), subset=ess_cols
-        )
-    styler.set_caption(
-        "Reported convergence diagnostics. Cells highlighted red flag "
-        "r̂ > 1.01 or ESS < 400."
-    )
-    return styler
-
-
-_style_diagnostics(diagnostics)
+style_diagnostics_table(diagnostics)
 ```
 
 ![energy_plot](energy_plot.png){#fig-energy .lightbox width=480 fig-align="left"}

--- a/docs/report/_report_data.qmd
+++ b/docs/report/_report_data.qmd
@@ -12,26 +12,59 @@ derived from definitions.py so paths cannot drift from the code.
 from pathlib import Path
 
 import pandas as pd
+from dse_research_utils.report.data import ReportData
+from dse_research_utils.report.data import num as _num
+from dse_research_utils.report.data import show_or_pending as _show_or_pending
 from vocab_growth.models.definitions import MODEL_REGISTRY
 
 FIG_ROOT = Path("figures")
 _DIR_BY_ID = {m.model_id: f"{m.model_id}-{m.config_name}" for m in MODEL_REGISTRY.values()}
 
+# Shared per-model artefact reader (dse_research_utils) over this report's curated
+# figures/<MODEL_ID>-<config_name> store; the directory is fixed per model (registry-
+# derived) so the resolver ignores the config argument.
+_report = ReportData(lambda model_id, _config: FIG_ROOT / _DIR_BY_ID[model_id])
+
 
 def model_dir(model_id):
-    return FIG_ROOT / _DIR_BY_ID[model_id]
+    return _report.model_dir(model_id)
 
 
 def load_summary(model_id, name):
     """Posterior-summary / data CSV for a model, or None if not present."""
-    p = model_dir(model_id) / f"{name}.csv"
-    return pd.read_csv(p) if p.exists() else None
+    return _report.load_summary(model_id, name)
+
+
+def load_json(model_id, name):
+    """Parsed JSON artefact for a model (e.g. the convergence gate), or None."""
+    return _report.load_json(model_id, name)
 
 
 def fig(model_id, filename):
     """Relative path to a figure for embedding."""
-    return str(model_dir(model_id) / filename)
+    return _report.fig(model_id, filename)
 
+
+def summary_value(model_id, summary, column):
+    """Single value from the first row of a summary, or None."""
+    return _report.summary_value(model_id, summary, column)
+
+
+def val(model_id, summary, age_months, column):
+    """Single value from a summary at (or nearest to) an age, or None."""
+    return _report.value_at(model_id, summary, column, at=age_months, key="age_months")
+
+
+def show_or_pending(df, what):
+    return _show_or_pending(df, what, hint="its output is present under `docs/report/figures/`")
+
+
+def num(value, fmt="{:.0f}"):
+    """Format a value for prose, or an em dash when it is missing."""
+    return _num(value, fmt)
+
+
+# --- Report-specific helpers (kept local) -----------------------------------
 
 # Cross-model DS/TD comparison artefacts (figures/comparisons/, synced from
 # output/comparisons/). Schemas vary per file, so access is by (match_col, value).
@@ -53,23 +86,6 @@ def comp_at(name, match_col, match_val, col):
     return row[col]
 
 
-def val(model_id, summary, age_months, column):
-    """Single value from a summary at (or nearest to) an age, or None."""
-    df = load_summary(model_id, summary)
-    if df is None or "age_months" not in df or column not in df:
-        return None
-    row = df.iloc[(df["age_months"] - age_months).abs().argmin()]
-    return row[column]
-
-
-def summary_value(model_id, summary, column):
-    """Single value from the first row of a summary, or None."""
-    df = load_summary(model_id, summary)
-    if df is None or df.empty or column not in df:
-        return None
-    return df[column].iloc[0]
-
-
 def words(model_id, summary, age_months, column="Ey_median"):
     """Expected word count at an age, rounded to a whole word (str for prose)."""
     v = val(model_id, summary, age_months, column)
@@ -78,13 +94,14 @@ def words(model_id, summary, age_months, column="Ey_median"):
 
 # Columns to surface, in order, when present (posterior_summary_*.csv schema:
 # age_months; Ey_* = expected count, typical child; Y_* = predictive, individual).
+# The engines report 90% HDIs (ReportingConfiguration ci_prob=0.90, interval_kind="hdi").
 _COUNT_COLS = {
     "age_months": "Age (mo)",
     "Ey_median": "Expected",
-    "Ey_hdi_lo": "Expected 94% lo",
-    "Ey_hdi_hi": "Expected 94% hi",
-    "Y_hdi_lo": "Individual 94% lo",
-    "Y_hdi_hi": "Individual 94% hi",
+    "Ey_hdi_lo": "Expected 90% lo",
+    "Ey_hdi_hi": "Expected 90% hi",
+    "Y_hdi_lo": "Individual 90% lo",
+    "Y_hdi_hi": "Individual 90% hi",
 }
 
 
@@ -96,30 +113,6 @@ def format_counts(df):
     num = out.select_dtypes("number").columns
     out[num] = out[num].round(0).astype("Int64", errors="ignore")
     return out
-
-
-def show_or_pending(df, what):
-    if df is None:
-        from IPython.display import Markdown
-
-        return Markdown(
-            f"> **Pending fit** — {what} will appear here once the model has been "
-            f"fitted and its output is present under `docs/report/figures/`."
-        )
-    return df
-
-
-def load_json(model_id, name):
-    """Parsed JSON artefact for a model (e.g. the convergence gate), or None."""
-    import json
-
-    p = model_dir(model_id) / f"{name}.json"
-    return json.loads(p.read_text()) if p.exists() else None
-
-
-def num(value, fmt="{:.0f}"):
-    """Format a value for prose, or an em dash when it is missing."""
-    return "—" if value is None else fmt.format(value)
 
 
 def summary_num(model_id, summary, column, fmt="{:.0f}"):

--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,7 @@ dependencies:
       # notebook (ipython/ipywidgets/notebook/jupytext), io (orjson/tabulate).
       # This also pulls dse-research-utils' own runtime deps (azure-identity/
       # -storage-blob, rich, psutil, pyyaml, …) — no need to list them here.
-      - dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.5.2#subdirectory=src/python
+      - dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.7.0#subdirectory=src/python
       - -e ./
       # Local-dev override — to develop against a sibling checkout of research,
       # comment the git line above and uncomment this instead:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "arviz-stats>=1.2.0",
   "arviz>=1.2.0",
   "duckdb>=1.5.4",
-  "dse-research-utils>=0.5.0",
+  "dse-research-utils>=0.7.0",
   "jaxlib>=0.9.2",
   "matplotlib>=3.10.9",
   "numpy>=2.4.4",
@@ -43,7 +43,7 @@ dev = [
 # dse-research-utils isn't published to PyPI — resolve it from the public git
 # tag. (The conda env in environment.yml installs it from the same tag in its
 # pip layer; this entry is only consumed by uv.)
-dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.5.0" }
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.7.0" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"

--- a/scripts/kfold_loso.py
+++ b/scripts/kfold_loso.py
@@ -172,7 +172,8 @@ def fit_fold(
         model_name=f"KFOLD-{label}",
         config_name=definition.config_name,
         output_root_dir=KFOLD_TMP_DIR,
-        hdi=0.90,
+        ci_prob=0.90,
+        interval_kind="hdi",
     )
     if os.path.exists(reporting_cfg.output_dir):
         shutil.rmtree(reporting_cfg.output_dir)

--- a/scripts/prior_predictive_audit.py
+++ b/scripts/prior_predictive_audit.py
@@ -44,7 +44,8 @@ def _context(definition) -> ModelFitContext:
             model_name=definition.model_id,
             config_name=definition.config_name,
             output_root_dir=env.output_root(),
-            hdi=0.90,
+            ci_prob=0.90,
+            interval_kind="hdi",
         ),
         sampling=sampling.get_sampling_configuration("dev"),
     )

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -831,7 +831,7 @@ def diagnostics(
         var_names=var_names,
         round_to=round_to,
         ci_prob=context.reporting.ci_prob,
-        ci_kind="hdi",
+        ci_kind=context.reporting.interval_kind,
     )
 
     diagnostics_df.to_csv(
@@ -899,7 +899,7 @@ def diagnostics(
         context.trace,
         var_names=posterior_var_names,
         point_estimate="median",
-        ci_kind="hdi",
+        ci_kind=context.reporting.interval_kind,
         ci_prob=context.reporting.ci_prob,
     )
     plt.savefig(

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -830,7 +830,7 @@ def diagnostics(
         context.trace,
         var_names=var_names,
         round_to=round_to,
-        ci_prob=context.reporting.hdi,
+        ci_prob=context.reporting.ci_prob,
         ci_kind="hdi",
     )
 
@@ -900,7 +900,7 @@ def diagnostics(
         var_names=posterior_var_names,
         point_estimate="median",
         ci_kind="hdi",
-        ci_prob=context.reporting.hdi,
+        ci_prob=context.reporting.ci_prob,
     )
     plt.savefig(
         os.path.join(context.reporting.output_dir, "posterior_plot.png"), dpi=300
@@ -991,7 +991,7 @@ def posterior_summary(context: ModelFitContext):
         context.model_samples.p_query,
         context.model_samples.y_query,
         n_trials=context.model_data.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
     )
 
     dataframe_table(
@@ -1015,7 +1015,7 @@ def run_standard_plots(context: ModelFitContext, *, outcome_label: str = "Word c
         X_query=context.model_samples.X_query,
         y_query=context.model_samples.y_query,
         n_trials=context.model_data.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         output_dir=context.reporting.output_dir,
         filename="posterior_predictive_count_distributions",
         x_label=outcome_label,
@@ -1065,7 +1065,7 @@ def run_standard_plots(context: ModelFitContext, *, outcome_label: str = "Word c
         context.model_samples.X_plot,
         context.model_samples.f_plot,
         n_trials=context.model_data.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         output_dir=context.reporting.output_dir,
         filename="expected_learning_rate",
     )
@@ -1074,7 +1074,7 @@ def run_standard_plots(context: ModelFitContext, *, outcome_label: str = "Word c
         context.model_samples.X_plot,
         context.model_samples.f_plot,
         n_trials=context.model_data.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         smooth=True,
         savgol_window_length=15,
         savgol_polyorder=3,
@@ -1089,7 +1089,7 @@ def run_standard_plots(context: ModelFitContext, *, outcome_label: str = "Word c
         context.model_samples.X_query,
         context.model_samples.kappa_query,
         n_trials=context.model_data.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         output_dir=context.reporting.output_dir,
         filename="posterior_kappa",
     )
@@ -1160,7 +1160,7 @@ def _plot_and_print_dist(context, dist, name):
     context.plots[name] = plot_dist.plot_distribution(
         dist, context.reporting.output_dir, name
     )
-    summary = dist.summary(mass=context.reporting.hdi)
+    summary = dist.summary(mass=context.reporting.ci_prob)
     console.print(f"  [yellow]{name}[/yellow]: {summary}")
 
 
@@ -1327,7 +1327,8 @@ def run_fit_pipeline(
             model_name=definition.model_id,
             config_name=definition.config_name,
             output_root_dir=local_env.output_root(),
-            hdi=0.90,
+            ci_prob=0.90,
+            interval_kind="hdi",
         ),
         sampling=sampling.get_sampling_configuration(config),
     )

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -1013,7 +1013,7 @@ def posterior_summary(context: BivariateContext):
     """Compute and store the posterior summary tables at query ages."""
     samples = context.model_samples
     n_trials = context.model_data.n_trials
-    hdi_prob = context.reporting.hdi
+    hdi_prob = context.reporting.ci_prob
     has_subject_re = any(
         name in context.model_variables for name in ("tau_subj_u", "tau_subj_q")
     )
@@ -1663,7 +1663,7 @@ def _run_bivariate_joint_plots(
 
     fig = plot_production_rate(
         samples,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         output_dir=context.reporting.output_dir,
         filename="production_rate",
     )
@@ -1675,7 +1675,7 @@ def _run_bivariate_joint_plots(
     fig = plot_production_rate_by_understood(
         samples,
         n_trials=definition.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         output_dir=context.reporting.output_dir,
         filename="production_rate_by_understood",
     )
@@ -1697,7 +1697,7 @@ def _run_bivariate_joint_plots(
     fig = plot_comprehension_production_gap(
         samples,
         n_trials=context.model_data.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         output_dir=context.reporting.output_dir,
         filename="comprehension_production_gap",
     )
@@ -1731,7 +1731,7 @@ def _run_bivariate_joint_plots(
     fig = plot_spoken_given_understood(
         samples,
         n_trials=context.model_data.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         output_dir=context.reporting.output_dir,
         filename="spoken_given_understood",
     )
@@ -1750,7 +1750,7 @@ def _run_bivariate_joint_plots(
         x_obs=analysis_df.loc[has_u, "age"],
         y_obs=analysis_df.loc[has_u, "understood"],
         n_trials=context.model_data.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         output_dir=context.reporting.output_dir,
         suffix="u",
         outcome_label="Words understood",
@@ -1769,7 +1769,7 @@ def _run_bivariate_joint_plots(
         x_obs=analysis_df.loc[has_s, "age"],
         y_obs=analysis_df.loc[has_s, "spoken"],
         n_trials=context.model_data.n_trials,
-        hdi_prob=context.reporting.hdi,
+        hdi_prob=context.reporting.ci_prob,
         output_dir=context.reporting.output_dir,
         suffix="s",
         outcome_label="Words spoken",

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -1198,7 +1198,7 @@ def sample_posterior_predictive(context: JointContext, definition=None):
 def posterior_summary(context: JointContext):
     s = context.model_samples
     n_trials = context.model_data.n_trials
-    hdi = context.reporting.hdi
+    hdi = context.reporting.ci_prob
     od = context.reporting.output_dir
 
     def probability_summary(X, draws, prefix, label):
@@ -1272,7 +1272,7 @@ def _run_joint_plots(context: JointContext):
     s = context.model_samples
     n_trials = context.model_data.n_trials
     od = context.reporting.output_dir
-    hdi = context.reporting.hdi
+    hdi = context.reporting.ci_prob
     X = s.X_plot
 
     # 1) Data-identified p_any vs independence upper bound (expected counts)

--- a/src/vocab_growth/models/common_trivariate.py
+++ b/src/vocab_growth/models/common_trivariate.py
@@ -1331,7 +1331,7 @@ def posterior_summary(context: TrivariateContext):
     """Compute and store the posterior summary tables at query ages."""
     samples = context.model_samples
     n_trials = context.model_data.n_trials
-    hdi_prob = context.reporting.hdi
+    hdi_prob = context.reporting.ci_prob
 
     # Understood summary
     summary_u = posterior_analysis.posterior_summary_table(
@@ -1953,7 +1953,7 @@ def _run_trivariate_plots(context: TrivariateContext):
     has_s = analysis_df["spoken"].notna()
     has_sign = analysis_df["signed"].notna()
     n_trials = context.model_data.n_trials
-    hdi_prob = context.reporting.hdi
+    hdi_prob = context.reporting.ci_prob
     output_dir = context.reporting.output_dir
 
     # ---- Joint trajectory (understood, spoken, signed) ----

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -284,7 +284,7 @@ def plot_posterior_predictive_count_distributions_by_query_age(
     nq = len(X_query)
     axis_max = n_trials if count_axis_max is None else count_axis_max
 
-    # ETI quantile levels matching context.reporting.hdi mass (e.g., 0.90 -> [0.05, 0.95])
+    # ETI quantile levels matching context.reporting.ci_prob mass (e.g., 0.90 -> [0.05, 0.95])
     if eti_prob is not None:
         q_lo = (1.0 - eti_prob) / 2.0
         q_hi = 1.0 - q_lo

--- a/tests/test_bivariate_re_holdout_mask.py
+++ b/tests/test_bivariate_re_holdout_mask.py
@@ -94,7 +94,8 @@ def _build_holdout_model(tmp_path, monkeypatch, definition=VG07):
             model_name="TEST_VG07_HOLDOUT",
             config_name="test",
             output_root_dir=str(tmp_path),
-            hdi=0.90,
+            ci_prob=0.90,
+            interval_kind="hdi",
         ),
         sampling=sampling.get_sampling_configuration("test"),
     )

--- a/tests/test_joint_four_cell.py
+++ b/tests/test_joint_four_cell.py
@@ -106,7 +106,8 @@ def test_prepare_joint_data_uses_cell_total_and_drops_empty_rows(
             model_name="TEST_VG15_DATA",
             config_name="test",
             output_root_dir=str(tmp_path),
-            hdi=0.90,
+            ci_prob=0.90,
+            interval_kind="hdi",
         ),
         sampling=sampling.get_sampling_configuration("test"),
     )

--- a/tests/test_nz01_produced_cells.py
+++ b/tests/test_nz01_produced_cells.py
@@ -102,7 +102,8 @@ def _prepare_context(tmp_path, monkeypatch, definition):
             model_name="TEST_VG15_NZ01",
             config_name="test",
             output_root_dir=str(tmp_path),
-            hdi=0.90,
+            ci_prob=0.90,
+            interval_kind="hdi",
         ),
         sampling=sampling.get_sampling_configuration("test"),
     )

--- a/tests/test_study_re_parameterisation.py
+++ b/tests/test_study_re_parameterisation.py
@@ -45,7 +45,8 @@ def vg07_model(tmp_path, monkeypatch):
             model_name=VG07.model_id,
             config_name=VG07.config_name,
             output_root_dir=str(tmp_path),
-            hdi=0.90,
+            ci_prob=0.90,
+            interval_kind="hdi",
         ),
         sampling=sampling.get_sampling_configuration("dev"),
     )

--- a/tests/test_trend_gp_consolidation.py
+++ b/tests/test_trend_gp_consolidation.py
@@ -58,7 +58,8 @@ def _build(model_id, tmp_path, monkeypatch):
             model_name=d.model_id,
             config_name=d.config_name,
             output_root_dir=str(tmp_path),
-            hdi=0.90,
+            ci_prob=0.90,
+            interval_kind="hdi",
         ),
         sampling=sampling.get_sampling_configuration("dev"),
     )


### PR DESCRIPTION
> [!NOTE]
> Drafted by a LLM-based AI tool (Claude Code/Opus 4.8).

Part of dseinternational/research#46. Migrates this report onto the consolidated reporting surfaces landed in **dse-research-utils 0.7.0** (dseinternational/research#68), dropping the local copies.

## Changes

- **`ReportingConfiguration`** — the shared `hdi` field (a misnomer that stored the coverage probability) was renamed to `ci_prob` + an explicit `interval_kind`. All 8 construction sites now pass `ci_prob=0.90, interval_kind="hdi"`, and every `context.reporting.hdi` read across the model engines becomes `.ci_prob`.
- **Model pages** — the `_flag_red` / `_style_diagnostics` block was copy-pasted **verbatim across all 14** `docs/models/*/index.qmd` pages. Replaced with the shared `diagnostics.style_diagnostics_table` (identical thresholds r̂ > 1.01 / ESS < 400, precision, and caption — a true drop-in).
- **`_report_data.qmd`** — `model_dir` / `load_summary` / `load_json` / `fig` / `summary_value` / `val` / `show_or_pending` / `num` now delegate to the shared `report.data.ReportData` (call signatures preserved, so no chapter changes). The report-specific helpers (`comp_load` / `comp_at` / `words` / `format_counts` / `psi_evidence` / `convergence_banner`) stay local.
- **Bug fix — stale interval labels.** `_COUNT_COLS` labelled the expected/individual columns "94%", but the engines compute **90%** HDIs (`ci_prob=0.90`). Corrected to "90%".
- **Version pins** — `pyproject.toml` (uv source tag + floor) and `environment.yml` bumped to **v0.7.0**, reconciling the prior v0.5.0 / v0.5.2 drift.

**Net −321 lines** (mostly the 14× de-duplicated diagnostics block).

## Verification

- Full test suite: **126 passed, 8 skipped** against research 0.7.0 (resolved via `PYTHONPATH` to the local 0.7.0 worktree). `ruff check` clean.
- The refactored `_report_data.qmd` and a model-page diagnostics chunk were smoke-tested under 0.7.0 (graceful "pending fit", banner placeholder, and a styled diagnostics table). A full Quarto render was **not** exercised locally (needs the render toolchain + fitted outputs); the changes are minimal Python delegations.

> **Merge order:** depends on dseinternational/research#68 being merged and tagged **v0.7.0** (the pins resolve from that tag). CI here will not resolve the dependency until the tag exists.