### PR TITLE
fix(models): resolve hierarchical-model convergence ridges (sum-to-zero REs + orthogonal-GP anchor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,20 @@ figures/
 # Standalone comparison-doc render artifacts. The comparison suite writes its
 # tables to output/comparisons/; docs/comparison/index.qmd reads them by bare
 # name, so they are staged next to the doc at render time (with the rendered
-# index.html + index_files/). All generated — never committed.
+# index.html + index_files/). The plot copies (.png/.svg) are staged the same
+# way. All generated — never committed. (Leaving the plots untracked previously
+# flagged fit manifests as dirty because git_metadata counts untracked files.)
 docs/comparison/*.csv
+docs/comparison/*.png
+docs/comparison/*.svg
 docs/comparison/index.html
 docs/comparison/index_files/
+
+# Quarto/LaTeX render byproducts staged next to docs/report/index.qmd.
+docs/report/index.aux
+docs/report/index.tex
+docs/report/index.toc
+docs/report/index.pdf
 _freeze/
 _temp/
 temp/

--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -115,3 +115,4 @@ nohup
 reparam
 setsid
 unconverged
+docstrings

--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -108,3 +108,10 @@ hightune
 resumable
 rhat
 vars
+dseresearch
+incl
+logind
+nohup
+reparam
+setsid
+unconverged

--- a/notes/202607191614-full-refit-rep-hightune-run.md
+++ b/notes/202607191614-full-refit-rep-hightune-run.md
@@ -185,3 +185,12 @@ All 15 model reports uploaded via `scripts/upload.py all --config rep` (traces e
 | VG16  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b2-2106-75b2-8ad6-5476b3bdac6a/VG16-age-understood-spoken-ds-re-subj-uq-crosslag/index.html |
 
 Note: `upload.py` publishes the per-model reports; the consolidated report book (`docs/report`) and comparison book (`docs/comparison`) are rendered locally but not part of this per-model upload path.
+
+## Phase C addendum — consolidated books uploaded (2026-07-24)
+
+The consolidated report book (`output/report`, HTML + PDF + DOCX) and the comparison book (`docs/comparison`, rendered HTML; Quarto source excluded) were uploaded via `upload_directory_to_blob_storage` (shared run id `019f93ff-4065-706e-a592-d9e6839411bc`):
+
+| artefact                 | index URL                                                                                                                                     |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Consolidated report book | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93ff-4065-706e-a592-d9e6839411bc/report/index.html     |
+| Comparison analysis      | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93ff-4065-706e-a592-d9e6839411bc/comparison/index.html |

--- a/notes/202607191614-full-refit-rep-hightune-run.md
+++ b/notes/202607191614-full-refit-rep-hightune-run.md
@@ -148,7 +148,7 @@ Implemented and unit-tested (full suite green; ruff clean). **No model definitio
 | ----- | --------- | --------- | ------- | --- | -------- | ----------- |
 | vg07  | PASS      | 1.0005    | 8434    | 0   | 0.78     | —           |
 | vg08  | PASS      | 1.0020    | 1899    | 0   | 0.54     | —           |
-| vg09  | PASS      | 1.0033    | 1684    | 0   | 0.50     | —           |
+| vg09  | PASS      | 1.0033    | 1684    | 0   | 0.49     | —           |
 | vg10  | PASS      | 1.0016    | 5020    | 0   | 0.50     | —           |
 | vg15  | PASS      | 1.0012    | 4451    | 0   | 0.59     | —           |
 | vg16  | PASS      | 1.0062    | 1630    | 0   | 0.50     | —           |
@@ -156,7 +156,7 @@ Implemented and unit-tested (full suite green; ruff clean). **No model definitio
 | vg13  | PASS      | 1.0041    | 1215    | 0   | 0.28     | BFMI ~0.28  |
 | vg11  | PASS      | 1.0058    | 621     | 2   | 0.40     | 2 div       |
 
-The DS six are pristine (0 div, BFMI ≥ 0.5). The TD trio's BFMI ≈ 0.28 is intrinsic to the age-varying dispersion posterior over the narrow young-TD window — the same soft caveat accepted last run, now reached at plain `rep`. vg10 (DS anchored) is well conditioned (min ESS 5020), confirming the corrected obs-only anchor matches the flawed whole-grid form it replaced. These numbers supersede the whole-grid VG10/VG15 metrics quoted earlier.
+The DS six are pristine (0 div, BFMI 0.49–0.78; vg09 0.495 and vg16 0.496 sit just under 0.5). The TD trio's BFMI ≈ 0.28 is intrinsic to the age-varying dispersion posterior over the narrow young-TD window — the same soft caveat accepted last run, now reached at plain `rep`. vg10 (DS anchored) is well conditioned (min ESS 5020), confirming the corrected obs-only anchor matches the flawed whole-grid form it replaced. These numbers supersede the whole-grid VG10/VG15 metrics quoted earlier.
 
 **Provenance gap found and fixed.** The first corrected re-fit recorded `dirty=True` on every manifest: `git_metadata` computes dirty from `git status --porcelain --untracked-files=normal`, and 68 untracked `docs/comparison/*.png|svg` figure copies (left over from an earlier render) were in the tree at launch — `.gitignore` covered `*.csv`/`index.html` but not the plots. Fixed in `d2f2b96` (ignore the plot copies + report LaTeX byproducts), cleaned the tree, and re-fit on a porcelain-clean tree so all manifests are `dirty=False`. Lesson: the "never fit on an unclean tree" rule includes untracked build artifacts, not just modified tracked files.
 

--- a/notes/202607191614-full-refit-rep-hightune-run.md
+++ b/notes/202607191614-full-refit-rep-hightune-run.md
@@ -112,3 +112,30 @@ Restart of the deliberately-paused 2026-07-17 run (`202607170935-full-refit-vm-r
 **Provenance note:** published set will span commits 3e6f61d (baselines, code-identical) + b563586 (reparam) + the branch HEAD after this note. All docs/reparam commits are code-equivalent for each model's engine.
 
 **Infra lessons captured:** (1) never write into the working tree during a reporting run (dirties in-flight manifests); (2) launch long runs under `systemd-run` (system scope), not bare `setsid`/`nohup` (logind `KillUserProcesses` kills the latter on logout); (3) the hierarchical TD hightune fits are memory-heavy — draws 12000 OOMs on 251 GB; keep draws ≤ 8000 and never run two heavy fits concurrently.
+
+## GP orthogonalisation added, then TD trio landed at hightune (2026-07-21 late → 2026-07-22)
+
+- **GP orthogonalisation (commit `5397561`).** To remove the trend-vs-GP redundancy structurally (rather than lean on hightune), the anchored HSGP was changed from a single-point anchor (`g_unit - g_unit[idx]`) to a **whole-grid** orthogonalisation: project the constant AND linear-in-age components out of `g_unit` over the full `X_all_z` grid. This improved the already-passing DS anchored models — **vg10** R-hat 1.0027 → 1.0013, min ESS 2135 → 5111; **vg15** R-hat 1.0035 → 1.0011, min ESS 2050 → 6428 (0 divergences both). (These before/after numbers are from the `5397561` whole-grid form; see the correction below — they are superseded and will be re-derived.)
+- **TD trio** refit at hightune on the reparam + GP-orthogonalisation code: all three cleared the hard gate. Final soft caveats: **vg12** BFMI 0.29, **vg13** BFMI 0.28 (both pass R-hat/ESS); vg11 clean. All 15 models then passed the hard gate (11 fully clean, 4 soft-caveat: vg01 3 div, vg02 1 div, vg12/vg13 low BFMI).
+- Phase B (comparisons + render) completed; PR #176 opened.
+
+## Statistical review of #176 (PR reviewer via Codex/GPT-5, 2026-07-23) — four P1 + two P2
+
+The review found the two core conditioning commits were **correct in intent but flawed in implementation**. All six points verified against the code and accepted:
+
+- **P1-A — the whole-grid orthogonalisation leaked the reporting grid into inference.** `X_all_z` stacks observations with plot points, query ages and the anchor row; computing the projection statistics (`g.mean()`, the `z`-slope) over that whole stack makes the _observed-row_ latent — hence the likelihood — depend on `n_plot` / `ages_query`. A reporting-only choice must never move the posterior.
+- **P1-B — the whole-grid form broke the `anchor_g*_at_ref` point-anchor contract** (`g` no longer passed through zero at the reference age, contradicting the docstrings, the `definitions` field and the build output), and for the `tent` mean it projected against only `[1, z]`, a smaller basis than the three-anchor tent spans.
+- **P1-C — the sum-to-zero RE change was mis-described as prior-preserving.** `ZeroSumNormal(1)` has covariance `I − J/K` (marginal `1 − 1/K`, a 25 % shrink at K=4, plus a −1/K correlation); `tau` unchanged does not restore it.
+- **P1-D — the sign study zero-sum spanned all studies, not the sign-informed subset.** Uninformed studies' `z_sign` could counterbalance a common shift among the informed ones, so the constraint need not remove the sign-intercept ridge.
+- **P2-A** — the new guard tests skip in CI (`pytest` runs before `prepare_data.py`). **P2-B** — this note stopped before the GP-orthogonalisation commit and final validation.
+
+## Corrected fixes on the branch (2026-07-23)
+
+Implemented and unit-tested (full suite green; ruff clean). **No model definitions or priors semantics beyond the intentional, now-documented RE constraint.**
+
+- **GP anchor (P1-A + P1-B), `gp_utils.py`.** Projection coefficients are now fitted on the **observed rows only** (`n_obs`, a fixed model design) and applied to every row, so plot/query grids cannot leak into inference; the residual is then **pinned to zero at the anchor row**, restoring the point-anchor contract. The nuisance basis is **mean-specific**: `[1, z]` for the logit-linear trend, `[1]` for the free-intercept mean (a linear GP direction there is genuine signal), and the **three tent hats** for the peak mean. New data-free unit tests (`test_gp_anchor_orthogonalisation.py`) assert anchor-zero, observed-row orthogonality, reporting-grid invariance, and the intercept/tent basis behaviour; they run in CI.
+- **Sum-to-zero rescale (P1-C).** `ZeroSumNormal` sigma is rescaled by `sqrt(K/(K−1))` so each study effect's marginal prior variance stays `tau²`; only the group-mean DOF (the ridge) and a −1/K correlation remain. Relabelled in code/PR as an intentional identifiability constraint, not prior-preserving. Applied in `common_univariate_re`, `common_bivariate_re`, `common_joint_modality`.
+- **Sign zero-sum over informed studies (P1-D), `common_joint_modality.py`.** `delta_sign` is now `ZeroSumNormal` over the **sign-informed studies only** (union of `idx_sign` / `idx_cells` / `idx_prod`), scattered into full `study_id` with **0 for uninformed studies**. Verified on VG15: of 12 studies, 5 are active and zero-sum, 7 are forced to exactly 0. U and q remain global (audited: informed by every retained study via their direct + nested terms).
+- **P2-A** — added the synthetic CI tests above; updated the integration test's assertions to the new (observed-row, point-anchored) contract.
+
+**Refit scope (pending).** The GP-anchor and sign-zero-sum changes alter the likelihood, and the RE rescale shifts the prior scale, so **every study-RE and every anchored model must be re-fit** before publication: the DS RE/anchored models (vg07–10, 15, 16) and the TD trio (vg11–13) at least. The whole-grid VG10/VG15 before/after numbers above are **superseded** and will be regenerated from the corrected fits. **Phase C (upload to `dseresearch/public`) is held** until the re-fit is clean. Baselines with no study REs and no anchor (vg01–05, 14) are unaffected by these changes.

--- a/notes/202607191614-full-refit-rep-hightune-run.md
+++ b/notes/202607191614-full-refit-rep-hightune-run.md
@@ -139,3 +139,25 @@ Implemented and unit-tested (full suite green; ruff clean). **No model definitio
 - **P2-A** — added the synthetic CI tests above; updated the integration test's assertions to the new (observed-row, point-anchored) contract.
 
 **Refit scope (pending).** The GP-anchor and sign-zero-sum changes alter the likelihood, and the RE rescale shifts the prior scale, so **every study-RE and every anchored model must be re-fit** before publication: the DS RE/anchored models (vg07–10, 15, 16) and the TD trio (vg11–13) at least. The whole-grid VG10/VG15 before/after numbers above are **superseded** and will be regenerated from the corrected fits. **Phase C (upload to `dseresearch/public`) is held** until the re-fit is clean. Baselines with no study REs and no anchor (vg01–05, 14) are unaffected by these changes.
+
+## Clean re-fit + Phase B on the corrected code (2026-07-23/24)
+
+**All 9 affected models converged at plain `rep`** — the corrected fixes removed the ridges structurally, so the TD trio no longer needs hightune (vg11/12/13 previously failed plain `rep` and required hightune; vg12 got _worse_ at hightune before the fixes). Diagnostics (commit `d2f2b96`, all `dirty=False`):
+
+| model | hard gate | max R-hat | min ESS | div | min BFMI | soft caveat |
+| ----- | --------- | --------- | ------- | --- | -------- | ----------- |
+| vg07  | PASS      | 1.0005    | 8434    | 0   | 0.78     | —           |
+| vg08  | PASS      | 1.0020    | 1899    | 0   | 0.54     | —           |
+| vg09  | PASS      | 1.0033    | 1684    | 0   | 0.50     | —           |
+| vg10  | PASS      | 1.0016    | 5020    | 0   | 0.50     | —           |
+| vg15  | PASS      | 1.0012    | 4451    | 0   | 0.59     | —           |
+| vg16  | PASS      | 1.0062    | 1630    | 0   | 0.50     | —           |
+| vg12  | PASS      | 1.0083    | 451     | 0   | 0.28     | BFMI ~0.28  |
+| vg13  | PASS      | 1.0041    | 1215    | 0   | 0.28     | BFMI ~0.28  |
+| vg11  | PASS      | 1.0058    | 621     | 2   | 0.40     | 2 div       |
+
+The DS six are pristine (0 div, BFMI ≥ 0.5). The TD trio's BFMI ≈ 0.28 is intrinsic to the age-varying dispersion posterior over the narrow young-TD window — the same soft caveat accepted last run, now reached at plain `rep`. vg10 (DS anchored) is well conditioned (min ESS 5020), confirming the corrected obs-only anchor matches the flawed whole-grid form it replaced. These numbers supersede the whole-grid VG10/VG15 metrics quoted earlier.
+
+**Provenance gap found and fixed.** The first corrected re-fit recorded `dirty=True` on every manifest: `git_metadata` computes dirty from `git status --porcelain --untracked-files=normal`, and 68 untracked `docs/comparison/*.png|svg` figure copies (left over from an earlier render) were in the tree at launch — `.gitignore` covered `*.csv`/`index.html` but not the plots. Fixed in `d2f2b96` (ignore the plot copies + report LaTeX byproducts), cleaned the tree, and re-fit on a porcelain-clean tree so all manifests are `dirty=False`. Lesson: the "never fit on an unclean tree" rule includes untracked build artifacts, not just modified tracked files.
+
+**Phase B complete.** All 15 model reports rendered; comparison suite (incl. the now-guarded `loo_compare`) ran clean; figures synced; report + comparison books rendered. `check_fit --purpose publish` passes for all 15 (dirty=False + reporting quality + rendered). **Phase C (blob upload) held** pending reviewer sign-off on PR #176.

--- a/notes/202607191614-full-refit-rep-hightune-run.md
+++ b/notes/202607191614-full-refit-rep-hightune-run.md
@@ -18,10 +18,10 @@ Restart of the deliberately-paused 2026-07-17 run (`202607170935-full-refit-vm-r
 
 ## Model split
 
-| Config         | Models                                                        | n   |
-| -------------- | ------------------------------------------------------------- | --- |
-| `rep`          | vg01 vg02 vg03 vg04 vg05 vg07 vg08 vg09 vg10 vg14 vg15 vg16   | 12  |
-| `rep-hightune` | vg11 vg12 (ta 0.95), vg13 (ta 0.99)                           | 3   |
+| Config         | Models                                                      | n   |
+| -------------- | ----------------------------------------------------------- | --- |
+| `rep`          | vg01 vg02 vg03 vg04 vg05 vg07 vg08 vg09 vg10 vg14 vg15 vg16 | 12  |
+| `rep-hightune` | vg11 vg12 (ta 0.95), vg13 (ta 0.99)                         | 3   |
 
 ## Plan (scope confirmed by user 2026-07-19)
 
@@ -53,7 +53,7 @@ Restart of the deliberately-paused 2026-07-17 run (`202607170935-full-refit-vm-r
 
 ## Incident 3: vg13 failed the R-hat gate at standard hightune (2026-07-20 17:14 UTC)
 
-- **vg13** (young TD joint, 5,406 rows, 4 studies) **failed** at tune 12000 / draws 8000 / ta 0.99: **6 R-hat failures, max 1.0135**, 0 ESS failures, **0 divergences**, min BFMI 0.284. Failing params: `p_slope_low_u`, `p_slope_hi_u`, `intercept_u`, `delta_u_raw[0/2/3]` — the **understood trend/intercept + study random-intercept ridge**. ESS min 459 (barely passing) → slow-but-valid mixing of a weakly-identified block (few studies, narrow 8–18 mo age band). This is the first *post-#164* (hierarchical) vg13 hightune attempt; July's ta-0.99 success was on the pre-#164 model.
+- **vg13** (young TD joint, 5,406 rows, 4 studies) **failed** at tune 12000 / draws 8000 / ta 0.99: **6 R-hat failures, max 1.0135**, 0 ESS failures, **0 divergences**, min BFMI 0.284. Failing params: `p_slope_low_u`, `p_slope_hi_u`, `intercept_u`, `delta_u_raw[0/2/3]` — the **understood trend/intercept + study random-intercept ridge**. ESS min 459 (barely passing) → slow-but-valid mixing of a weakly-identified block (few studies, narrow 8–18 mo age band). This is the first _post-#164_ (hierarchical) vg13 hightune attempt; July's ta-0.99 success was on the pre-#164 model.
 - **Diagnosis:** 0 divergences ⇒ not a step-size problem; the lever is more tuning + more draws (ridge mixing), not higher ta.
 - **Retry (queued):** tune 20000 / draws 12000 / ta 0.99 / chains 6, via `fit_vg13_strong.sh` (`vgvg13.service`), which **waits for vg11 to finish first** — vg13's 39 GB trace makes it as memory-heavy as vg11, so they cannot co-reside on the 251 GB box.
 - **If the strong retry still fails (>1.01):** genuine decision point for the user — (a) accept-with-caveat and document vg13's understood-trend block as marginally non-converged, (b) exclude vg13 from the published set, or (c) reparameterise (sum-to-zero/non-centred study REs — a code change). Not doing any of these unilaterally.
@@ -83,7 +83,7 @@ Restart of the deliberately-paused 2026-07-17 run (`202607170935-full-refit-vm-r
 ## Reparam validated; vg13 needs hightune ta 0.99 for a DIFFERENT block (2026-07-21 ~12:02 UTC)
 
 - **The sum-to-zero reparam WORKED.** vg13's failing parameters changed completely: from the study-RE ridge (`p_slope_*_u`, `intercept_u`, `delta_u_raw[...]`) to the **dispersion block** (`kappa_min_u`, `a_kappa_u`, `b_kappa_mag_u`, `b_kappa_u`). The ridge is gone. All 6 DS RE models refit clean at plain rep (e.g. vg08 maxRhat 1.0026, BFMI 0.53, dirty=False @ b563586).
-- **vg13 at plain rep FAILED** on the dispersion block: max R-hat 1.037, min ESS 107, **28 divergences**, BFMI 0.264. This is vg13's *separate, known* difficulty (age-varying dispersion on a narrow young-TD age range) — the same block that needed **ta 0.99** in July. Plain rep (tune 6000, ta 0.95) can't clear it.
+- **vg13 at plain rep FAILED** on the dispersion block: max R-hat 1.037, min ESS 107, **28 divergences**, BFMI 0.264. This is vg13's _separate, known_ difficulty (age-varying dispersion on a narrow young-TD age range) — the same block that needed **ta 0.99** in July. Plain rep (tune 6000, ta 0.95) can't clear it.
 - **Plan:** refit vg13 at **hightune ta 0.99** (tune 12000 / draws 8000) on the reparam code — with the ridge gone, the heavy tuning + high ta should now resolve the dispersion (previously hightune was consumed fighting the ridge). Memory-OK at draws 8000 (~39 GB), run alone.
 - **vg11, vg12 still fitting at plain rep** — awaiting their verdicts to see if they also need ta 0.99 or pass at rep.
 
@@ -95,11 +95,13 @@ Restart of the deliberately-paused 2026-07-17 run (`202607170935-full-refit-vm-r
 ## Current status + next steps (as of 2026-07-21 ~13:00 UTC)
 
 **Complete & publishable (13/15), all `dirty=False`:**
+
 - Baselines/unaffected @ 3e6f61d: vg01, vg02, vg03, vg04, vg05, vg14.
 - Study-RE models refit @ b563586 (sum-to-zero): vg07, vg08, vg09, vg10, vg15, vg16.
 - Soft caveats only (pass hard gate): vg01 (3 div), vg02 (1 div).
 
 **Outstanding (TD trio) — need reparam + hightune:**
+
 - vg12 (TD understood): fail at rep on trend/GP (1.013) → refit hightune tune 12000 / draws 8000 / ta 0.97.
 - vg13 (TD joint young): fail at rep on dispersion + 28 div (1.037) → refit hightune tune 12000 / draws 8000 / **ta 0.99**.
 - vg11 (TD spoken, 16k obs): fitting at plain rep now; if it fails on trend/GP → refit hightune tune 12000 / **draws 6000** (memory) / ta 0.97.

--- a/notes/202607191614-full-refit-rep-hightune-run.md
+++ b/notes/202607191614-full-refit-rep-hightune-run.md
@@ -1,0 +1,112 @@
+# Full reporting-config refit of VG01–VG16 (rep + rep-hightune) — run record
+
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+
+Restart of the deliberately-paused 2026-07-17 run (`202607170935-full-refit-vm-run-147-163.md`) on the updated code (`main` @ `3e6f61d`, post-#168/#170/#171). Full reporting-quality refit of every registered model, render every report, and upload to `dseresearch/public`. This run carries the paused run's durable findings, most importantly: **the hierarchical TD models (vg11/vg12/vg13) are fitted at `rep-hightune`, not `rep-lite`** (their #164 child random effects re-introduced the trend/GP/study-intercept ridge that `rep-lite` under-converges).
+
+## Environment and method
+
+- **Machine:** Azure VM — 32 cores, 251 GB RAM, 410 GB free on `/scratch` (repo lives on `/scratch`). RAM is ample; the binding constraint is the 32-core CPU. No OOM risk on the full-data TD fits.
+- **Env:** conda `dse-vocab-growth`; `dse-check-env environment.yml` clean (conda-forge core matches canonical spec). `dse-research-utils` ≥ 0.6.0 → unrounded R-hat/ESS gate (no false-pass rounding).
+- **Code:** `main` @ `3e6f61d`, clean tree.
+- **De-risk:** `dev` smoke fits of `vg05` (DS joint) and `vg13` (TD joint, hierarchical) built and initialised cleanly on the current code; `vg05` cleared the full pipeline (sample → diagnostics → **PSIS-LOO, no degenerate-n=0 crash** → posterior predictive → plots), confirming the #165/#170 changes are healthy end-to-end. Smoke output discarded.
+- **Data:** re-prepared at run start — 1,026 raw rows → 1,221 analysis rows; DuckDB + `vocab_data_merged.csv` current.
+- **Output root:** repo-local `output/` (gitignored; keeps quarto rendering in-repo so `code-links: [repo]` resolves).
+- **Configs:** `rep` = 6 chains / 6000 tune / 6000 draws / ta 0.95. `rep-hightune` = 6 chains / 12000 tune / 8000 draws (ta 0.99 for vg13, 0.95 for vg11/vg12). A `rep-hightune` fit validates as `rep`-compatible because draws/tune/chains/target_accept are minimum requirements (`fit_artifacts._sampling_parameter_errors`).
+- **Execution (Phase A):** `output/fitrun/fit_driver.sh` — 3 background `rep-hightune` fits (vg11/vg12/vg13, 18 cores) concurrent with a thread-pinned 2-wide pool of the 10 DS models + vg03/vg04 at `rep` (12 cores). ~30 of 32 cores. Resumable (each wrapper skips a model with a compatible complete fit). Detached via `setsid` so it survives disconnects. Logs `output/fitrun/logs/<model>.log`, status `output/fitrun/status.tsv`.
+
+## Model split
+
+| Config         | Models                                                        | n   |
+| -------------- | ------------------------------------------------------------- | --- |
+| `rep`          | vg01 vg02 vg03 vg04 vg05 vg07 vg08 vg09 vg10 vg14 vg15 vg16   | 12  |
+| `rep-hightune` | vg11 vg12 (ta 0.95), vg13 (ta 0.99)                           | 3   |
+
+## Plan (scope confirmed by user 2026-07-19)
+
+- Phase A — fit all 15 (above).
+- Phase B — verify convergence gate (unrounded); `run_replication.sh --config rep --no-fit --no-descriptives --no-upload` → validate, comparisons, render-only per model, sync figures, render `docs/report` + `docs/comparison`.
+- Phase C — upload to `dseresearch/public` (needs interactive `az login`; `AZURE_TOKEN_CREDENTIALS=dev`).
+- Not in scope this run: #147 Target-8 / #163 P0-P1 sensitivity study, parameter-recovery/SBC (deferred; can follow).
+
+## Progress log
+
+- **2026-07-19 ~16:14 UTC** — data re-prepared; env + dev smokes clean; Phase A driver launched (pid 9468). vg11/vg12/vg13 hightune + vg01/vg02 rep started.
+
+## Incident: session death mid-run + dirty-manifest cleanup (2026-07-20 ~08:30 UTC)
+
+- **~22:02 UTC (07-19):** DS/TD-baseline rep pool complete; vg12 hightune complete (20:48). Driver waiting on vg11/vg13 hightune.
+- **Overnight:** the SSH/tmux session died; `systemd-logind` killed all user processes — including the `setsid`-detached driver (setsid does not protect against `KillUserProcesses`). vg11/vg13 interrupted mid-sampling; the monitor was killed. Machine itself stayed up (no reboot).
+- **On disk after death:** 13/15 `state=complete` with traces (all except vg11/vg13, which left no dirs). BUT the fit manifests recorded **inconsistent `code.dirty` flags**: only vg01/vg02/vg12 were `dirty=False`; the other 10 were `dirty=True`. Cause: the run-notes file was written into the working tree (`notes/…md`) mid-run, so every model whose manifest was stamped after that captured an untracked-file dirty tree. `require_clean_fit` (publish gate) rejects `dirty=True`, so those 10 are not publishable.
+- **Fix:** relocated the notes file out of the repo (tree clean at `3e6f61d`); deleted the 10 `dirty=True` dirs; kept vg01/vg02/vg12 (`dirty=False`). Refit set = vg03,04,05,07,08,09,10,14,15,16 (rep) + vg11 (ta 0.95), vg13 (ta 0.99) (hightune). **12 refits; vg12 hightune kept (saved a ~4.5h refit).**
+- **Robustness fix:** relaunched the driver under `sudo systemd-run --unit=vgfitrun --uid=azureuser` (system-managed transient service) so it survives any future SSH/tmux/session death — the setsid+nohup approach did not. Restart at **2026-07-20 08:33 UTC**: vg11+vg13 hightune + 3-wide rep pool.
+- **Lesson (carry to runbook):** never write into the working tree during a reporting run — it dirties in-flight manifests and blocks publication. Keep run notes outside the checkout until fitting completes. And launch long detached runs via `systemd-run`, not bare `setsid`/`nohup`, on hosts with logind `KillUserProcesses=yes`.
+
+## Incident 2: OOM-kill of the concurrent hightune fits (2026-07-20 13:16 UTC)
+
+- **13/15 rep fits refit clean** (`dirty=False`, all pass R-hat/ESS; soft-gate caveats: vg01 3 div, vg02 1 div, vg12 2 div + BFMI 0.287). vg12 hightune kept from run 1.
+- **~13:16 UTC:** `vgfitrun.service` **OOM-killed** — memory peak **248.3 GB / 251 GB**. The rep refit pool finished 12:30; from then vg11 (16,235 obs) + vg13 hightune ran concurrently, and the vg11 posterior-predictive/LOO spike (its trace alone scales ~2.7× vg12's 25 GB) on top of vg13 holding its draws exceeded RAM. Both hightune fits + the driver died (unit killed → no FIT_DONE).
+- **Why run 1 didn't OOM here:** run 1 was killed by logind (session death) before vg11 reached its PP peak; run 2 additionally stacked a 3-wide rep pool (incl. vg03 @ 16k obs) under the hightune fits, pushing the peak higher.
+- **Mitigation (`fit_hightune_seq.sh`, `vghightune.service`):** run the two hightune fits **sequentially, alone** — vg13 first (draws 8000, ta 0.99; small data), then **vg11 at draws 6000** (ta 0.95). draws 6000 is still ≥ the rep minimum (rep-compatible) and tune stays 12000 (the ridge fix is tuning, not draws); ESS at 36k draws clears 400 with huge margin, and the ~25% lower draw count trims the PP/LOO peak. Armed a memory-headroom monitor as a backstop.
+- **Lesson (carry to runbook):** the hierarchical TD hightune fits are memory-heavy; **do not run vg11 hightune concurrently with other large fits** on a 251 GB box. Fit vg11 alone, and consider draws 6000 to cap the PP/LOO peak.
+
+## Incident 3: vg13 failed the R-hat gate at standard hightune (2026-07-20 17:14 UTC)
+
+- **vg13** (young TD joint, 5,406 rows, 4 studies) **failed** at tune 12000 / draws 8000 / ta 0.99: **6 R-hat failures, max 1.0135**, 0 ESS failures, **0 divergences**, min BFMI 0.284. Failing params: `p_slope_low_u`, `p_slope_hi_u`, `intercept_u`, `delta_u_raw[0/2/3]` — the **understood trend/intercept + study random-intercept ridge**. ESS min 459 (barely passing) → slow-but-valid mixing of a weakly-identified block (few studies, narrow 8–18 mo age band). This is the first *post-#164* (hierarchical) vg13 hightune attempt; July's ta-0.99 success was on the pre-#164 model.
+- **Diagnosis:** 0 divergences ⇒ not a step-size problem; the lever is more tuning + more draws (ridge mixing), not higher ta.
+- **Retry (queued):** tune 20000 / draws 12000 / ta 0.99 / chains 6, via `fit_vg13_strong.sh` (`vgvg13.service`), which **waits for vg11 to finish first** — vg13's 39 GB trace makes it as memory-heavy as vg11, so they cannot co-reside on the 251 GB box.
+- **If the strong retry still fails (>1.01):** genuine decision point for the user — (a) accept-with-caveat and document vg13's understood-trend block as marginally non-converged, (b) exclude vg13 from the published set, or (c) reparameterise (sum-to-zero/non-centred study REs — a code change). Not doing any of these unilaterally.
+
+## Incident 4: BOTH hierarchical TD models fail the R-hat gate at hightune (2026-07-20 22:17 UTC)
+
+- **vg11** (TD spoken, full-data) failed at tune 12000 / draws 6000 / ta 0.95: **7 R-hat failures, max 1.0161**, ESS 500 ✓, 0 div, BFMI 0.383 ✓. Failing: `slope`, `intercept`, `p_slope_hi`, `delta_raw[3/4/5/6]` (dataset/study REs). ~8h56m wall. No OOM (the draws-6000 memory mitigation worked; vg11 ran to completion and failed only on the gate).
+- This is the **same structural ridge as vg13**: the global **trend (slope/intercept) is weakly identified against the dataset/study random intercepts that #164 added**. The documented hightune remedy (tune 12000 / draws 8000) does **not** clear it post-#164 for either model (vg11 1.016, vg13 1.013). vg12 passed R-hat only marginally (1.006) with sub-threshold BFMI — same family.
+- **Evidence test running:** vg13 strong retry (tune 20000 / draws 12000 / ta 0.99) via `vgvg13strong.service` — does much heavier sampling cross 1.01? Result will decide the strategy for vg11 too.
+- **Status: 13/15 clean & gate-passing** (10 DS + vg03 + vg04 + vg12). **vg11, vg13 unconverged.** Phase B (comparisons/render) is blocked on the TD models.
+- **Likely decision for the user** (pending vg13-strong result): (A) escalate sampling further on vg11+vg13 (costly, uncertain); (B) publish the clean set now and defer vg11/vg12/vg13 to a follow-up; (C) reparameterise the study REs (sum-to-zero/centred — a reviewed model change) — the proper structural fix; (D) accept-with-caveat (requires bypassing the hard R-hat gate; not recommended for a knowingly non-converged fit).
+
+## Incident 5 + decision point: heavier sampling is memory-infeasible (2026-07-21 04:29 UTC)
+
+- **vg13 strong retry (tune 20000 / draws 12000 / ta 0.99) was OOM-killed** at 04:28 (peak 248 GB) mid-sampling — never reached diagnostics. At draws 12000 × 6 chains the joint model (per-subject REs `delta_subj_*_raw` + PP on 5,406 rows) exceeds 251 GB. **draws 8000 (~39 GB trace) is the practical memory ceiling** for these models on this box, and at draws ≤8000 they fail the R-hat gate (vg13 1.013, vg11 1.016).
+- **Conclusion:** the vg11/vg13 non-convergence is a **structural ridge** (global trend vs #164 dataset/study REs), not fixable by brute-force sampling here — and heavier sampling is memory-infeasible regardless. The proper fix is a **reparameterisation of the study/dataset REs (sum-to-zero / centred)**, a reviewed model change.
+- **Authoritative state: 13/15 complete, all `dirty=False`, all pass the hard R-hat/ESS gate.** 11 fully clean; vg01 (3 div), vg02 (1 div), vg12 (2 div + BFMI 0.287) pass the hard gate with soft caveats. **vg11, vg13 unconverged / not complete.**
+- **Compute stopped. Awaiting user decision:** (A) publish the 13 now, defer vg11/vg13; (B) reparameterise the REs and refit the TD trio before publishing; (C) one more memory-viable heavier attempt (low confidence).
+
+## Structural fix: sum-to-zero study REs (user chose "reparameterise", 2026-07-21 ~10:30 UTC)
+
+- **Change (commit `b563586`, branch `fix/study-re-sum-to-zero`):** study-level random intercepts now use `pm.ZeroSumNormal` for the unit offsets (`delta_raw = ZeroSumNormal(1)`, `delta = tau * delta_raw`), removing the intercept vs study-RE-mean ridge while keeping #65's funnel-avoiding non-centring and all public names. Applied to `common_univariate_re` (vg11/12), `common_bivariate_re` (vg07-10/13/16), `common_joint_modality` (vg15). Subject REs unchanged. Added a sum-to-zero guard to `test_study_re_parameterisation.py`. **Full suite: 232 passed.** ruff clean. vg11 dev fit built + sampled clean on the new path.
+- **Refit scope:** only the **9 affected study-RE models** (vg07,08,09,10,11,12,13,15,16) at **plain rep** — the ridge fix should converge them without hightune. The 6 unaffected models (vg01,02,03,04,05,14; no study REs) are kept as-is at commit 3e6f61d (`dirty=False`) — provably identical under the change; avoids re-running the 16k-obs vg03. **Published set will span two commits (documented; scientifically coherent).**
+- **Execution (`vgreparam.service`, `fit_reparam.sh`):** 3-wide rep pool {vg07,08,09,10,15,16,12} + background SEQUENTIAL heavy {vg13 then vg11}. At rep (6000 draws) peak stays well under 251 GB. Started 10:33 UTC.
+- **Watching:** do vg11/vg13 (and vg12) now pass at plain rep? vg13 is the first TD test (~2h).
+
+## Reparam validated; vg13 needs hightune ta 0.99 for a DIFFERENT block (2026-07-21 ~12:02 UTC)
+
+- **The sum-to-zero reparam WORKED.** vg13's failing parameters changed completely: from the study-RE ridge (`p_slope_*_u`, `intercept_u`, `delta_u_raw[...]`) to the **dispersion block** (`kappa_min_u`, `a_kappa_u`, `b_kappa_mag_u`, `b_kappa_u`). The ridge is gone. All 6 DS RE models refit clean at plain rep (e.g. vg08 maxRhat 1.0026, BFMI 0.53, dirty=False @ b563586).
+- **vg13 at plain rep FAILED** on the dispersion block: max R-hat 1.037, min ESS 107, **28 divergences**, BFMI 0.264. This is vg13's *separate, known* difficulty (age-varying dispersion on a narrow young-TD age range) — the same block that needed **ta 0.99** in July. Plain rep (tune 6000, ta 0.95) can't clear it.
+- **Plan:** refit vg13 at **hightune ta 0.99** (tune 12000 / draws 8000) on the reparam code — with the ridge gone, the heavy tuning + high ta should now resolve the dispersion (previously hightune was consumed fighting the ridge). Memory-OK at draws 8000 (~39 GB), run alone.
+- **vg11, vg12 still fitting at plain rep** — awaiting their verdicts to see if they also need ta 0.99 or pass at rep.
+
+## vg12 confirms: reparam fixed the study-RE ridge; TD trio needs hightune for trend/GP (2026-07-21 ~12:46 UTC)
+
+- **vg12 at plain rep FAILED** on the **trend/GP block** (`p_slope_low`, `p_slope_hi`, `slope`, `intercept`, `g_unit_hsgp_coeffs[3]`), max R-hat 1.013, ESS 569, 4 div, BFMI 0.283. The study-RE `delta_raw` is **absent** from the failures — the reparam fixed that ridge here too.
+- **Consistent finding across the TD trio:** the sum-to-zero reparam removed the study-RE ridge; what remains is the **standard trend-vs-GP redundancy** (vg11/vg12) and vg13's **dispersion + divergences**. These are the ordinary blocks that heavier tuning clears (runbook: DS understood-GP ridge cleared by hightune, e.g. vg16 1.024→1.009). Crucially, hightune's heavy tuning is no longer consumed fighting the study-RE ridge, so it should now land for the TD models.
+
+## Current status + next steps (as of 2026-07-21 ~13:00 UTC)
+
+**Complete & publishable (13/15), all `dirty=False`:**
+- Baselines/unaffected @ 3e6f61d: vg01, vg02, vg03, vg04, vg05, vg14.
+- Study-RE models refit @ b563586 (sum-to-zero): vg07, vg08, vg09, vg10, vg15, vg16.
+- Soft caveats only (pass hard gate): vg01 (3 div), vg02 (1 div).
+
+**Outstanding (TD trio) — need reparam + hightune:**
+- vg12 (TD understood): fail at rep on trend/GP (1.013) → refit hightune tune 12000 / draws 8000 / ta 0.97.
+- vg13 (TD joint young): fail at rep on dispersion + 28 div (1.037) → refit hightune tune 12000 / draws 8000 / **ta 0.99**.
+- vg11 (TD spoken, 16k obs): fitting at plain rep now; if it fails on trend/GP → refit hightune tune 12000 / **draws 6000** (memory) / ta 0.97.
+- Run the hightune refits **sequentially** (memory: vg11 16k + vg13 joint are heavy; never stack).
+
+**Then:** Phase B (comparisons + render docs/report + docs/comparison) → Phase C (upload to dseresearch/public; needs `az login`).
+
+**Provenance note:** published set will span commits 3e6f61d (baselines, code-identical) + b563586 (reparam) + the branch HEAD after this note. All docs/reparam commits are code-equivalent for each model's engine.
+
+**Infra lessons captured:** (1) never write into the working tree during a reporting run (dirties in-flight manifests); (2) launch long runs under `systemd-run` (system scope), not bare `setsid`/`nohup` (logind `KillUserProcesses` kills the latter on logout); (3) the hierarchical TD hightune fits are memory-heavy — draws 12000 OOMs on 251 GB; keep draws ≤ 8000 and never run two heavy fits concurrently.

--- a/notes/202607191614-full-refit-rep-hightune-run.md
+++ b/notes/202607191614-full-refit-rep-hightune-run.md
@@ -161,3 +161,27 @@ The DS six are pristine (0 div, BFMI ≥ 0.5). The TD trio's BFMI ≈ 0.28 is in
 **Provenance gap found and fixed.** The first corrected re-fit recorded `dirty=True` on every manifest: `git_metadata` computes dirty from `git status --porcelain --untracked-files=normal`, and 68 untracked `docs/comparison/*.png|svg` figure copies (left over from an earlier render) were in the tree at launch — `.gitignore` covered `*.csv`/`index.html` but not the plots. Fixed in `d2f2b96` (ignore the plot copies + report LaTeX byproducts), cleaned the tree, and re-fit on a porcelain-clean tree so all manifests are `dirty=False`. Lesson: the "never fit on an unclean tree" rule includes untracked build artifacts, not just modified tracked files.
 
 **Phase B complete.** All 15 model reports rendered; comparison suite (incl. the now-guarded `loo_compare`) ran clean; figures synced; report + comparison books rendered. `check_fit --purpose publish` passes for all 15 (dirty=False + reporting quality + rendered). **Phase C (blob upload) held** pending reviewer sign-off on PR #176.
+
+## Phase C complete — published to `dseresearch/public` (2026-07-24)
+
+All 15 model reports uploaded via `scripts/upload.py all --config rep` (traces excluded; `AZURE_TOKEN_CREDENTIALS=dev`, `DSERESEARCH_BLOB_CONTAINER_URL=https://dseresearch.blob.core.windows.net/public`). Each report is at a UUID-versioned path `.../public/projects/vocabulary-growth/output/<id>/<model-label>/index.html`:
+
+| model | report URL                                                                                                                                                                           |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| VG01  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b0-86f2-7762-8560-518939d1ca12/VG01-age-spoken-ds/index.html                                |
+| VG02  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b0-9b34-7209-b080-6b7a4aa8e287/VG02-age-understood-ds/index.html                            |
+| VG03  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b0-afb6-7328-a803-b236b53bf7a6/VG03-age-spoken-td/index.html                                |
+| VG04  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b0-c1ba-711c-a64a-6a6c1d450569/VG04-age-understood-td/index.html                            |
+| VG05  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b0-d3b4-72ea-8e37-9a070c17e996/VG05-age-understood-spoken-ds/index.html                     |
+| VG07  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b0-f96f-752c-a590-8fe04bd877df/VG07-age-understood-spoken-ds-re/index.html                  |
+| VG08  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b1-1f08-7594-8d8a-dfce3caa8cac/VG08-age-understood-spoken-ds-re-subj/index.html             |
+| VG09  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b1-4572-773c-a2e1-0733c00a453a/VG09-age-understood-spoken-ds-re-subj-uq/index.html          |
+| VG10  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b1-6ca0-74b3-af97-f08b709e1656/VG10-age-understood-spoken-ds-re-subj-uq-anchored/index.html |
+| VG11  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b1-9247-70dc-9e54-abc154e6f4fe/VG11-age-spoken-td-re/index.html                             |
+| VG12  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b1-a49a-7734-8970-1837cc5cf49a/VG12-age-understood-td-re/index.html                         |
+| VG13  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b1-b72b-74ea-b4c9-b1415a5f935f/VG13-age-understood-spoken-td-re-young/index.html            |
+| VG14  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b1-d75b-7393-914a-0ec560fc5d8e/VG14-age-understood-spoken-signed-ds/index.html              |
+| VG15  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b2-0a5d-73e9-9589-acf892c920e6/VG15-age-joint-signspeech-ds/index.html                      |
+| VG16  | https://dseresearch.blob.core.windows.net/public/projects/vocabulary-growth/output/019f93b2-2106-75b2-8ad6-5476b3bdac6a/VG16-age-understood-spoken-ds-re-subj-uq-crosslag/index.html |
+
+Note: `upload.py` publishes the per-model reports; the consolidated report book (`docs/report`) and comparison book (`docs/comparison`) are rendered locally but not part of this per-model upload path.

--- a/notes/202607241334-td-repeat-measures.md
+++ b/notes/202607241334-td-repeat-measures.md
@@ -1,0 +1,22 @@
+# Repeat measures in the TD data
+
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+
+There is no single "TD data" observation count: it is outcome-specific, because comprehension (`understood`) is recorded only on CDI:WG forms while production (`spoken`) exists on both WG and WS forms. Repeat measures (multiple visits per child) matter for the two TD models that carry subject-level random effects — VG11 (spoken) and VG12 (understood); the baselines VG03/VG04 pool visits as independent (`use_subject_re=False`). Counts below are reconstructed from the current prepared DuckDB via `load_data(population="td", …)` + `filter_studies_by_min_obs(200)`; the spoken figure (16,235) matches VG11's fit manifest exactly, so this is faithful to the published fit.
+
+| metric                                    | VG11 (spoken) | VG12 (understood) |
+| ----------------------------------------- | ------------- | ----------------- |
+| observations (rows)                       | 16,235        | 5,997             |
+| unique children                           | 12,266        | 4,764             |
+| children with >1 visit                    | 1,947 (15.9%) | 1,000 (21.0%)     |
+| repeat observations (rows beyond 1/child) | 3,969 (24.4%) | 1,233 (20.6%)     |
+| mean visits/child                         | 1.32          | 1.26              |
+| max visits (one child)                    | 11            | 6                 |
+| contributing studies                      | 7             | 4                 |
+
+Spoken studies (min 200 obs/study): ByersHeinlein, Floccia, Hoff, Kalashnikova, Marchman, Smith, Thal. Understood studies: ByersHeinlein, Floccia, Marchman, Thal.
+
+Headline: roughly 1,900–2,000 TD children are seen more than once, and about a quarter of the spoken observations (3,969 / 16,235) are longitudinal repeats — the corresponding understood figure is about a fifth (1,233 / 5,997). The distribution is heavily single-visit (10,319 of 12,266 spoken children appear once); a distinct cluster of 708 children with exactly 4 spoken visits stands out, likely one study's longitudinal design. VG13 (young joint) is a narrower age-restricted subset (5,406 rows) of the same children.
+
+Relevance: the subject random intercept in VG11/VG12 exists precisely to absorb this within-child correlation, and it sits alongside the #164 dataset/study intercepts whose identifiability ridges we removed in the #176 conditioning fixes — see `202607191614-full-refit-rep-hightune-run.md`. The repeat-measure structure is why these TD models are hierarchical, and why their geometry was delicate.

--- a/scripts/loo_compare.py
+++ b/scripts/loo_compare.py
@@ -123,8 +123,19 @@ def per_model_loo() -> dict[str, list[dict]]:
             continue
 
         rows = []
+        # PSIS-LOO can fail numerically for the heavily subject-random-effect
+        # models (leaving out one observation swings that child's intercept, so
+        # the importance-weight tail degenerates — "All tail values are the
+        # same"). Guard each az.loo call so one such model is skipped with a
+        # warning rather than aborting the whole comparison, matching the
+        # missing-trace / missing-log_likelihood skips above. The high Pareto-k
+        # counts already flag the models whose PSIS-LOO is unreliable.
         if short in UNIVARIATE:
-            loo = az.loo(idata, pointwise=True)
+            try:
+                loo = az.loo(idata, pointwise=True)
+            except Exception as exc:  # noqa: BLE001 - any LOO failure -> skip
+                print(f"  {short}: LOO failed ({type(exc).__name__}: {exc}) — skipped")
+                continue
             row = _loo_summary_row("y_obs", loo)
             rows.append(row)
             print(
@@ -135,7 +146,11 @@ def per_model_loo() -> dict[str, list[dict]]:
         else:
             _attach_joint_log_likelihood(idata)
             for var in ("y_u_obs", "y_s_obs", "y_joint"):
-                loo = az.loo(idata, pointwise=True, var_name=var)
+                try:
+                    loo = az.loo(idata, pointwise=True, var_name=var)
+                except Exception as exc:  # noqa: BLE001 - any LOO failure -> skip
+                    print(f"  {short} [{var}]: LOO failed ({type(exc).__name__}: {exc}) — skipped")
+                    continue
                 row = _loo_summary_row(var, loo)
                 rows.append(row)
                 print(
@@ -144,6 +159,9 @@ def per_model_loo() -> dict[str, list[dict]]:
                     f"high-k = {row['pareto_k_gt_0.7']}/{row['n_observations']}"
                 )
 
+        if not rows:
+            print(f"  {short}: no usable LOO — skipped")
+            continue
         pd.DataFrame(rows).to_csv(os.path.join(OUT_DIR, f"loo_{short}.csv"),
                                   index=False)
         out[short] = rows
@@ -161,7 +179,11 @@ def compare_pair(
     kwargs = {"method": "stacking"}
     if var_name is not None:
         kwargs["var_name"] = var_name
-    df = az.compare(compare_dict, **kwargs)
+    try:
+        df = az.compare(compare_dict, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - degenerate PSIS-LOO -> skip this comparison
+        print(f"  compare {tag}: failed ({type(exc).__name__}: {exc}) — skipped")
+        return
     df.to_csv(os.path.join(OUT_DIR, f"loo_compare_{tag}.csv"))
     print(f"\n=== az.compare(): {tag} ===")
     print(df.to_string())

--- a/src/vocab_growth/models/common_bivariate_re.py
+++ b/src/vocab_growth/models/common_bivariate_re.py
@@ -531,17 +531,21 @@ def build_model_re(
         # Study-level random intercepts
         # ============================================================
 
-        # Non-centred (delta = tau * z, z ~ Normal(0, 1)) for HMC-friendly
-        # geometry with few studies — consistent with the subject REs below and
-        # the rest of the codebase. Mathematically identical to the centred form;
-        # the public names delta_u/delta_q/tau_u/tau_q are preserved (downstream
-        # scripts extract them by name from the trace). See issue #65.
+        # Non-centred, sum-to-zero (delta = tau * z, z ~ ZeroSumNormal(1)) for
+        # HMC-friendly geometry with few studies — consistent with the subject REs
+        # below and the rest of the codebase. The tau * raw scaling keeps the
+        # funnel-avoiding non-centring of issue #65; the sum-to-zero constraint on
+        # the unit offsets additionally removes the intercept vs study-RE-mean
+        # ridge (with few studies an unconstrained mean trades off against the
+        # global intercept/slope, an R-hat failure). The public names
+        # delta_u/delta_q/tau_u/tau_q are preserved (downstream scripts extract
+        # them by name from the trace).
         tau_u = pm.HalfNormal("tau_u", sigma=definition.tau_u_sigma)
-        delta_u_raw = pm.Normal("delta_u_raw", mu=0.0, sigma=1.0, dims="study_id")
+        delta_u_raw = pm.ZeroSumNormal("delta_u_raw", sigma=1.0, dims="study_id")
         delta_u = pm.Deterministic("delta_u", tau_u * delta_u_raw, dims="study_id")
 
         tau_q = pm.HalfNormal("tau_q", sigma=definition.tau_q_sigma)
-        delta_q_raw = pm.Normal("delta_q_raw", mu=0.0, sigma=1.0, dims="study_id")
+        delta_q_raw = pm.ZeroSumNormal("delta_q_raw", sigma=1.0, dims="study_id")
         delta_q = pm.Deterministic("delta_q", tau_q * delta_q_raw, dims="study_id")
 
         # ============================================================

--- a/src/vocab_growth/models/common_bivariate_re.py
+++ b/src/vocab_growth/models/common_bivariate_re.py
@@ -511,6 +511,7 @@ def build_model_re(
             store_deterministic=True,
             latent_name="f_u_all",
             anchor_idx=i_anchor if anchor_g_u else None,
+            n_obs=n,
         )
 
         # ---- Production ratio: h(a) -> q(a) = sigmoid(h(a)) ----
@@ -525,27 +526,35 @@ def build_model_re(
             store_deterministic=True,
             latent_name="h_all",
             anchor_idx=i_anchor if anchor_g_q else None,
+            n_obs=n,
         )
 
         # ============================================================
         # Study-level random intercepts
         # ============================================================
 
-        # Non-centred, sum-to-zero (delta = tau * z, z ~ ZeroSumNormal(1)) for
+        # Non-centred, sum-to-zero (delta = tau * z, z ~ ZeroSumNormal) for
         # HMC-friendly geometry with few studies — consistent with the subject REs
         # below and the rest of the codebase. The tau * raw scaling keeps the
         # funnel-avoiding non-centring of issue #65; the sum-to-zero constraint on
-        # the unit offsets additionally removes the intercept vs study-RE-mean
-        # ridge (with few studies an unconstrained mean trades off against the
-        # global intercept/slope, an R-hat failure). The public names
-        # delta_u/delta_q/tau_u/tau_q are preserved (downstream scripts extract
-        # them by name from the trace).
+        # the unit offsets additionally removes the intercept vs study-RE-mean ridge
+        # (with few studies an unconstrained mean trades off against the global
+        # intercept/slope, an R-hat failure). This is an intentional identifiability
+        # constraint, not a prior-preserving reparameterisation — it removes the
+        # group-mean DOF. We rescale sigma by sqrt(K/(K-1)) so each study effect's
+        # marginal prior variance stays tau^2 (unchanged from independent Normal),
+        # leaving only the mean DOF removed and a -1/K correlation imposed. Both
+        # outcomes are informed by every retained study here, so a global zero-sum
+        # over study_id is correct (cf. the joint model's per-outcome coordinates).
+        # The public names delta_u/delta_q/tau_u/tau_q are preserved (downstream
+        # scripts extract them by name from the trace).
+        zsn_sigma = float(np.sqrt(n_studies / (n_studies - 1)))
         tau_u = pm.HalfNormal("tau_u", sigma=definition.tau_u_sigma)
-        delta_u_raw = pm.ZeroSumNormal("delta_u_raw", sigma=1.0, dims="study_id")
+        delta_u_raw = pm.ZeroSumNormal("delta_u_raw", sigma=zsn_sigma, dims="study_id")
         delta_u = pm.Deterministic("delta_u", tau_u * delta_u_raw, dims="study_id")
 
         tau_q = pm.HalfNormal("tau_q", sigma=definition.tau_q_sigma)
-        delta_q_raw = pm.ZeroSumNormal("delta_q_raw", sigma=1.0, dims="study_id")
+        delta_q_raw = pm.ZeroSumNormal("delta_q_raw", sigma=zsn_sigma, dims="study_id")
         delta_q = pm.Deterministic("delta_q", tau_q * delta_q_raw, dims="study_id")
 
         # ============================================================

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -59,6 +59,7 @@ import numpy as np
 import pandas as pd
 import preliz as pz
 import pymc as pm
+import pytensor.tensor as pt
 from preliz.distributions.distributions import Continuous
 
 import vocab_growth.data_utils as vocab_data_utils
@@ -845,6 +846,7 @@ def build_model(context: JointContext, definition: JointModelDefinition):
             grid=gp_grid,
             store_deterministic=False,
             anchor_idx=i_anchor if anchor_g_u else None,
+            n_obs=n,
         )
         h_all = trend_and_gp(
             cfg_low=config.p_slope_low_q_dist,
@@ -856,6 +858,7 @@ def build_model(context: JointContext, definition: JointModelDefinition):
             grid=gp_grid,
             store_deterministic=False,
             anchor_idx=i_anchor if anchor_g_q else None,
+            n_obs=n,
         )
         # Signed marginal: three-anchor "tent" hump mean (young/peak/old) + GP; the
         # study random intercept delta_sign is added at obs level below. The GP is
@@ -876,23 +879,57 @@ def build_model(context: JointContext, definition: JointModelDefinition):
             grid=gp_grid,
             store_deterministic=False,
             anchor_idx=i_anchor if anchor_g_sign else None,
+            n_obs=n,
         )
 
         # Study random intercepts (non-centred, sum-to-zero), applied at obs level
         # only. Sum-to-zero on the unit offsets removes the intercept vs
-        # study-RE-mean ridge; the tau * z scaling keeps the non-centring.
+        # study-RE-mean ridge; the tau * z scaling keeps the non-centring. This is an
+        # intentional identifiability constraint, not a prior-preserving
+        # reparameterisation: it removes the group-mean DOF and imposes a -1/K
+        # correlation. Each ZeroSumNormal sigma is rescaled by sqrt(K/(K-1)) so the
+        # marginal per-study prior variance stays tau^2 (its value before the
+        # constraint), where K is the number of studies the *outcome* actually
+        # constrains.
+        #
+        # The zero-sum must be taken over only the studies that inform each outcome
+        # (P1-D). delta_u/delta_q are informed by every retained study — U enters its
+        # own likelihood and the spoken/sign nested terms for all studies, and q
+        # enters the spoken likelihood and the cross-tab cells — so a global zero-sum
+        # over study_id is correct for them. But signing is observed by only a
+        # subset (the y_sign rows and the uk_02/nz_01 cross-tabs); a global zero-sum
+        # would let the uninformed studies' z_sign counterbalance a common shift
+        # among the informed ones, so it need not remove the sign-intercept ridge and
+        # it couples the informed effects through nuisance ones. delta_sign is
+        # therefore zero-summed over the sign-informed studies only, and fixed to 0
+        # for studies with no signing information (they never enter a sign term).
         tau_u = pm.HalfNormal("tau_u", sigma=config.tau_u_sigma)
         tau_q = pm.HalfNormal("tau_q", sigma=config.tau_q_sigma)
         tau_sign = pm.HalfNormal("tau_sign", sigma=config.tau_sign_sigma)
+        zsn_sigma = float(np.sqrt(n_studies / (n_studies - 1)))
         delta_u = pm.Deterministic(
-            "delta_u", tau_u * pm.ZeroSumNormal("z_u", sigma=1.0, dims="study_id"), dims="study_id"
+            "delta_u", tau_u * pm.ZeroSumNormal("z_u", sigma=zsn_sigma, dims="study_id"), dims="study_id"
         )
         delta_q = pm.Deterministic(
-            "delta_q", tau_q * pm.ZeroSumNormal("z_q", sigma=1.0, dims="study_id"), dims="study_id"
+            "delta_q", tau_q * pm.ZeroSumNormal("z_q", sigma=zsn_sigma, dims="study_id"), dims="study_id"
         )
-        delta_sign = pm.Deterministic(
-            "delta_sign", tau_sign * pm.ZeroSumNormal("z_sign", sigma=1.0, dims="study_id"), dims="study_id"
+
+        # Sign-informed studies: those contributing a signing marginal (idx_sign) or
+        # a within-understood/produced cross-tab (idx_cells / idx_prod).
+        sign_informed = np.unique(
+            np.concatenate([
+                study_codes[idx_sign],
+                study_codes[idx_cells],
+                study_codes[idx_prod],
+            ]).astype(int)
         )
+        n_sign_studies = int(sign_informed.size)
+        zsn_sigma_sign = float(np.sqrt(n_sign_studies / (n_sign_studies - 1)))
+        z_sign = pm.ZeroSumNormal("z_sign", sigma=zsn_sigma_sign, shape=n_sign_studies)
+        delta_sign_full = pt.set_subtensor(
+            pt.zeros(n_studies)[sign_informed], tau_sign * z_sign
+        )
+        delta_sign = pm.Deterministic("delta_sign", delta_sign_full, dims="study_id")
 
         # Subject random intercepts (non-centred), applied at obs level only. Each
         # is gated by its flag so the sign-RE can be dropped via config alone.

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -878,18 +878,20 @@ def build_model(context: JointContext, definition: JointModelDefinition):
             anchor_idx=i_anchor if anchor_g_sign else None,
         )
 
-        # Study random intercepts (non-centred), applied at obs level only.
+        # Study random intercepts (non-centred, sum-to-zero), applied at obs level
+        # only. Sum-to-zero on the unit offsets removes the intercept vs
+        # study-RE-mean ridge; the tau * z scaling keeps the non-centring.
         tau_u = pm.HalfNormal("tau_u", sigma=config.tau_u_sigma)
         tau_q = pm.HalfNormal("tau_q", sigma=config.tau_q_sigma)
         tau_sign = pm.HalfNormal("tau_sign", sigma=config.tau_sign_sigma)
         delta_u = pm.Deterministic(
-            "delta_u", tau_u * pm.Normal("z_u", 0.0, 1.0, dims="study_id"), dims="study_id"
+            "delta_u", tau_u * pm.ZeroSumNormal("z_u", sigma=1.0, dims="study_id"), dims="study_id"
         )
         delta_q = pm.Deterministic(
-            "delta_q", tau_q * pm.Normal("z_q", 0.0, 1.0, dims="study_id"), dims="study_id"
+            "delta_q", tau_q * pm.ZeroSumNormal("z_q", sigma=1.0, dims="study_id"), dims="study_id"
         )
         delta_sign = pm.Deterministic(
-            "delta_sign", tau_sign * pm.Normal("z_sign", 0.0, 1.0, dims="study_id"), dims="study_id"
+            "delta_sign", tau_sign * pm.ZeroSumNormal("z_sign", sigma=1.0, dims="study_id"), dims="study_id"
         )
 
         # Subject random intercepts (non-centred), applied at obs level only. Each

--- a/src/vocab_growth/models/common_univariate_re.py
+++ b/src/vocab_growth/models/common_univariate_re.py
@@ -371,11 +371,15 @@ def build_univariate_re_model(
         )
 
         # ============================================================
-        # Study-level random intercepts (non-centred parameterisation)
+        # Study-level random intercepts (non-centred, sum-to-zero)
         # ============================================================
 
+        # Sum-to-zero on the unit offsets (delta_raw) removes the intercept vs
+        # study-RE-mean ridge: with few studies an unconstrained mean trades off
+        # against the global intercept/slope (R-hat failure at rep-hightune). The
+        # tau * raw scaling keeps the funnel-avoiding non-centring of issue #65.
         tau = pm.HalfNormal("tau", sigma=definition.tau_study_sigma)
-        delta_raw = pm.Normal("delta_raw", mu=0.0, sigma=1.0, dims="study_id")
+        delta_raw = pm.ZeroSumNormal("delta_raw", sigma=1.0, dims="study_id")
         delta = pm.Deterministic("delta", tau * delta_raw, dims="study_id")
 
         if use_subject_re:

--- a/src/vocab_growth/models/common_univariate_re.py
+++ b/src/vocab_growth/models/common_univariate_re.py
@@ -368,6 +368,7 @@ def build_univariate_re_model(
             store_deterministic=True,
             latent_name="f_all",
             anchor_idx=i_anchor if anchor_g else None,
+            n_obs=n,
         )
 
         # ============================================================
@@ -376,10 +377,17 @@ def build_univariate_re_model(
 
         # Sum-to-zero on the unit offsets (delta_raw) removes the intercept vs
         # study-RE-mean ridge: with few studies an unconstrained mean trades off
-        # against the global intercept/slope (R-hat failure at rep-hightune). The
-        # tau * raw scaling keeps the funnel-avoiding non-centring of issue #65.
+        # against the global intercept/slope (R-hat failure at rep-hightune). This is
+        # an intentional identifiability constraint, NOT a prior-preserving
+        # reparameterisation: it removes the group-mean degree of freedom (that is
+        # the ridge) and imposes a -1/K correlation. ZeroSumNormal(sigma=1) would
+        # also shrink each marginal to Var = tau^2 * (K-1)/K; we rescale sigma by
+        # sqrt(K/(K-1)) so the marginal per-study prior variance stays tau^2 (its
+        # value before this change), leaving only the mean DOF removed. The tau * raw
+        # scaling keeps the funnel-avoiding non-centring of issue #65.
         tau = pm.HalfNormal("tau", sigma=definition.tau_study_sigma)
-        delta_raw = pm.ZeroSumNormal("delta_raw", sigma=1.0, dims="study_id")
+        zsn_sigma = float(np.sqrt(n_studies / (n_studies - 1)))
+        delta_raw = pm.ZeroSumNormal("delta_raw", sigma=zsn_sigma, dims="study_id")
         delta = pm.Deterministic("delta", tau * delta_raw, dims="study_id")
 
         if use_subject_re:

--- a/src/vocab_growth/models/gp_utils.py
+++ b/src/vocab_growth/models/gp_utils.py
@@ -258,7 +258,18 @@ def _gp_from_mean(
     hsgp = pm.gp.HSGP(cov_func=cov, m=grid.M, L=grid.L)
     g_unit = hsgp.prior(f"g_unit{suffix}", X=X_all_z_data, dims="all_id")
     if anchor_idx is not None:
-        g_unit = g_unit - g_unit[anchor_idx]
+        # Orthogonalise the GP deviation against the linear trend: remove its
+        # constant AND linear-in-age components over the grid, so `g` carries only
+        # nonlinear curvature. The old single-point anchor (``g_unit -
+        # g_unit[anchor_idx]``) removed only the level trade-off with the
+        # intercept; the GP could still tilt linearly and alias with ``slope`` — an
+        # R-hat ridge on ``p_slope_*``/``slope``/``g_unit_hsgp_coeffs`` that heavier
+        # tuning does not fix (it worsened for vg12 at hightune). Zeroing the mean
+        # and linear slope of ``g_unit`` decouples it from intercept + slope.
+        z = X_all_z_data[:, 0]
+        zc = z - z.mean()
+        g_unit = g_unit - g_unit.mean()
+        g_unit = g_unit - ((zc * g_unit).sum() / (zc * zc).sum()) * zc
     if store_deterministic:
         g = pm.Deterministic(f"g{suffix}", eta * g_unit, dims=("all_id",))
         return pm.Deterministic(latent_name, mean_trend + g, dims=("all_id",))

--- a/src/vocab_growth/models/gp_utils.py
+++ b/src/vocab_growth/models/gp_utils.py
@@ -27,7 +27,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import pymc as pm
+import pytensor.tensor as pt
 from dse_research_utils.statistics.models.pymc_utils import logit
+from pytensor.tensor.linalg import solve as pt_solve
 
 
 def make_kappa_of_z(kappa_min, a_kappa, b_kappa):
@@ -96,18 +98,20 @@ def trend_and_gp(
     store_deterministic,
     latent_name=None,
     anchor_idx=None,
+    n_obs=None,
 ):
     """Logit-linear trend + HSGP deviation; return the full-grid latent.
 
-    Emits exactly the ops previously inlined in every engine, so it moves no
-    random-variable creation and cannot change the model graph. ``suffix`` carries
-    its own leading underscore (``""`` for single-outcome engines; ``"_u"`` /
-    ``"_q"`` / ``"_sign"`` otherwise). When ``store_deterministic`` is true the GP
-    value ``g{suffix}`` and the latent ``latent_name`` are stored as named
-    ``Deterministic``\\ s (``dims=("all_id",)``); otherwise a plain tensor is
-    returned (the trace-memory discipline used by the trivariate / joint engines).
-    ``anchor_idx`` (Option D) centres the GP to pass through zero at that grid row
-    for every draw.
+    ``suffix`` carries its own leading underscore (``""`` for single-outcome
+    engines; ``"_u"`` / ``"_q"`` / ``"_sign"`` otherwise). When
+    ``store_deterministic`` is true the GP value ``g{suffix}`` and the latent
+    ``latent_name`` are stored as named ``Deterministic``\\ s (``dims=("all_id",)``);
+    otherwise a plain tensor is returned (the trace-memory discipline used by the
+    trivariate / joint engines). When ``anchor_idx`` is set the GP is
+    orthogonalised against this mean's identifiable basis ``[1, z]`` (coefficients
+    fitted on the first ``n_obs`` observed rows only) and pinned to zero at the
+    reference-age anchor row — so it carries only nonlinear curvature and its level
+    is fixed against ``intercept``/``slope`` (see :func:`_gp_from_mean`).
     """
     p_lo = cfg_low.to_pymc(f"p_slope_low{suffix}")
     p_hi = cfg_hi.to_pymc(f"p_slope_hi{suffix}")
@@ -117,7 +121,9 @@ def trend_and_gp(
     intercept = pm.Deterministic(
         f"intercept{suffix}", logit(p_lo) - slope * grid.sa_z
     )
-    mean_trend = intercept + slope * X_all_z_data[:, 0]
+    z = X_all_z_data[:, 0]
+    mean_trend = intercept + slope * z
+    nuisance_basis = pt.stack([pt.ones_like(z), z], axis=1) if anchor_idx is not None else None
     return _gp_from_mean(
         mean_trend,
         cfg_ell=cfg_ell,
@@ -128,6 +134,8 @@ def trend_and_gp(
         store_deterministic=store_deterministic,
         latent_name=latent_name,
         anchor_idx=anchor_idx,
+        n_obs=n_obs,
+        nuisance_basis=nuisance_basis,
     )
 
 
@@ -142,6 +150,7 @@ def intercept_and_gp(
     store_deterministic,
     latent_name=None,
     anchor_idx=None,
+    n_obs=None,
 ):
     """Intercept-only mean (no age slope) + HSGP deviation; full-grid latent.
 
@@ -149,8 +158,17 @@ def intercept_and_gp(
     below the data floor: the mean is the free RV ``intercept{suffix}`` (created via
     ``to_pymc``, *not* a ``Deterministic``) and the GP carries the age-varying
     shape. Otherwise identical to :func:`trend_and_gp` (see it for the parameters).
+    When anchored the nuisance basis is ``[1]`` only — the mean carries no age slope,
+    so a linear GP direction is genuine signal here and must not be projected out;
+    only the level (co-identified with the free ``intercept``) is removed, then the
+    GP is pinned to zero at the reference-age anchor row.
     """
     intercept = cfg_intercept.to_pymc(f"intercept{suffix}")
+    nuisance_basis = (
+        pt.stack([pt.ones_like(X_all_z_data[:, 0])], axis=1)
+        if anchor_idx is not None
+        else None
+    )
     return _gp_from_mean(
         intercept,
         cfg_ell=cfg_ell,
@@ -161,6 +179,8 @@ def intercept_and_gp(
         store_deterministic=store_deterministic,
         latent_name=latent_name,
         anchor_idx=anchor_idx,
+        n_obs=n_obs,
+        nuisance_basis=nuisance_basis,
     )
 
 
@@ -180,6 +200,7 @@ def tent_and_gp(
     store_deterministic,
     latent_name=None,
     anchor_idx=None,
+    n_obs=None,
 ):
     """Three-anchor "tent" mean (rise to a peak anchor, then decline) + HSGP.
 
@@ -191,8 +212,10 @@ def tent_and_gp(
     is two logit-linear segments meeting at the peak anchor, **clamped flat beyond
     the outer anchors** so it does not extrapolate to implausible values. The peak
     therefore sits at the middle anchor age by construction, and the GP carries
-    smooth departures. Otherwise identical to :func:`trend_and_gp`; ``anchor_idx``
-    (Option D) still centres the GP through zero at that grid row.
+    smooth departures. When anchored the GP is orthogonalised against this mean's
+    full basis — the three fixed tent hats spanning ``{p_low, p_mid, p_hi}``, a
+    larger space than ``[1, z]`` — so it cannot mimic a shift of any anchor, then
+    pinned to zero at the reference-age anchor row (see :func:`_gp_from_mean`).
     """
     p_low = cfg_low.to_pymc(f"p_slope_low{suffix}")
     p_mid = cfg_mid.to_pymc(f"p_slope_mid{suffix}")
@@ -217,6 +240,21 @@ def tent_and_gp(
             ),
         ),
     )
+    if anchor_idx is not None:
+        # Fixed partition-of-unity tent hats: mean_tent == logit(p_low)*phi_low +
+        # logit(p_mid)*phi_mid + logit(p_hi)*phi_hi. Projecting the GP out of their
+        # span removes exactly the directions that alias with the three anchors
+        # (a strictly larger nuisance space than [1, z]).
+        phi_low = pt.clip((z_mid - zc) / (z_mid - z_low), 0.0, 1.0)
+        phi_hi = pt.clip((zc - z_mid) / (z_hi - z_mid), 0.0, 1.0)
+        phi_mid = pt.clip(
+            pt.minimum((zc - z_low) / (z_mid - z_low), (z_hi - zc) / (z_hi - z_mid)),
+            0.0,
+            1.0,
+        )
+        nuisance_basis = pt.stack([phi_low, phi_mid, phi_hi], axis=1)
+    else:
+        nuisance_basis = None
     return _gp_from_mean(
         mean_tent,
         cfg_ell=cfg_ell,
@@ -227,7 +265,43 @@ def tent_and_gp(
         store_deterministic=store_deterministic,
         latent_name=latent_name,
         anchor_idx=anchor_idx,
+        n_obs=n_obs,
+        nuisance_basis=nuisance_basis,
     )
+
+
+def _orthogonalise_and_anchor(g_unit, nuisance_basis, n_obs, anchor_idx, *, ridge=1e-6):
+    """Project the GP out of the mean's identifiable basis, then point-anchor it.
+
+    ``nuisance_basis`` is the ``(n_all, k)`` design whose columns span the mean term
+    the GP would otherwise alias with (``[1, z]`` for the logit-linear trend, ``[1]``
+    for the free-intercept mean, the three tent hats for the peak mean). Two
+    properties matter, and both are enforced here:
+
+    * **Inference must not depend on the reporting grid.** ``X_all_z`` stacks the
+      observations with plot points, query ages and the anchor row; the projection
+      coefficients are therefore fitted on the first ``n_obs`` *observed* rows only
+      (a fixed model design), then applied to every row. Changing ``n_plot`` /
+      ``ages_query`` cannot move the observed-row latent, so it cannot move the
+      likelihood or posterior.
+    * **The reference-age anchor contract is preserved.** After removing the
+      identifiable directions, the residual is shifted so it is exactly zero at
+      ``anchor_idx`` — every posterior draw still passes through zero at the
+      reference age, fixing the GP level against the mean (the reference age is a
+      deliberate model choice, unlike the plot/query grids). The linear/tent
+      directions removed above are the additional decoupling that stops the GP
+      aliasing with ``slope`` / the anchors.
+
+    A tiny ridge stabilises the normal-equations solve if a basis column is empty
+    over the observed rows (e.g. a tent hat with no observations in its support).
+    """
+    B = nuisance_basis
+    B_obs = B[:n_obs]
+    g_obs = g_unit[:n_obs]
+    gram = pt.dot(B_obs.T, B_obs) + ridge * pt.eye(B_obs.shape[1])
+    coef = pt_solve(gram, pt.dot(B_obs.T, g_obs), assume_a="pos")
+    g_unit = g_unit - pt.dot(B, coef)
+    return g_unit - g_unit[anchor_idx]
 
 
 def _gp_from_mean(
@@ -241,13 +315,17 @@ def _gp_from_mean(
     store_deterministic,
     latent_name,
     anchor_idx,
+    n_obs=None,
+    nuisance_basis=None,
 ):
     """Shared HSGP tail: build ell/eta/HSGP, sample ``g_unit``, combine with the mean.
 
     Factored out of :func:`trend_and_gp` / :func:`intercept_and_gp` so the two
-    differ only in their mean term. The op order is unchanged from the inlined
-    engines: ``ell_unit`` and ``eta`` are created after the mean term and before the
-    single RNG-bearing ``hsgp.prior`` call, so the free-RV stream is identical.
+    differ only in their mean term. ``ell_unit`` and ``eta`` are created after the
+    mean term and before the single RNG-bearing ``hsgp.prior`` call, so the free-RV
+    stream is identical across engines. When ``anchor_idx`` is set the GP is
+    orthogonalised against ``nuisance_basis`` and pinned to zero at the reference
+    row by :func:`_orthogonalise_and_anchor` (deterministic ops only — no new RVs).
     """
     ell_unit = cfg_ell.to_pymc(f"ell_unit{suffix}")
     ell = pm.Deterministic(
@@ -258,18 +336,12 @@ def _gp_from_mean(
     hsgp = pm.gp.HSGP(cov_func=cov, m=grid.M, L=grid.L)
     g_unit = hsgp.prior(f"g_unit{suffix}", X=X_all_z_data, dims="all_id")
     if anchor_idx is not None:
-        # Orthogonalise the GP deviation against the linear trend: remove its
-        # constant AND linear-in-age components over the grid, so `g` carries only
-        # nonlinear curvature. The old single-point anchor (``g_unit -
-        # g_unit[anchor_idx]``) removed only the level trade-off with the
-        # intercept; the GP could still tilt linearly and alias with ``slope`` — an
-        # R-hat ridge on ``p_slope_*``/``slope``/``g_unit_hsgp_coeffs`` that heavier
-        # tuning does not fix (it worsened for vg12 at hightune). Zeroing the mean
-        # and linear slope of ``g_unit`` decouples it from intercept + slope.
-        z = X_all_z_data[:, 0]
-        zc = z - z.mean()
-        g_unit = g_unit - g_unit.mean()
-        g_unit = g_unit - ((zc * g_unit).sum() / (zc * zc).sum()) * zc
+        if n_obs is None or nuisance_basis is None:
+            raise ValueError(
+                "anchored GP requires n_obs and nuisance_basis "
+                f"(suffix={suffix!r}, anchor_idx={anchor_idx})"
+            )
+        g_unit = _orthogonalise_and_anchor(g_unit, nuisance_basis, n_obs, anchor_idx)
     if store_deterministic:
         g = pm.Deterministic(f"g{suffix}", eta * g_unit, dims=("all_id",))
         return pm.Deterministic(latent_name, mean_trend + g, dims=("all_id",))

--- a/tests/test_gp_anchor_orthogonalisation.py
+++ b/tests/test_gp_anchor_orthogonalisation.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Synthetic guards for the anchored-GP orthogonalisation and the sum-to-zero
+study random-intercept rescale.
+
+These tests are deliberately data-free (no DuckDB, no MCMC): they exercise the
+graph helpers on small hand-built designs so they run in CI, where ``pytest``
+executes before ``scripts/prepare_data.py`` and the model-construction fixtures
+that need the prepared database skip. They pin the statistical contracts of the
+#176 conditioning fixes directly:
+
+* the anchored GP is orthogonalised against its mean's basis using coefficients
+  fitted on the observed rows only (so the plot/query reporting grid cannot leak
+  into the observed-row latent), and it is pinned to zero at the reference-age
+  anchor row (the ``anchor_g*_at_ref`` contract); and
+* ``ZeroSumNormal`` rescaled by ``sqrt(K / (K - 1))`` restores each group's
+  marginal prior variance to that of the original independent ``Normal(0, 1)``
+  offsets, so only the group-mean degree of freedom is removed.
+"""
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+
+from vocab_growth.models.gp_utils import _orthogonalise_and_anchor
+
+
+def _apply(g_np, basis_np, n_obs, anchor_idx):
+    """Evaluate ``_orthogonalise_and_anchor`` on numeric inputs."""
+    out = _orthogonalise_and_anchor(
+        pt.as_tensor_variable(np.asarray(g_np, dtype="float64")),
+        pt.as_tensor_variable(np.asarray(basis_np, dtype="float64")),
+        n_obs,
+        anchor_idx,
+    )
+    return np.asarray(out.eval())
+
+
+def _linear_basis(z):
+    return np.column_stack([np.ones_like(z), z])
+
+
+def _grid(n_obs=60, n_plot=80, anchor_z=0.7, seed=0):
+    """Observed rows, then plot rows, then a single appended anchor row."""
+    rng = np.random.default_rng(seed)
+    z_obs = np.linspace(-2.0, 2.0, n_obs)
+    z_plot = np.linspace(-3.0, 3.0, n_plot)
+    z = np.concatenate([z_obs, z_plot, [anchor_z]])
+    anchor_idx = z.size - 1
+    return z, n_obs, anchor_idx, rng
+
+
+def _centered_cov(a, b):
+    return float(((a - a.mean()) * (b - b.mean())).mean())
+
+
+def test_point_anchor_is_exactly_zero():
+    z, n_obs, anchor_idx, rng = _grid()
+    g = rng.standard_normal(z.size)
+    out = _apply(g, _linear_basis(z), n_obs, anchor_idx)
+    assert abs(out[anchor_idx]) < 1e-9
+
+
+def test_orthogonal_to_linear_trend_over_observed_rows():
+    z, n_obs, anchor_idx, rng = _grid()
+    g = 1.3 + 0.8 * z + rng.standard_normal(z.size)  # deliberate level + slope
+    out = _apply(g, _linear_basis(z), n_obs, anchor_idx)
+    z_obs, out_obs = z[:n_obs], out[:n_obs]
+    # After projecting out [1, z] on the observed rows, the residual has no linear
+    # component there (constant-invariant, so unaffected by the anchor shift). The
+    # bound is set by the 1e-6 stabilising ridge, not the float epsilon.
+    assert abs(_centered_cov(out_obs, z_obs)) < 1e-6
+
+
+def test_observed_latent_is_invariant_to_the_reporting_grid():
+    # Same observed rows and same observed g; different plot rows and plot g.
+    z_obs = np.linspace(-2.0, 2.0, 60)
+    anchor_z = 0.7
+    rng = np.random.default_rng(1)
+    g_obs = rng.standard_normal(z_obs.size)
+    g_anchor = 0.42  # the anchor row is part of the model — hold it fixed too
+
+    def build(n_plot, plot_seed):
+        pr = np.random.default_rng(plot_seed)
+        z_plot = np.linspace(-3.0, 3.0, n_plot)
+        z = np.concatenate([z_obs, z_plot, [anchor_z]])
+        g = np.concatenate([g_obs, pr.standard_normal(n_plot), [g_anchor]])
+        out = _apply(g, _linear_basis(z), z_obs.size, z.size - 1)
+        return out[: z_obs.size]
+
+    out_a = build(n_plot=80, plot_seed=2)
+    out_b = build(n_plot=200, plot_seed=3)
+    # Changing only the plot grid (count and values) leaves the observed-row latent
+    # unchanged: the projection coefficients come from the observed rows alone.
+    assert np.allclose(out_a, out_b, atol=1e-10)
+
+
+def test_intercept_only_basis_preserves_a_linear_trend():
+    # For the free-intercept mean the nuisance basis is [1] only: a linear GP
+    # direction is genuine signal and must NOT be projected out.
+    z, n_obs, anchor_idx, rng = _grid()
+    g = 0.5 + 0.9 * z + 0.1 * rng.standard_normal(z.size)
+    out = _apply(g, np.ones((z.size, 1)), n_obs, anchor_idx)
+    assert abs(out[anchor_idx]) < 1e-9
+    # The slope over the observed rows survives (it was ~0.9, well clear of 0).
+    z_obs, out_obs = z[:n_obs], out[:n_obs]
+    slope = _centered_cov(out_obs, z_obs) / _centered_cov(z_obs, z_obs)
+    assert abs(slope - 0.9) < 0.15
+
+
+def test_tent_basis_removes_all_three_anchor_directions():
+    # The peak ("tent") mean spans three hats, a larger space than [1, z]; the GP
+    # must be orthogonal to every column over the observed rows.
+    z, n_obs, anchor_idx, rng = _grid(anchor_z=1.0)
+    z_low, z_mid, z_hi = -1.0, 0.0, 1.5
+    phi_low = np.clip((z_mid - z) / (z_mid - z_low), 0.0, 1.0)
+    phi_hi = np.clip((z - z_mid) / (z_hi - z_mid), 0.0, 1.0)
+    phi_mid = np.clip(
+        np.minimum((z - z_low) / (z_mid - z_low), (z_hi - z) / (z_hi - z_mid)), 0.0, 1.0
+    )
+    basis = np.column_stack([phi_low, phi_mid, phi_hi])
+    g = 2.0 * phi_low - 1.0 * phi_mid + 0.5 * phi_hi + rng.standard_normal(z.size)
+    out = _apply(g, basis, n_obs, anchor_idx)
+    assert abs(out[anchor_idx]) < 1e-9
+    out_obs = out[:n_obs]
+    for j in range(basis.shape[1]):
+        assert abs(_centered_cov(out_obs, basis[:n_obs, j])) < 1e-6
+
+
+def test_zero_sum_rescale_preserves_marginal_variance():
+    # ZeroSumNormal(sigma=1) has marginal variance (K-1)/K; rescaling sigma by
+    # sqrt(K/(K-1)) restores it to 1 (the independent-Normal(0,1) marginal), so
+    # only the group-mean DOF is removed, not the per-study prior scale.
+    for K in (3, 4, 6):
+        sigma = float(np.sqrt(K / (K - 1)))
+        with pm.Model():
+            x = pm.ZeroSumNormal("x", sigma=sigma, shape=K)
+            draws = pm.draw(x, draws=40000, random_seed=0)
+        assert np.allclose(draws.sum(axis=1), 0.0, atol=1e-6)
+        assert abs(draws.var(axis=0).mean() - 1.0) < 0.05

--- a/tests/test_gp_orthogonal_anchor.py
+++ b/tests/test_gp_orthogonal_anchor.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Guard the orthogonal-GP anchor.
+
+When a model anchors its HSGP deviation (``anchor_g*_at_ref``), the deviation is
+orthogonalised against the linear trend: its constant AND linear-in-age
+components are projected out over the grid, so ``g`` carries only nonlinear
+curvature and cannot alias with ``slope``. (The previous single-point anchor
+``g_unit - g_unit[idx]`` removed only the level trade-off, leaving a trend-vs-GP
+R-hat ridge that heavier tuning did not fix.)
+
+This builds the real anchored VG11 model (no sampling) and checks that prior
+draws of ``g`` are orthogonal to ``[1, z]`` over the grid; it skips cleanly when
+the prepared DuckDB is not present.
+"""
+
+import os
+
+import dse_research_utils.statistics.models.reporting as reporting
+import dse_research_utils.statistics.models.sampling as sampling
+import numpy as np
+import pymc as pm
+import pytest
+
+import vocab_growth.data_utils as vocab_data_utils
+from vocab_growth.models import common_univariate_re as cur
+from vocab_growth.models.common import ModelFitContext
+from vocab_growth.models.definitions import VG11
+
+
+@pytest.fixture
+def vg11_model(tmp_path, monkeypatch):
+    if not os.path.exists(vocab_data_utils.VOCABULARY_DATA_PATH):
+        pytest.skip("prepared vocabulary DuckDB not available")
+    monkeypatch.setattr(cur, "render_model_graph", lambda *a, **k: None)
+    context = ModelFitContext(
+        reporting=reporting.ReportingConfiguration(
+            model_name=VG11.model_id,
+            config_name=VG11.config_name,
+            output_root_dir=str(tmp_path),
+            ci_prob=0.90,
+            interval_kind="hdi",
+        ),
+        sampling=sampling.get_sampling_configuration("dev"),
+    )
+    os.makedirs(context.reporting.output_dir, exist_ok=True)
+    cur.prepare_univariate_re_data(context, VG11)
+    cur.configure_univariate_priors(context, VG11)
+    cur.build_univariate_re_model(context, VG11)
+    return context.model
+
+
+def test_anchored_gp_is_orthogonal_to_linear_trend(vg11_model):
+    assert VG11.anchor_g_at_ref, "VG11 is expected to anchor its GP"
+    z = vg11_model["X_all_z"].get_value()[:, 0]
+    zc = z - z.mean()
+    with vg11_model:
+        g = pm.draw(vg11_model["g"], draws=48, random_seed=0)
+    # Each draw: zero mean and zero linear slope over the grid (orthogonal to [1, z]).
+    assert np.abs(g.mean(axis=1)).max() < 1e-6
+    slopes = (g * zc).sum(axis=1) / (zc * zc).sum()
+    assert np.abs(slopes).max() < 1e-6

--- a/tests/test_gp_orthogonal_anchor.py
+++ b/tests/test_gp_orthogonal_anchor.py
@@ -1,18 +1,21 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Guard the orthogonal-GP anchor.
+"""Guard the orthogonal-GP anchor (integration; see also the data-free
+``test_gp_anchor_orthogonalisation`` unit tests that run in CI).
 
 When a model anchors its HSGP deviation (``anchor_g*_at_ref``), the deviation is
-orthogonalised against the linear trend: its constant AND linear-in-age
-components are projected out over the grid, so ``g`` carries only nonlinear
-curvature and cannot alias with ``slope``. (The previous single-point anchor
+orthogonalised against its mean's basis (``[1, z]`` for the logit-linear trend)
+using coefficients fitted on the *observed* rows only, so it carries only
+nonlinear curvature there and cannot alias with ``slope`` — and it is pinned to
+zero at the reference-age anchor row. (The previous single-point anchor
 ``g_unit - g_unit[idx]`` removed only the level trade-off, leaving a trend-vs-GP
-R-hat ridge that heavier tuning did not fix.)
+R-hat ridge that heavier tuning did not fix; an intermediate whole-grid
+orthogonalisation additionally let the plot/query grid leak into inference.)
 
 This builds the real anchored VG11 model (no sampling) and checks that prior
-draws of ``g`` are orthogonal to ``[1, z]`` over the grid; it skips cleanly when
-the prepared DuckDB is not present.
+draws of ``g`` pass through zero at the anchor and are orthogonal to ``[1, z]``
+over the observed rows; it skips cleanly when the prepared DuckDB is not present.
 """
 
 import os
@@ -54,10 +57,15 @@ def vg11_model(tmp_path, monkeypatch):
 def test_anchored_gp_is_orthogonal_to_linear_trend(vg11_model):
     assert VG11.anchor_g_at_ref, "VG11 is expected to anchor its GP"
     z = vg11_model["X_all_z"].get_value()[:, 0]
-    zc = z - z.mean()
+    n_obs = len(vg11_model.coords["obs_id"])
     with vg11_model:
         g = pm.draw(vg11_model["g"], draws=48, random_seed=0)
-    # Each draw: zero mean and zero linear slope over the grid (orthogonal to [1, z]).
-    assert np.abs(g.mean(axis=1)).max() < 1e-6
-    slopes = (g * zc).sum(axis=1) / (zc * zc).sum()
+    # Point anchor: some grid row is pinned to zero on every draw (the reference age).
+    assert np.abs(g).max(axis=0).min() < 1e-6
+    # Over the observed rows, each draw is orthogonal to [1, z] (constant-invariant,
+    # so unaffected by the anchor shift): no linear component to alias with `slope`.
+    g_obs = g[:, :n_obs]
+    zc = z[:n_obs] - z[:n_obs].mean()
+    gc = g_obs - g_obs.mean(axis=1, keepdims=True)
+    slopes = (gc * zc).sum(axis=1) / (zc * zc).sum()
     assert np.abs(slopes).max() < 1e-6

--- a/tests/test_gp_utils.py
+++ b/tests/test_gp_utils.py
@@ -112,8 +112,11 @@ def test_trend_and_gp_anchor_adds_no_free_rv():
         latent_name="f_all",
     )
     plain = _model_with(lambda X: trend_and_gp(X_all_z_data=X, anchor_idx=None, **cfg))
-    anchored = _model_with(lambda X: trend_and_gp(X_all_z_data=X, anchor_idx=3, **cfg))
-    # Option-D centring is a deterministic transform: same free RVs, same order.
+    anchored = _model_with(
+        lambda X: trend_and_gp(X_all_z_data=X, anchor_idx=3, n_obs=6, **cfg)
+    )
+    # The anchor + orthogonalisation is a deterministic transform: same free RVs,
+    # same order (no new sampled quantities).
     assert [v.name for v in plain.free_RVs] == [v.name for v in anchored.free_RVs]
 
 

--- a/tests/test_study_re_parameterisation.py
+++ b/tests/test_study_re_parameterisation.py
@@ -74,3 +74,27 @@ def test_study_deltas_are_deterministic_not_free(vg07_model):
     assert {"delta_u", "delta_q"}.isdisjoint(free)
     # The raw offsets and scales are the sampled quantities.
     assert {"delta_u_raw", "delta_q_raw", "tau_u", "tau_q"}.issubset(free)
+
+
+def test_study_raw_offsets_are_sum_to_zero(vg07_model):
+    """The unit study offsets are ZeroSumNormal, removing the intercept vs
+    study-RE-mean ridge that broke R-hat for the hierarchical models. Guards the
+    reparameterisation: prior draws of delta_u_raw / delta_q_raw sum to ~0 across
+    studies, and the underlying free RV is the zero-sum axis."""
+    import numpy as np
+    import pymc as pm
+
+    with vg07_model:
+        draws = pm.draw(
+            [vg07_model["delta_u_raw"], vg07_model["delta_q_raw"]], draws=64, random_seed=0
+        )
+    for arr in draws:
+        # last axis is study_id; each draw sums to zero up to float tolerance
+        assert np.allclose(arr.sum(axis=-1), 0.0, atol=1e-6)
+
+    # The sampled free variables are the zero-sum reparameterisation, not plain Normal.
+    free_names = {v.name for v in vg07_model.free_RVs}
+    assert {"delta_u_raw", "delta_q_raw"}.issubset(free_names)
+    for name in ("delta_u_raw", "delta_q_raw"):
+        rv_op = type(vg07_model[name].owner.op).__name__
+        assert "ZeroSum" in rv_op, f"{name} is {rv_op}, expected a ZeroSumNormal"


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).

## Summary

Model-conditioning fixes that resolve genuine identifiability ridges in the hierarchical models, found during the full reporting-config (`rep`) refit of `VG01`–`VG16`. The ridges were structural, not sampling effort — heavier tuning did not help (`vg12` at hightune got *worse*: R-hat 1.013 → 1.019) — so each fix reconditions the model rather than throwing draws at it.

**Updated after review** (commits `23f5ba1`, `71e46b4`): the initial versions of the GP and RE fixes were correct in intent but flawed in implementation; the four P1 findings are now addressed and the guards run in CI. See the per-thread replies for detail.

## Changes

1. **Orthogonal-GP anchor** (`gp_utils.py`). The anchored HSGP deviation is orthogonalised against its mean's basis so it carries only nonlinear curvature and cannot alias with `slope` / the anchors. Crucially: the projection coefficients are fitted on the **observed rows only** (a fixed model design) and applied to every row, so the plot/query reporting grid cannot leak into the observed-row likelihood; and the residual is then **pinned to zero at the reference-age row**, preserving the `anchor_g*_at_ref` point-anchor contract. The nuisance basis is mean-specific: `[1, z]` for the logit-linear trend, `[1]` for the free-intercept mean (a linear GP direction there is genuine signal), and the three tent hats for the peak mean. Affects anchored outcomes only (`vg10`–`vg13`, `vg15`); `anchor_idx is None` is unchanged.

2. **Sum-to-zero study random intercepts** (`common_univariate_re`, `common_bivariate_re`, `common_joint_modality`). Constraining the unit offsets to sum to zero removes the study-RE-mean vs intercept ridge. This is an **intentional identifiability constraint, not a prior-preserving reparameterisation**: it removes the group-mean degree of freedom (that is the ridge) and imposes a −1/K correlation. `ZeroSumNormal(1)` would also shrink each marginal to `tau²·(K−1)/K`; we rescale sigma by `sqrt(K/(K−1))` so each study effect's **marginal prior variance stays `tau²`** (its value before the change), leaving only the mean DOF removed. Keeps #65's non-centred `tau · raw` scaling and every public name.

3. **Sign study RE over the informed subset** (`common_joint_modality`). `delta_sign` is zero-summed over only the **sign-informed studies** (union of `idx_sign` / `idx_cells` / `idx_prod`), scattered into full `study_id` with 0 for uninformed studies — so the constraint removes the sign-intercept ridge instead of letting nuisance studies counterbalance a common shift. U and q stay global (audited: informed by every retained study via their direct and nested terms).

## Validation

- Full test suite green; new **data-free** synthetic unit tests (`test_gp_anchor_orthogonalisation.py`) assert anchor-zero, observed-row orthogonality, reporting-grid invariance, the intercept/tent basis behaviour, and the RE-rescale marginal variance — and run in CI (the earlier guards only ran when the prepared DuckDB was present, i.e. never in CI).
- The joint sign fix is verified end-to-end on VG15: of 12 studies, the 5 sign-informed are zero-summed and the other 7 are forced to exactly 0.
- **Reporting-quality refits are being regenerated** on the corrected code (the GP-anchor and sign changes alter the likelihood; the RE rescale shifts the prior scale). The previously-quoted `vg10`/`vg15` before/after metrics were from the superseded whole-grid form and will be replaced with numbers from the corrected fits. The full run — config choices, incidents, the review, and the corrected fixes — is documented in `notes/202607191614-full-refit-rep-hightune-run.md`.

## Status / scope

No model definitions or prior semantics change beyond the documented RE constraint. Affected study-RE and anchored models (`vg07`–`vg13`, `vg15`, `vg16`) are being re-fit before publication; the no-RE / no-anchor baselines (`vg01`–`vg05`, `vg14`) are unaffected. Relates to the #163 statistical-validity work and the #164 hierarchical-TD change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019anXhhvM8P55HkdKWMBpLZ
