### PR TITLE
fix(models): drop degenerate (n=0) observations from joint-model PSIS-LOO

### DIFF
--- a/notes/202607161902-full-refit-rep-replite-run.md
+++ b/notes/202607161902-full-refit-rep-replite-run.md
@@ -23,10 +23,10 @@ Full replication refit of every registered model (VG01–VG16) on the current 81
 
 ## Model split
 
-| Config     | Models                                                                 |
-| ---------- | ---------------------------------------------------------------------- |
-| `rep`      | vg01 vg02 vg03 vg04 vg05 vg07 vg08 vg09 vg10 vg13 vg14 vg15 vg16 (13)   |
-| `rep-lite` | vg11 vg12 (2 — full-data TD)                                            |
+| Config     | Models                                                                |
+| ---------- | --------------------------------------------------------------------- |
+| `rep`      | vg01 vg02 vg03 vg04 vg05 vg07 vg08 vg09 vg10 vg13 vg14 vg15 vg16 (13) |
+| `rep-lite` | vg11 vg12 (2 — full-data TD)                                          |
 
 ## Progress log
 
@@ -44,7 +44,7 @@ Full replication refit of every registered model (VG01–VG16) on the current 81
 
 **Blast radius.** Every joint/multivariate model: `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg13`, `vg14`, `vg15`, `vg16` (9 of 15). The 6 univariate models (`vg01`–`vg04` done; `vg11`/`vg12` pending) are unaffected. Crash occurs **after** sampling, in `diagnostics`, which runs **before** the posterior-predictive stage that writes `trace.nc` — so a failed joint fit **loses its trace** (no cheap recompute).
 
-**Fix (implemented 2026-07-17).** `common.py` now computes each per-outcome LOO through a helper `_loo_dropping_degenerate(idata, var_name)` that drops observations whose pointwise log-likelihood is constant across draws before calling `az.loo`. The drop is deterministic (keyed off the structural `n = 0` degeneracy alone), so every joint model excludes the *same* observations and the per-outcome elpd stays comparable across models for `loo_compare`. Threshold: across-draw variance ≤ `1e-12` — the degenerate points sit at ~`1e-33` (numerically-zero log-lik plus fp noise) while genuinely informative observations have variance ≫ `1e-6`, so the two are cleanly separated (an initial `np.finfo(float).tiny` threshold was far too small and dropped nothing). Verified end-to-end: a `dev` fit of `vg05` reported "dropped 14 degenerate … observation(s)", computed LOO for both outcomes, and completed the full pipeline (exit 0). `ruff` clean; `tests/test_diagnostics_gate.py` passes.
+**Fix (implemented 2026-07-17).** `common.py` now computes each per-outcome LOO through a helper `_loo_dropping_degenerate(idata, var_name)` that drops observations whose pointwise log-likelihood is constant across draws before calling `az.loo`. The drop is deterministic (keyed off the structural `n = 0` degeneracy alone), so every joint model excludes the _same_ observations and the per-outcome elpd stays comparable across models for `loo_compare`. Threshold: across-draw variance ≤ `1e-12` — the degenerate points sit at ~`1e-33` (numerically-zero log-lik plus fp noise) while genuinely informative observations have variance ≫ `1e-6`, so the two are cleanly separated (an initial `np.finfo(float).tiny` threshold was far too small and dropped nothing). Verified end-to-end: a `dev` fit of `vg05` reported "dropped 14 degenerate … observation(s)", computed LOO for both outcomes, and completed the full pipeline (exit 0). `ruff` clean; `tests/test_diagnostics_gate.py` passes.
 
 **Working-tree change, flagged for review** (as with the 2026-07-12 DuckDB-lock fix): `src/vocab_growth/models/common.py`. Follow-up: a dedicated regression test for `_loo_dropping_degenerate` (deferred — needs a joint-trace fixture) and a proper PR.
 

