### PR TITLE
docs: paused full-refit run findings + rep-hightune helper (#147, #163)

### DIFF
--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -67,6 +67,7 @@ orcid
 overfitting
 parameterisation
 preliz
+PyMC
 pyplot
 pytest
 rankdir

--- a/docs/runbooks/full-refit.md
+++ b/docs/runbooks/full-refit.md
@@ -75,7 +75,19 @@ memory-heavy. So:
 - **TD models** (`vg03 vg04 vg13 vg11 vg12`): **strictly one at a time** — the
   full-data TD fits can OOM if stacked.
 
-### Config choice for the full-data TD models (`rep-lite` is validated for these)
+### Config choice for the full-data TD models
+
+> [!WARNING]
+> **Superseded for the hierarchical TD models (2026-07-17, post-#164).** #164 added
+> child (subject) random effects to `vg11`/`vg12`/`vg13` (the #163 P1 fix; their output
+> dirs are now `…-td-re`), making them hierarchical. They now carry the same
+> trend/GP/study-intercept ridge the DS models have, and **`rep-lite` no longer
+> converges them**: `vg11` failed at `rep-lite` with max R-hat 1.023 / min ESS 164 on the
+> trend/GP/study-RE block (not the per-child effects). **Fit `vg11`/`vg12`/`vg13` at
+> `rep-hightune`** (tune 12000 / draws 8000 / 6 chains; `target_accept 0.99` for `vg13`,
+> which also has divergences) — e.g. via `scripts/refit_hightune.py`. The `rep-lite`
+> guidance below was validated only on the _pre-#164, non-hierarchical_ TD models and is
+> retained for history. (See `notes/202607170935-full-refit-vm-run-147-163.md`.)
 
 The full-data TD fits dominate wall time (`vg11`: 16,235 obs, ~9 h at `rep`; `vg12`:
 ~6,000 obs). At those sample sizes the posterior is **likelihood-dominated** and ESS
@@ -137,6 +149,14 @@ redundancy the VG10 GP anchor addresses for the `q`-GP, here on the understood G
 Remedy: refit with heavier tuning (**tune 12000 / draws 8000 / target_accept 0.97**,
 6 chains), which cleared all four in the 2026-07-12 run (e.g. vg16 1.024 → 1.009).
 Back up the non-converged output first; the refit becomes the model of record.
+
+> [!NOTE]
+> **Update (2026-07-17, post-#164/#161):** this DS understood-GP ridge did **not** recur —
+> all ten DS models passed R-hat/ESS at plain `rep` (max R-hat 1.0066), so no DS
+> `rep-hightune` refits were needed. **Re-assess the DS family empirically** rather than
+> assuming hightune. The ridge now surfaces instead on the **hierarchical TD models**
+> (`vg11`/`vg12`/`vg13`) — see the TD config warning above. (`vg13` additionally needs
+> `target_accept 0.99` for divergences, as in July.)
 
 ## 3. Render + comparisons
 

--- a/notes/202607170935-full-refit-vm-run-147-163.md
+++ b/notes/202607170935-full-refit-vm-run-147-163.md
@@ -1,0 +1,138 @@
+# Full refit (rep + rep-lite) of VG01–VG16 on a 16-core VM, resolving #147 and #163 — run record
+
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+
+> [!IMPORTANT]
+> **Run intentionally PAUSED 2026-07-17 ~18:40 UTC** (user decision — further code changes are inbound, so it is sensible to restart the full run later on the updated code). This note is the record of what was completed and, most importantly, the **convergence/methodology findings** that should shape the restart. **12 of 15 models** finished with valid reporting-quality traces; the 3 hierarchical TD models (vg11/vg12/vg13) were mid-refit when stopped. No reports were rendered and nothing was uploaded. The #147/#163 sensitivity, parameter-recovery, comparison, render, and upload stages were **not** reached — see "Run paused" below.
+
+## Purpose
+
+Full reporting-quality refit of every registered model (VG01–VG16) on the current 810-item reference scale, following `docs/runbooks/full-refit.md`, on the post-#164/#165 code (nested outcome likelihood, TD child effects, signing-source harmonisation, Edgin revision, degenerate-LOO fix). Then: render every report, upload to the public research blob storage and record the index URLs, and drive issues **#147** (Target-8 young-age anchor prior-sensitivity) and **#163** (statistical-model validity review) to resolution.
+
+This supersedes the interrupted 2026-07-16 Mac run (`202607161902-full-refit-rep-replite-run.md`), whose only blocker — the joint-model PSIS-LOO crash on `understood == 0` rows — is now fixed and committed as **#165** (`f08f7ed`). This run is a clean start on a larger machine.
+
+## Environment and method
+
+- **Machine:** Azure VM `dse-vm-res-frank-buckley-07170854` — 16 cores, 125 GB RAM, 410 GB free on `/scratch`. Far more RAM than the Mac's 48 GB, so the full-data TD fits carry **no OOM risk** here; the binding constraint is the 16-core CPU.
+- **Env:** conda `dse-vocab-growth`, Python 3.14, `dse-research-utils 0.7.0` (≥ v0.6.0 → convergence gate reports **unrounded** R-hat/ESS natively; no gate-rounding false-pass risk). `dse-check-env` clean. pymc 6.1.0, nutpie 0.16.11, arviz 1.2.0.
+- **Code:** `main` @ `f08f7ed`, clean tree. Prerequisite fixes all committed: #161 (R-hat gate, read-only DuckDB concurrency, 810 validation, runbook), #164 (statistical-review implementation), #165 (drop degenerate n=0 obs from joint-model PSIS-LOO).
+- **De-risk:** a full `dev` smoke fit of `vg05` (the exact path that crashed on the Mac) completed clean end-to-end in 4m28s (sampled → diagnostics/LOO → posterior predictive → wrote trace), confirming the #165 fix on this VM. Output was thrown away (separate dir).
+- **Data:** re-prepared at run start — 1,026 raw rows → 1,221 analysis rows; merged DuckDB + `vocab_data_merged.csv` current.
+- **Output root:** repo-local `output/` (gitignored; 410 GB free is ample). Report figure cache stays in the checkout at `docs/report/figures/`.
+- **Configs:** `rep` = 6 chains / 6000 tune / 6000 draws / `target_accept` 0.95. `rep-lite` = 4 chains / 4000 tune / 4000 draws / `target_accept` 0.95.
+- **Execution:** `output/fitrun/fit_driver.sh` — a 2-wide, thread-pinned DS pool (2 × 6 chains = 12 of 16 cores; `OMP/OPENBLAS/MKL/NUMBA_NUM_THREADS=1`) then strictly sequential TD (rep) then sequential full-data TD (rep-lite). Resumable (a model whose `trace.nc` exists is skipped). Per-model logs in `output/fitrun/logs/`, status in `output/fitrun/status.tsv`.
+
+## Model split
+
+| Config     | Models                                                               | n   |
+| ---------- | -------------------------------------------------------------------- | --- |
+| `rep`      | vg01 vg02 vg03 vg04 vg05 vg07 vg08 vg09 vg10 vg13 vg14 vg15 vg16     | 13  |
+| `rep-lite` | vg11 vg12 (full-data TD, per the runbook's validated recommendation) | 2   |
+
+## Plan for #147 and #163 (scope confirmed by user 2026-07-17)
+
+- **#147 (Target-8 anchors):** fit baselines (vg10/vg11/vg12) + Target-8 variants at `test` tier in an **isolated output dir** (`/scratch/vg-sens-output`) so the rep models of record are never clobbered; `compare_sensitivity.py`; document the robustness matrix in `docs/models/PRIORS.md`.
+- **#163 robustness (chosen: Target-8 + P0/P1 variants):** additionally run the checks tied to #163's P0/P1 findings — signing source (vg15 `sign-include-uk01`/`sign-include-uk06`/`sign-study-only`), us01 ceiling (vg10/vg15 `us01-ceiling-excluded`), TD child-dependence (vg11/vg12 `single-admin`), dispersion (vg10 `kappa-broadfloor`), child-effect sanity (vg10 `no-subject`) — at `test` tier in the same isolated dir.
+- **#163 calibration:** quantitative posterior-predictive calibration is **auto-produced** by every fit this run (`write_trace_calibration` → `posterior_predictive_calibration` table).
+- **#163 SBC (chosen: basic parameter-recovery):** build a minimal simulate-from-posterior → refit → recover check for the headline models (vg10/vg12/vg15).
+- **Not doing unilaterally:** marking the methodology "publication-ready" — that human decision is left to the team; this run supplies the evidence.
+
+## Blob upload target
+
+- Account `dseresearch`, container `public` (blob-level public read). `DSERESEARCH_BLOB_CONTAINER_URL=https://dseresearch.blob.core.windows.net/public`.
+- Report URLs will be `https://dseresearch.blob.core.windows.net/public/vocabulary-growth/<model_id>-<config_name>/index.html`.
+
+## Progress log
+
+- **2026-07-17 ~09:25 UTC** — prerequisites verified; data re-prepared; vg05 dev smoke clean.
+- **2026-07-17 ~09:33 UTC** — full refit driver launched (PID 8618). DS pool started with vg01, vg02.
+- **2026-07-17 ~11:36–11:42 UTC** — all 10 DS models complete (vg01,02,05,07,08,09,10,14,15,16). Driver moved to the TD `rep` tail (vg03 → vg04 → vg13), then `rep-lite` (vg11, vg12).
+- **2026-07-17 ~11:48 UTC** — **session disconnect** (not in tmux); the `nohup`'d driver **survived** and kept fitting — only the harness-side progress monitor was lost. Re-established monitoring; no re-fit needed. Now in a tmux session so a further disconnect is safe.
+- **2026-07-17 ~13:42 UTC** — vg03 PASS (rep, 2h0m). **2026-07-17 ~14:15 UTC** — vg04 PASS (rep, 33m). Both full-data TD baselines pristine (0 div).
+- **2026-07-17 ~15:32 UTC** — **vg13 FAILED the R-hat/ESS gate at rep** (49 divergences, 8 params R-hat > 1.01 [max 1.014], 4 params ESS < 400 [min 341], at ta 0.95) — the same non-convergence that needed hightune in July. Driver moved to the rep-lite phase (vg11, then vg12).
+- **2026-07-17 ~15:36 UTC** — launched the **vg13 rep-hightune refit** (ta 0.99, tune 12000, draws 8000, 6 chains) via `output/fitrun/refit_hightune.py` (monkey-patches the sampling factory; no source edits), **concurrently** with vg11 rep-lite (6 + 4 cores). Failed rep fit backed up to `output/preconv-backup/VG13-rep-fail/`.
+- **2026-07-17 ~17:59 UTC** — **vg11 FAILED the gate at rep-lite** (0 div, but max R-hat 1.023 / min ESS 164 across ~11 trend/GP/study-RE params). Driver moved to vg12 (rep-lite). See "rep-lite is inadequate for the hierarchical TD models" below.
+- **2026-07-17 ~18:06 UTC** — launched **vg11 rep-hightune** (tune 12000, draws 8000, 6 chains, ta 0.95 — 0 divergences, so the ridge, not divergence, is the issue) via `refit_launch.sh`, concurrently with the vg13 hightune (12 cores). Prior (failed) diagnostics backed up to `output/preconv-backup/`. vg12 rep-lite left running to see whether the smaller TD model clears rep-lite on its own.
+- **2026-07-17 ~18:40 UTC** — **run PAUSED by user decision** (inbound code changes make a later restart on the updated code the sensible course). Stopped the vg11 + vg13 `rep-hightune` refits and the vg12 `rep-lite` fit (all mid-sampling) and the monitors. 12/15 models retain valid traces; vg11/vg12/vg13 left incomplete for the restart. Findings documented; PR [#167](https://github.com/dseinternational/vocabulary-growth/pull/167) raised.
+
+## rep-lite is inadequate for the hierarchical TD models (config revision)
+
+**#164 added child (subject) random effects to vg11/vg12/vg13** — the #163 P1 fix for "TD models ignore repeated measurements". The output dirs gained the `-re` suffix (`VG11-age-spoken-td-re`, etc.) and the sampled parameters now include `delta_subject_raw`/`tau_subject`.
+
+The July recommendation to fit the large TD models at `rep-lite` was validated on the **old, non-hierarchical** vg11 (then likelihood-dominated with ESS ≈ 9,850). That no longer holds: the now-hierarchical models have the same **trend/GP/study-intercept ridge** the DS models have, and at `rep-lite` (4 chains × 4000 draws) vg11 under-converges (min ESS 164, R-hat 1.023). The failing parameters are the global trend/anchor/GP terms and the ~7 **study** intercepts — **not** the 12k per-child effects — so heavier sampling resolves it.
+
+**Decision:** escalate the hierarchical TD models from `rep-lite` to **`rep-hightune`** (tune 12000 / draws 8000 / 6 chains) — the same remedy the DS models needed in July. This reverses the "rep-lite for large TD" plan for vg11/vg12/vg13 specifically, because the model structure changed under #164. (vg12 is being observed at rep-lite first in case the smaller model clears the gate; if it fails it gets the same hightune treatment.)
+
+## Gate semantics (important for honest reporting)
+
+The pipeline **hard-stops only on R-hat/ESS failures** (`enforce_convergence_gate`, `common.py:1313`). Divergences and BFMI are **recorded** and set the summary's `passed` flag, but do **not** stop fitting/rendering — so a model with a few divergences is written as a model of record with a caveat (as VG11 was in the July-12 run). "PASS" below therefore means the R-hat/ESS/BFMI thresholds are met; divergence counts are reported separately and honestly.
+
+## Convergence (models of record — true, unrounded diagnostics)
+
+Thresholds: max R-hat ≤ 1.01, min ESS ≥ 400, BFMI ≥ 0.3 (hard-gated); 0 divergences (target, not hard-gated). All min BFMI ≥ 0.499.
+
+**DS models (all `rep`) — complete:**
+
+| Model | population / outcome | max R-hat | min ESS | div | verdict                              | config |
+| ----- | -------------------- | --------- | ------- | --- | ------------------------------------ | ------ |
+| vg01  | DS spoken            | 1.00126   | 5476    | 3   | R-hat/ESS PASS; ⚠ 3 div (refit)      | rep    |
+| vg02  | DS understood        | 1.00072   | 7833    | 1   | R-hat/ESS PASS; ⚠ 1 div (refit)      | rep    |
+| vg05  | DS joint             | 1.00053   | 8652    | 0   | PASS                                 | rep    |
+| vg07  | DS joint + study RE  | 1.00051   | 10383   | 0   | PASS                                 | rep    |
+| vg08  | DS joint + subj RE   | 1.00355   | 1511    | 0   | PASS                                 | rep    |
+| vg09  | DS joint + q RE      | 1.00663   | 1582    | 0   | PASS (was FALSE-PASS→hightune 07-12) | rep    |
+| vg10  | DS anchored joint    | 1.00271   | 2160    | 0   | PASS (was FAIL→hightune 07-12)       | rep    |
+| vg14  | DS + signing         | 1.00087   | 7508    | 0   | PASS                                 | rep    |
+| vg15  | DS sign–speech       | 1.00428   | 2050    | 0   | PASS (was hightune 07-12)            | rep    |
+| vg16  | DS cross-lag         | 1.00487   | 1552    | 0   | PASS (was FALSE-PASS→hightune 07-12) | rep    |
+
+**TD models:**
+
+| Model | population / outcome | max R-hat | min ESS | div | verdict                                                            | config   |
+| ----- | -------------------- | --------- | ------- | --- | ------------------------------------------------------------------ | -------- |
+| vg03  | TD spoken            | 1.00044   | 8647    | 0   | PASS                                                               | rep      |
+| vg04  | TD understood        | 1.00069   | 10416   | 0   | PASS                                                               | rep      |
+| vg11  | TD spoken (full)     | 1.02290   | 164     | 0   | FAIL at rep-lite → needs rep-hightune (refit interrupted at pause) | rep-lite |
+| vg12  | TD understood (full) | —         | —       | —   | rep-lite fit interrupted at pause (incomplete)                     | rep-lite |
+| vg13  | TD joint (young)     | 1.01399   | 341     | 49  | FAIL at rep → needs rep-hightune (refit interrupted at pause)      | rep      |
+
+**Net: 12/15 models complete with valid traces** (all DS models + vg03 + vg04). **vg11, vg12, vg13** (the hierarchical TD models) are **incomplete** — their `rep-hightune`/`rep-lite` fits were running when the run was paused, so their output dirs hold partial/interrupted output (no valid `trace.nc`). They must be refitted at `rep-hightune` on the restart. vg11's failed-`rep-lite` diagnostics are preserved under `output/preconv-backup/`.
+
+### Key convergence finding vs the 2026-07-12 run
+
+The **understood-GP R-hat ridge is gone**: vg09/vg10/vg15/vg16 — which all failed the R-hat gate at `rep` in July and needed `rep-hightune` (tune 12000/draws 8000/ta 0.97) — **all pass at plain `rep`** now (max R-hat 1.0066). This is attributable to the post-#164/#161 model changes (nested likelihood + anchoring). So the heavy DS hightune campaign of July is **not** repeated. Outstanding convergence items this run are narrower:
+
+1. **vg13** — genuinely non-convergent at `rep` (49 div, R-hat 1.014, ESS 341), as in July; a `rep-hightune` refit at ta 0.99 (which gave 0 div / R-hat 1.002 / ESS 2308 in July) is running.
+2. **vg01 (3 div), vg02 (1 div)** — R-hat/ESS pristine; a cheap `target_accept=0.99` refit is planned to clear the divergences (accept-with-caveat if they persist, as vg11 was in July).
+
+## Run paused — findings, status, and restart plan
+
+The run was stopped deliberately before completion. Nothing downstream of fitting was done, so there are **no rendered reports, no uploads, and no #147/#163 sensitivity, calibration-review, or parameter-recovery outputs yet**. What this run establishes is a set of **convergence/methodology findings** that should shape the restart.
+
+### Findings (durable — carry these into the restart)
+
+1. **The DS understood-GP R-hat ridge is resolved at plain `rep`.** All ten DS models pass R-hat/ESS/BFMI at `rep` (max R-hat 1.0066). In the 2026-07-12 run, vg09/vg10/vg15/vg16 all failed at `rep` and needed `rep-hightune`. The post-#161/#164 model changes (anchoring + nested likelihood) removed that ridge. **The DS hightune campaign should not be assumed necessary next time** — re-check empirically, but expect plain `rep` to suffice for the DS family.
+2. **`rep-lite` is no longer valid for the large TD models.** #164 added child random effects to vg11/vg12/vg13 (dirs now `…-td-re`), making them hierarchical. July's `rep-lite`≈`rep` validation was on the _old_ non-hierarchical vg11 and no longer holds: vg11 fails `rep-lite` (R-hat 1.023, ESS 164) on the trend/GP/study-intercept ridge (not the per-child effects). **Restart these three at `rep-hightune`, not `rep-lite`.**
+3. **vg13 needs `rep-hightune` at `ta=0.99`** (49 divergences + ridge at plain `rep`, as in July).
+4. **The #165 nested-likelihood LOO fix holds at `rep`** — every joint/signing model (vg05/07/08/09/10/14/15/16) sampled, cleared the degenerate-`n=0` LOO path, and passed the gate. No recurrence of the July Mac crash.
+5. **vg01 (3 div) / vg02 (1 div)** — trivial divergence counts on the two simplest baselines; R-hat/ESS pristine. A `ta=0.99` refit should clear them; otherwise accept-with-caveat.
+6. **Provenance and calibration are captured automatically** — each fit writes `fit_manifest.json` (git commit, data hash `sha256:2bfb…`, per-source row counts, sampling config) and a `posterior_predictive_calibration` table. These address two of #163's acceptance items directly (record provenance; quantitative posterior-predictive calibration).
+
+### Restart checklist (on the updated code)
+
+- [ ] Re-prepare data; re-verify the environment and gate (`dse-research-utils ≥ 0.6.0`).
+- [ ] Fit the **DS family + vg03/vg04 at `rep`** (expected clean, per finding 1). Consider a `ta=0.99` variant for vg01/vg02 to clear the minor divergences.
+- [ ] Fit **vg11/vg12/vg13 at `rep-hightune`** (tune 12000 / draws 8000 / 6 chains; **ta 0.99 for vg13**, ta 0.95 acceptable for vg11/vg12 since they had 0 divergences) — use `scripts/refit_hightune.py` (added in this PR) or update the sampling-config tiers directly. **Do not use `rep-lite` for these.**
+- [ ] Then resume the deferred pipeline: **#147 Target-8 + #163 P0/P1 sensitivity study** (test tier, isolated `--output-dir`), **parameter-recovery/SBC** for vg10/vg12/vg15, comparisons, sync figures, render all reports + `docs/report` + `docs/comparison`, upload to `dseresearch/public`, capture index URLs.
+- [ ] Prepare the dated **plain-language results note** (undergraduate-accessible; DS–TD contrast needs the converged vg11/vg12) once results are final.
+
+### Runbook correction
+
+`docs/runbooks/full-refit.md` has been updated in this PR to (a) drop the now-incorrect "fit the large TD models at `rep-lite`" recommendation and replace it with the `rep-hightune` requirement for the hierarchical TD models, and (b) note that the DS understood-GP ridge is resolved at `rep` (so hightune is re-assessed empirically, not assumed).
+
+## Reproduction / artefacts
+
+- Fit driver + wrappers: `output/fitrun/fit_driver.sh`, `fit_one.sh`, `refit_launch.sh`, `refit_vg13.sh`, `refit_hightune.py` (the last promoted to `scripts/refit_hightune.py` in this PR). `output/` is gitignored and ephemeral on this VM.
+- Logs: `output/fitrun/logs/<model>.log`; status `output/fitrun/status.tsv` and `output/fitrun/refit-status.tsv`.
+- Completed traces / figures / summaries (12 models): `output/models/<MODEL>/` (on the VM; not committed). Failed-fit diagnostics: `output/preconv-backup/`.

--- a/scripts/refit_hightune.py
+++ b/scripts/refit_hightune.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Refit a model at reporting quality with overridden sampling parameters,
+without editing source. Monkey-patches the shared sampling-config factory so the
+'rep' tier returns the requested tune/draws/target_accept/chains; the fit is
+still treated as reporting-quality (convergence gate enforced). The refit
+overwrites the canonical model output dir (back it up first if you need it).
+
+Usage:
+    python scripts/refit_hightune.py <model_key> \
+        --tune 12000 --draws 8000 --target-accept 0.99 [--chains 6]
+"""
+import argparse
+import importlib
+from multiprocessing import freeze_support
+
+import dse_research_utils.environment.setup as setup
+import dse_research_utils.statistics.models.sampling as S
+from dse_research_utils.statistics.models.sampling import SamplingConfiguration
+
+from vocab_growth import environment as env
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("model")
+    p.add_argument("--tune", type=int, required=True)
+    p.add_argument("--draws", type=int, required=True)
+    p.add_argument("--target-accept", type=float, required=True)
+    p.add_argument("--chains", type=int, default=6)
+    p.add_argument("--output-dir", default=None)
+    freeze_support()
+    a = p.parse_args()
+
+    _orig = S.get_sampling_configuration
+
+    def _patched(config: str = "dev", random_seed: int = 47):
+        if config in ("rep", "reporting", "report"):
+            return SamplingConfiguration(
+                draws=a.draws,
+                tune=a.tune,
+                chains=a.chains,
+                cores=a.chains,
+                target_accept=a.target_accept,
+                random_seed=random_seed,
+            )
+        return _orig(config, random_seed)
+
+    S.get_sampling_configuration = _patched
+
+    env.set_output_root(a.output_dir)
+    setup.init_script()
+    print(
+        f"[refit_hightune] {a.model}: rep-tier overridden -> tune={a.tune} "
+        f"draws={a.draws} target_accept={a.target_accept} chains={a.chains}"
+    )
+    m = importlib.import_module(f"vocab_growth.models.model_{a.model}")
+    m.fit("rep")


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

Records the **intentionally-paused** full reporting-quality refit of VG01–VG16 begun 2026-07-17 on the post-#164/#165 code, and captures the convergence/methodology findings that should shape the restart. The run was paused before completion because further code changes are inbound, so a clean restart on the updated code is the sensible course. **Documentation + one small helper — no model or pipeline behaviour changes.**

## What's here

- `notes/202607170935-full-refit-vm-run-147-163.md` — full run record: environment, config, per-model convergence (12/15 models completed with valid traces), incidents, the `rep-lite`→`rep-hightune` config revision, and a restart checklist.
- `docs/runbooks/full-refit.md` — two corrections (see Findings 1–2).
- `scripts/refit_hightune.py` — reusable, no-source-edit helper to refit a model at reporting quality with overridden tune/draws/target_accept/chains (monkey-patches the sampling-config factory; the convergence gate is still enforced). Supports the hightune refits the restart needs.
- `config/spellcheck/allow-en.txt` — add `PyMC`.

## Key findings

1. **The DS understood-GP R-hat ridge is resolved at plain `rep`.** All ten DS models pass R-hat/ESS/BFMI at `rep` (max R-hat 1.0066). In the 2026-07-12 run, vg09/vg10/vg15/vg16 failed at `rep` and needed `rep-hightune`; the post-#161/#164 changes (anchoring + nested likelihood) removed that ridge, so no DS hightune campaign was needed this time.
2. **`rep-lite` is no longer valid for the large TD models.** #164 added child random effects to vg11/vg12/vg13 (the #163 P1 fix; dirs now `…-td-re`), making them hierarchical. July's `rep-lite`≈`rep` validation was on the old non-hierarchical models and no longer holds — vg11 fails `rep-lite` (R-hat 1.023, min ESS 164 on the trend/GP/study-intercept ridge, not the per-child effects). They must be refit at `rep-hightune`; the runbook is corrected accordingly.
3. **vg13 needs `rep-hightune` at `target_accept=0.99`** (49 divergences + the same ridge at plain `rep`, as in July).
4. **The #165 nested-likelihood LOO fix holds at `rep`** — every joint/signing model (vg05/07/08/09/10/14/15/16) sampled, cleared the degenerate-`n=0` LOO path, and passed the gate. No recurrence of the July Mac crash.
5. vg01 (3 divergences) / vg02 (1 divergence) — trivial counts on the two simplest baselines; R-hat/ESS pristine. A `target_accept=0.99` refit should clear them.

## Status of #147 / #163

**Neither issue is resolved by this PR.** The refit that #163 was waiting on is 12/15 complete; the #147 Target-8 study, #163 P0/P1 robustness variants, parameter-recovery/SBC, comparisons, rendering, and upload were **not** reached (run paused). Provenance recording (`fit_manifest.json`) and quantitative posterior-predictive calibration (`posterior_predictive_calibration`) are produced automatically per fit, which addresses two of #163's acceptance items. The restart checklist in the note carries the remaining plan forward. Relates to #147, #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