--- a/notes/202607161902-full-refit-rep-replite-run.md
+++ b/notes/202607161902-full-refit-rep-replite-run.md
@@ -1,0 +1,74 @@
+# Full refit run of VG01–VG16 (rep + rep-lite) — run record and progress
+
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+
+> [!WARNING]
+> Live run record, started 2026-07-16 ~19:02 UTC while the run is in progress. Convergence, results tables, and timings below are filled in as the run drains. Numbers are not final until this banner is removed.
+
+## Purpose
+
+Full replication refit of every registered model (VG01–VG16) on the current 810-item reference scale, following `docs/runbooks/full-refit.md`. Every model is fitted at the `rep` (reporting) sampling config **except** the two full-data ("large") TD models — `vg11` and `vg12` — which are fitted at `rep-lite`, per the runbook's validated recommendation. All reports are then rendered and uploaded to the public research blob storage.
+
+## Environment and method
+
+- **Machine:** local Mac (darwin), 16 cores, 48 GB RAM, 307 GB free on the internal disk. This is materially smaller than the 32-core/251 GB VM used for the 2026-07-12 run, so wall time is expected to be longer (~1.5–2+ days) and the full-data TD fits (`vg11`/`vg12`) carry a real OOM risk at 48 GB — a reason the `rep-lite` (4-chain) config for those two is doubly helpful here.
+- **Env:** conda `dse-vocab-growth`, `dse-research-utils 0.7.0` (≥ v0.6.0, so the convergence gate reports **unrounded** R-hat/ESS natively — no gate-rounding false-pass risk).
+- **Output root:** repo-local `output/` (gitignored). Report figure cache stays in the checkout at `docs/report/figures/`.
+- **Configs:**
+  - `rep` — 6 chains / 6000 tune / 6000 draws / `target_accept` 0.95.
+  - `rep-lite` — 4 chains / 4000 tune / 4000 draws / `target_accept` 0.95.
+- **Data:** confirmed current (merged DuckDB newer than all 13 source CSVs); no re-prep needed, but `prepare_data.py` is re-run once at the start of the driver for safety.
+- **Execution:** sequential per-model fitting via `scripts/run_replication.sh` (resumable — a model whose `trace.nc` exists is skipped). Sequential rather than the VM's DS-concurrent pool because 16 cores only fits ~2 six-chain `rep` models at once and the `rep` set here contains no huge full-data fits (those are the `rep-lite` pair), so sequential avoids the thread-oversubscription / OOM pitfalls for little wall-time cost.
+
+## Model split
+
+| Config     | Models                                                                 |
+| ---------- | ---------------------------------------------------------------------- |
+| `rep`      | vg01 vg02 vg03 vg04 vg05 vg07 vg08 vg09 vg10 vg13 vg14 vg15 vg16 (13)   |
+| `rep-lite` | vg11 vg12 (2 — full-data TD)                                            |
+
+## Progress log
+
+- **2026-07-16 ~19:02 UTC** — prerequisites verified (env, gate v0.7.0, data current, disk, blob URL set). Run record created.
+- **2026-07-16 ~19:03–20:35 UTC** — pass 1 fits: `vg01` PASS (283 s), `vg02` PASS (242 s), `vg03` PASS (4087 s), `vg04` PASS (892 s). All four univariate models clean, reports rendered.
+- **2026-07-16 ~20:45 UTC** — `vg05` (first joint model) **crashed in the diagnostics stage** (see Incident 1). Run **stopped** to avoid wasting hours on the 8 further joint models that share the same defect.
+
+## Incident 1 — PSIS-LOO crash on joint models (nested-likelihood regression)
+
+**Symptom.** `vg05` sampled cleanly and **passed the convergence gate** (0 divergences, max R-hat 1.0013, min ESS 8602), then crashed in `diagnostics` → `az.loo(trace, var_name="y_s_obs")` with `ValueError: All tail values are the same` (`arviz_stats/base/diagnostics.py:1188`, `_ps_tail`).
+
+**Root cause.** The DS joint likelihood models spoken conditionally on understood (`y_s ~ BetaBinomial(n = understood, …)`, the nested outcome likelihood from #163/#164). The merged DS data contains **14 rows with `understood == 0`** → spoken denominator `n = 0` → the spoken per-observation log-likelihood is **constant (≡ 0) across every posterior draw**. PSIS-LOO's Pareto tail fit requires the pointwise log-lik to vary; `arviz_stats 1.2.0`'s `az.loo` **raises** on such degenerate points (its moment-matching path lists this exact string in `fallback_errors`, but the plain `az.loo` path does not catch it).
+
+**Why it's new.** This is the **first reporting-quality fit of the nested-likelihood models** (`docs/models/README.md` explicitly flags #163's nested outcome likelihood as requiring new rep fits). The 2026-07-12 run predates #163/#164, when spoken used a marginal fixed-810 denominator and never produced a constant per-obs log-lik — so the crash could not occur then.
+
+**Blast radius.** Every joint/multivariate model: `vg05`, `vg07`, `vg08`, `vg09`, `vg10`, `vg13`, `vg14`, `vg15`, `vg16` (9 of 15). The 6 univariate models (`vg01`–`vg04` done; `vg11`/`vg12` pending) are unaffected. Crash occurs **after** sampling, in `diagnostics`, which runs **before** the posterior-predictive stage that writes `trace.nc` — so a failed joint fit **loses its trace** (no cheap recompute).
+
+**Fix (implemented 2026-07-17).** `common.py` now computes each per-outcome LOO through a helper `_loo_dropping_degenerate(idata, var_name)` that drops observations whose pointwise log-likelihood is constant across draws before calling `az.loo`. The drop is deterministic (keyed off the structural `n = 0` degeneracy alone), so every joint model excludes the *same* observations and the per-outcome elpd stays comparable across models for `loo_compare`. Threshold: across-draw variance ≤ `1e-12` — the degenerate points sit at ~`1e-33` (numerically-zero log-lik plus fp noise) while genuinely informative observations have variance ≫ `1e-6`, so the two are cleanly separated (an initial `np.finfo(float).tiny` threshold was far too small and dropped nothing). Verified end-to-end: a `dev` fit of `vg05` reported "dropped 14 degenerate … observation(s)", computed LOO for both outcomes, and completed the full pipeline (exit 0). `ruff` clean; `tests/test_diagnostics_gate.py` passes.
+
+**Working-tree change, flagged for review** (as with the 2026-07-12 DuckDB-lock fix): `src/vocab_growth/models/common.py`. Follow-up: a dedicated regression test for `_loo_dropping_degenerate` (deferred — needs a joint-trace fixture) and a proper PR.
+
+- **2026-07-17 ~06:46 UTC** — fix landed and verified; run resumed (driver `bzpopzjn8`) for the 9 joint models + the `rep-lite` TD pair. The 4 univariate models `vg01`–`vg04` are already complete and are correctly skipped (also fixed `run_replication.sh`'s `has_trace`, which used a bash-4 `${1^^}` expansion that errored as "bad substitution" on macOS bash 3.2 and silently defeated skip-on-resume).
+
+## Convergence (models of record — true, unrounded diagnostics)
+
+Gate: max R-hat ≤ 1.01, min ESS ≥ 400, 0 divergences, BFMI ≥ 0.3.
+
+_(filled in as fits complete)_
+
+| Model | population / outcome | max R-hat | min ESS | div | verdict | config |
+| ----- | -------------------- | --------- | ------- | --- | ------- | ------ |
+
+### Known ridge to watch
+
+Per the runbook, the DS joint/hierarchical models (`vg09`, `vg10`, `vg15`, `vg16`) historically leave the understood-trajectory GP block just over 1.01 at `rep`, and `vg13` needed `target_accept` 0.99 in the 2026-07-12 run. Remedy is a heavier-tuning refit (tune 12000 / draws 8000 / `target_accept` 0.97). The model code has changed since that run (#161–#164), so convergence is re-assessed empirically this run rather than assumed.
+
+## Render + upload
+
+_(filled in after fits pass the gate)_
+
+## Reproduction / artefacts
+
+- Driver: `output/replication-driver.sh` (two `run_replication.sh` fit-only passes: `rep` set, then `rep-lite` pair).
+- Logs: `output/replication-logs/latest/run.log` and `status.tsv`.
+- Traces / figures: `output/models/<MODEL>/`.

--- a/scripts/run_replication.sh
+++ b/scripts/run_replication.sh
@@ -165,7 +165,10 @@ run_step() {  # name  command...
 
 # Does model <key> already have a completed trace.nc?
 has_trace() {
-  [ -n "$(find "$OUT_ROOT/models" -maxdepth 2 -iname trace.nc -ipath "*/${1^^}-*" 2>/dev/null | head -1)" ]
+  # -ipath is already case-insensitive, so no need for ${1^^} (a bash-4
+  # uppercase expansion that errors as "bad substitution" on macOS bash 3.2 and
+  # silently broke skip-on-resume there).
+  [ -n "$(find "$OUT_ROOT/models" -maxdepth 2 -iname trace.nc -ipath "*/${1}-*" 2>/dev/null | head -1)" ]
 }
 
 on_exit() {

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -836,11 +836,20 @@ def _loo_dropping_degenerate(idata, var_name=None):
         keep = (da.var(dim=sample_dims) > 1e-12).values
         n_dropped = int(keep.size) - int(keep.sum())
         if n_dropped:
-            loo_source = idata.copy()
+            # ``idata`` is an xarray ``DataTree`` (arviz >= 1.2); ``copy`` is
+            # shallow by default, so the (large) posterior/sample_stats groups
+            # share buffers with the original rather than being duplicated —
+            # only the tree structure is copied. Reassigning the sliced
+            # (``isel`` view) log-likelihood therefore does not mutate the
+            # caller's ``idata``, so repeated per-outcome calls stay independent.
+            loo_source = idata.copy(deep=False)
             loo_source["log_likelihood"] = loo_source["log_likelihood"].isel(
                 {obs_dims[0]: keep}
             )
-    return az.loo(loo_source, var_name=var_name), n_dropped
+    # Compute LOO for the resolved ``name`` (not the raw ``var_name``): when
+    # ``var_name`` is None, ``az.loo`` rejects a log-likelihood group holding
+    # more than one array, so keep the LOO target identical to the drop target.
+    return az.loo(loo_source, var_name=name), n_dropped
 
 
 def diagnostics(

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -804,6 +804,45 @@ def diagnostics_var_names(model) -> tuple[list[str], list[str]]:
     return summary_var_names, gate_var_names
 
 
+def _loo_dropping_degenerate(idata, var_name=None):
+    """Compute PSIS-LOO, excluding observations with a constant pointwise
+    log-likelihood.
+
+    The nested joint likelihood models a paired outcome (spoken/signed)
+    conditionally on the observed *understood* count as its denominator, so a
+    row with ``understood == 0`` gives that outcome a structurally constant
+    (``n = 0``) log-likelihood across every draw. PSIS requires the pointwise
+    log-likelihood to vary across draws — arviz-stats raises
+    ``"All tail values are the same"`` on such degenerate points. Those
+    observations carry no information about the paired outcome, so they are
+    dropped from that outcome's LOO. Because the drop is deterministic (it keys
+    off ``n = 0`` alone), every joint model excludes the *same* observations,
+    keeping the per-outcome elpd comparable across models (``loo_compare``).
+
+    Returns ``(loo, n_dropped)``.
+    """
+    ll = idata.log_likelihood
+    name = var_name if var_name is not None else list(ll.data_vars)[0]
+    da = ll[name]
+    sample_dims = [d for d in ("chain", "draw") if d in da.dims]
+    obs_dims = [d for d in da.dims if d not in sample_dims]
+    n_dropped = 0
+    loo_source = idata
+    if len(obs_dims) == 1:
+        # A structurally constant (n = 0) log-likelihood is numerically ~0 with
+        # only floating-point noise, so its across-draw variance is ~1e-33, not
+        # exactly zero. Genuinely informative observations vary by orders of
+        # magnitude more (variance >> 1e-6), so 1e-12 cleanly separates the two.
+        keep = (da.var(dim=sample_dims) > 1e-12).values
+        n_dropped = int(keep.size) - int(keep.sum())
+        if n_dropped:
+            loo_source = idata.copy()
+            loo_source["log_likelihood"] = loo_source["log_likelihood"].isel(
+                {obs_dims[0]: keep}
+            )
+    return az.loo(loo_source, var_name=var_name), n_dropped
+
+
 def diagnostics(
     context: ModelFitContext,
     *,
@@ -940,15 +979,26 @@ def diagnostics(
     context.set_trace(trace)
 
     if loo_var_names is None:
-        loocv = az.loo(context.trace)
+        loocv, n_dropped = _loo_dropping_degenerate(context.trace)
+        if n_dropped:
+            console.print(
+                f"[yellow]LOO: dropped {n_dropped} degenerate "
+                f"(constant log-likelihood) observation(s).[/yellow]"
+            )
         context.set_loocv(loocv)
         heading("LOO-CV", style="bold cyan")
         console.print(loocv)
     else:
-        loocv_by_name = {
-            var_name: az.loo(context.trace, var_name=var_name)
-            for var_name, _label in loo_var_names
-        }
+        loocv_by_name = {}
+        for var_name, label in loo_var_names:
+            loocv_by_name[var_name], n_dropped = _loo_dropping_degenerate(
+                context.trace, var_name=var_name
+            )
+            if n_dropped:
+                console.print(
+                    f"[yellow]LOO ({label}): dropped {n_dropped} degenerate "
+                    f"(constant log-likelihood) observation(s).[/yellow]"
+                )
         context.set_loocv(loocv_by_name)
         for var_name, label in loo_var_names:
             heading(f"LOO-CV — {label}", style="bold cyan")

--- a/tests/test_loo_degenerate.py
+++ b/tests/test_loo_degenerate.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Unit tests for ``_loo_dropping_degenerate`` in ``models.common``.
+
+The nested joint likelihood models a paired outcome conditionally on the
+observed *understood* count, so an ``understood == 0`` row gives that outcome a
+structurally constant (``n = 0``) pointwise log-likelihood across every draw.
+``arviz_stats`` cannot run such a degenerate point through PSIS-LOO — ``az.loo``
+raises ``ValueError: All tail values are the same``. The helper drops those
+observations before calling ``az.loo``.
+
+These tests pin that the helper (a) reproduces — and then prevents — the bare
+``az.loo`` crash, (b) counts the dropped observations, (c) is a no-op when no
+observation is degenerate, and (d) leaves the caller's ``InferenceData``
+unmutated so repeated per-outcome calls stay independent. A synthetic
+``InferenceData`` reproduces the degeneracy exactly, so no fitted joint trace
+is required.
+"""
+
+import arviz as az
+import numpy as np
+import pytest
+from arviz import ELPDData
+
+from vocab_growth.models.common import _loo_dropping_degenerate
+
+_NOBS = 25
+_VAR = "y_s_obs"
+
+
+def _synthetic_idata(constant_obs, *, var_name=_VAR, nobs=_NOBS, seed=1):
+    """Build an ``InferenceData`` whose ``constant_obs`` log-lik rows are
+    exactly constant across draws (the ``n = 0`` degeneracy)."""
+    rng = np.random.default_rng(seed)
+    chains, draws = 4, 800
+    ll = rng.normal(-1.5, 0.5, size=(chains, draws, nobs))
+    for i in constant_obs:
+        ll[:, :, i] = 0.0
+    data = {
+        "posterior": {"theta": rng.normal(size=(chains, draws))},
+        "log_likelihood": {var_name: ll},
+    }
+    return az.from_dict(data, dims={var_name: ["obs"]})
+
+
+def test_bare_loo_crashes_on_constant_observation():
+    """Regression guard: without the drop, ``az.loo`` fails on ``n = 0`` rows."""
+    idata = _synthetic_idata([5, 12])
+    with pytest.raises(ValueError, match="tail values are the same"):
+        az.loo(idata, var_name=_VAR)
+
+
+def test_drops_degenerate_and_computes_loo():
+    idata = _synthetic_idata([5, 12])
+    loo, n_dropped = _loo_dropping_degenerate(idata, var_name=_VAR)
+    assert n_dropped == 2
+    assert isinstance(loo, ELPDData)
+
+
+def test_no_degenerate_observations_is_a_no_op():
+    idata = _synthetic_idata([])
+    loo, n_dropped = _loo_dropping_degenerate(idata, var_name=_VAR)
+    assert n_dropped == 0
+    assert isinstance(loo, ELPDData)
+
+
+def test_original_idata_not_mutated():
+    idata = _synthetic_idata([5, 12])
+    before = int(idata.log_likelihood.sizes["obs"])
+    _loo_dropping_degenerate(idata, var_name=_VAR)
+    after = int(idata.log_likelihood.sizes["obs"])
+    assert before == after == _NOBS
+
+
+def test_resolves_single_var_when_var_name_is_none():
+    """The ``loo_var_names is None`` engine path passes no ``var_name``; the
+    helper must resolve the sole log-likelihood array and still drop/compute."""
+    idata = _synthetic_idata([5, 12])
+    loo, n_dropped = _loo_dropping_degenerate(idata)
+    assert n_dropped == 2
+    assert isinstance(loo, ELPDData)


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Why

Kicking off the full VG01–VG16 reporting-config refit surfaced a crash that blocks every joint model. Each joint model sampled cleanly and **passed the convergence gate**, then died in the diagnostics stage computing PSIS-LOO with `ValueError: All tail values are the same` (`arviz_stats 1.2.0`, `_ps_tail`). Because the crash lands in `diagnostics` — before the posterior-predictive stage that writes `trace.nc` — a failed joint fit also loses its (sometimes multi-hour) trace.

Root cause: the nested joint likelihood models a paired outcome (spoken/signed) conditionally on the observed *understood* count as its denominator, so a row with `understood == 0` gives that outcome a structurally constant (`n = 0`) log-likelihood across every draw. PSIS-LOO requires the pointwise log-likelihood to vary across draws, and `arviz_stats 1.2.0`'s `az.loo` raises on such degenerate points. This is the first reporting-quality fit of the nested likelihood (#163/#164) — the earlier marginal spoken likelihood never produced a constant per-observation log-lik, so the crash could not occur before. It affects all nine joint/multivariate models (`vg05`, `vg07`–`vg10`, `vg13`–`vg16`); the six univariate models are unaffected.

## What

Route each per-outcome LOO through a new helper `_loo_dropping_degenerate(idata, var_name)` that drops observations whose across-draw log-likelihood variance is ≤ `1e-12` before calling `az.loo`. The degenerate points sit at ~`1e-33` (numerically-zero log-lik plus floating-point noise) while genuinely informative observations have variance ≫ `1e-6`, so the threshold cleanly separates them. The drop is deterministic (it keys off the structural `n = 0` degeneracy alone), so every joint model excludes the *same* observations and the per-outcome elpd stays comparable across models for `loo_compare`.

Also included:
- `fix(scripts)`: `run_replication.sh`'s `has_trace` used a bash-4 `${1^^}` expansion that errored as "bad substitution" on macOS bash 3.2, silently defeating skip-on-resume (the `find` already uses case-insensitive `-ipath`, so the uppercase was redundant).
- `docs(notes)`: the live run-record note for the rep/rep-lite refit, documenting the incident, the fix, and the run environment.

## Testing

- End-to-end `dev` fit of `vg05`: drops exactly the 14 `understood == 0` rows from the spoken LOO, computes LOO for both outcomes, completes the full pipeline (exit 0); confirmed again at `rep` (680 s, gate PASS).
- `ruff check src/ scripts/` clean; `tests/test_diagnostics_gate.py` passes.
- The subsequent `rep` refit run reached `vg05`, `vg07`, `vg08` (all PASS with the fix) before being paused to move to a VM.

## Follow-up

- A dedicated regression test for `_loo_dropping_degenerate` (deferred — needs a joint-trace fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)