### PR TITLE
refactor(recovery): persist the synthetic frame via DuckDB Parquet (#178)

### DIFF
--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -121,3 +121,6 @@ setsid
 unconverged
 docstrings
 workstream
+dtype
+dtypes
+deterministics

--- a/docs/runbooks/parameter-recovery.md
+++ b/docs/runbooks/parameter-recovery.md
@@ -48,6 +48,12 @@ python scripts/fit_recovery.py headline --config test --compare-only
 
 Recovery fits land in `<output root>/models/<model_id>-<config_name>-recovery-rNN/` and never touch a model of record. `sync_report_figures.py` and `check_fit` key off the registered config names, so they skip these directories — a recovery fit cannot leak into the technical report.
 
+Each replicate's inputs live in `<output root>/recovery/<model_id>-<config_name>-recovery-rNN/`, deliberately outside `models/` because a completed fit atomically replaces its own output directory and would otherwise delete what produced it:
+
+- `synthetic_analysis_frame.parquet` — the simulated dataset, written and read through DuckDB. Parquet keeps dtypes, integer widths and missingness exactly, so a numeric-looking `subject_id` cannot come back as an integer; the round trip is verified at write time, including dtype identity, so a lossy write fails during simulation rather than surfacing as an unexplained difference in the refit. DuckDB carries its own Parquet implementation, so this needs no `pyarrow` Parquet support — which the pinned environment does not provide (see [#178](https://github.com/dseinternational/vocabulary-growth/issues/178)).
+- `truth.nc` — the single parameter draw the data were generated from, plus the reported deterministics computed from it.
+- `simulation.json` — provenance: the truth's source, chain and draw, the simulation order, the likelihood row counts, and every coherence check that passed.
+
 ### Choosing the truth source
 
 `--truth posterior` (the default) takes each replicate's truth from the model of record's stored posterior, one evenly spaced draw per replicate, spread across chains so replicates are not autocorrelated near-duplicates. This asks whether the parameters are recoverable **in the regime the study actually reports**, which is the question worth answering. It requires the model of record to have been fitted at the same output root, because it reads that fit's `trace.nc`.

--- a/src/vocab_growth/recovery/simulate.py
+++ b/src/vocab_growth/recovery/simulate.py
@@ -37,6 +37,7 @@ from typing import Any
 import dse_research_utils.statistics.models.data as model_data
 import dse_research_utils.statistics.models.reporting as model_reporting
 import dse_research_utils.statistics.models.sampling as model_sampling
+import duckdb
 import numpy as np
 import pandas as pd
 import pymc as pm
@@ -61,7 +62,7 @@ BUILD_STAGE_NAME = "Model definition and initialisation"
 PRIORS_STAGE_NAME = "Priors and hyperparameters"
 PREPARE_STAGE_NAME = "Prepare data"
 
-SYNTHETIC_FRAME_FILENAME = "synthetic_analysis_frame.csv"
+SYNTHETIC_FRAME_FILENAME = "synthetic_analysis_frame.parquet"
 TRUTH_FILENAME = "truth.nc"
 SIMULATION_FILENAME = "simulation.json"
 
@@ -779,49 +780,68 @@ def simulate_replicate(
     )
 
 
-def _write_frame(frame: pd.DataFrame, path: str) -> dict[str, str]:
-    """Write the synthetic frame as CSV and verify the round trip is lossless.
+def _sql_literal(path: str) -> str:
+    """Single-quoted SQL string literal for a filesystem path.
 
-    CSV rather than a columnar format because the pinned environment does not
-    guarantee a Parquet-capable ``pyarrow`` build, and this file has to be
-    readable by the refit on every platform the study runs on. The column dtypes
-    are recorded alongside it and re-applied on load, and the round trip is
-    verified here so a lossy write fails during simulation rather than surfacing
-    as a mysterious difference in the refit.
+    DuckDB takes the target of ``COPY … TO`` as a literal rather than a bound
+    parameter, so the path is escaped here rather than interpolated raw.
+    """
+    escaped = path.replace("'", "''")
+    return f"'{escaped}'"
+
+
+def _write_frame(frame: pd.DataFrame, path: str) -> dict[str, str]:
+    """Write the synthetic frame as Parquet via DuckDB, verifying the round trip.
+
+    DuckDB carries its own Parquet reader and writer, so this needs no
+    ``pyarrow`` Parquet support — which matters because the pinned environment
+    installs ``pyarrow-core`` (Arrow buffers only, pulled in by nutpie) and no
+    ``libparquet`` on either locked platform. DuckDB is already a declared
+    dependency and already the project's storage layer for the prepared data.
+
+    Parquet keeps dtypes, integer widths and missingness exactly, so unlike a
+    text round trip nothing has to be reconstructed from a recorded schema. The
+    schema is still recorded as provenance, and the round trip is still verified
+    here — including **dtype identity**, which a CSV round trip could not
+    guarantee — so a lossy write fails during simulation rather than surfacing as
+    an unexplained difference in the refit hours later.
     """
     schema = {str(column): str(dtype) for column, dtype in frame.dtypes.items()}
-    frame.to_csv(path, index=False)
-    reloaded = _read_frame(path, schema)
+    with duckdb.connect() as connection:
+        connection.register("synthetic_frame", frame)
+        connection.execute(
+            f"COPY (SELECT * FROM synthetic_frame) TO {_sql_literal(path)} (FORMAT PARQUET)"
+        )
+    reloaded = _read_frame(path)
     if list(reloaded.columns) != list(frame.columns):
-        raise RuntimeError("Synthetic frame columns changed on the CSV round trip.")
+        raise RuntimeError("Synthetic frame columns changed on the Parquet round trip.")
     for column in frame.columns:
         original, restored = frame[column], reloaded[column]
+        if str(original.dtype) != str(restored.dtype):
+            raise RuntimeError(
+                f"Column {column!r} changed dtype on the Parquet round trip "
+                f"({original.dtype} -> {restored.dtype})."
+            )
         if pd.api.types.is_numeric_dtype(original):
             if not np.allclose(
-                pd.to_numeric(original, errors="coerce").to_numpy(dtype=float),
-                pd.to_numeric(restored, errors="coerce").to_numpy(dtype=float),
+                original.to_numpy(dtype=float),
+                restored.to_numpy(dtype=float),
                 equal_nan=True,
             ):
-                raise RuntimeError(f"Column {column!r} changed on the CSV round trip.")
+                raise RuntimeError(f"Column {column!r} changed on the Parquet round trip.")
         elif not original.astype(str).equals(restored.astype(str)):
-            raise RuntimeError(f"Column {column!r} changed on the CSV round trip.")
+            raise RuntimeError(f"Column {column!r} changed on the Parquet round trip.")
     return schema
 
 
-def _read_frame(path: str, schema: dict[str, str] | None) -> pd.DataFrame:
-    """Read a synthetic frame back, restoring the recorded column dtypes."""
-    frame = pd.read_csv(path)
-    for column, dtype in (schema or {}).items():
-        if column not in frame.columns:
-            continue
-        try:
-            frame[column] = frame[column].astype(dtype)
-        except (TypeError, ValueError):
-            # A column that cannot be restored exactly is left as read; the
-            # round-trip check in _write_frame is what guarantees the values are
-            # unchanged, and every engine coerces the columns it consumes.
-            continue
-    return frame
+def _read_frame(path: str) -> pd.DataFrame:
+    """Read a synthetic frame back from Parquet, dtypes intact."""
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"No synthetic frame at {path}.")
+    with duckdb.connect() as connection:
+        return connection.execute(
+            f"SELECT * FROM read_parquet({_sql_literal(path)})"
+        ).df()
 
 
 def load_simulation(directory: str) -> tuple[pd.DataFrame, xr.DataTree, dict[str, Any]]:
@@ -829,10 +849,10 @@ def load_simulation(directory: str) -> tuple[pd.DataFrame, xr.DataTree, dict[str
     from vocab_growth.fit_artifacts import read_json
 
     record = read_json(os.path.join(directory, SIMULATION_FILENAME))
-    frame = _read_frame(
-        os.path.join(directory, SYNTHETIC_FRAME_FILENAME),
-        record.get("simulation", {}).get("frame_schema"),
+    frame_file = record.get("simulation", {}).get(
+        "frame_file", SYNTHETIC_FRAME_FILENAME
     )
+    frame = _read_frame(os.path.join(directory, frame_file))
     truth = xr.open_datatree(os.path.join(directory, TRUTH_FILENAME)).load()
     return frame, truth, record
 

--- a/tests/test_recovery_simulation.py
+++ b/tests/test_recovery_simulation.py
@@ -238,35 +238,70 @@ def test_write_column_rejects_an_unknown_column():
         _write_column(frame, "not_a_column", np.array([0]), np.array([1.0]))
 
 
-def test_frame_round_trip_preserves_values_and_missingness(tmp_path):
+def test_frame_round_trip_preserves_values_dtypes_and_missingness(tmp_path):
+    """The frame reaches the refit through a file, so it must survive exactly.
+
+    Parquet via DuckDB keeps dtypes as well as values, so this asserts dtype
+    identity — the property a text round trip could not offer, and the reason a
+    numeric-looking ``subject_id`` cannot silently become an integer.
+    """
     frame = _bivariate_frame()
     frame["subject_key"] = ["a::1", "a::2", "b::3", "b::4", "b::5"]
-    path = tmp_path / "synthetic.csv"
+    # All-numeric-looking string ids: the case a CSV round trip would coerce.
+    frame["subject_id"] = ["0012", "34", "56", "78", "90"]
+    path = tmp_path / "synthetic.parquet"
 
     schema = _write_frame(frame, str(path))
-    reloaded = _read_frame(str(path), schema)
+    reloaded = _read_frame(str(path))
 
     assert list(reloaded.columns) == list(frame.columns)
-    pd.testing.assert_frame_equal(reloaded, frame, check_dtype=False)
+    pd.testing.assert_frame_equal(reloaded, frame)
     assert reloaded["understood"].isna().tolist() == frame["understood"].isna().tolist()
+    assert reloaded["subject_id"].tolist() == ["0012", "34", "56", "78", "90"]
     assert schema["study"] == str(frame["study"].dtype)
 
 
 def test_frame_round_trip_reports_a_lossy_write(tmp_path, monkeypatch):
     """A lossy write must fail at simulation time, not in the refit."""
     frame = _bivariate_frame()
-    path = tmp_path / "synthetic.csv"
+    path = tmp_path / "synthetic.parquet"
 
-    def _truncating_read(read_path, schema):
-        loaded = pd.read_csv(read_path)
+    def _corrupting_read(read_path):
+        loaded = _read_frame(read_path)
         loaded.loc[0, "understood"] = 999.0
         return loaded
 
     monkeypatch.setattr(
-        "vocab_growth.recovery.simulate._read_frame", _truncating_read
+        "vocab_growth.recovery.simulate._read_frame", _corrupting_read
     )
-    with pytest.raises(RuntimeError, match="changed on the CSV round trip"):
+    with pytest.raises(RuntimeError, match="changed on the Parquet round trip"):
         _write_frame(frame, str(path))
+
+
+def test_frame_round_trip_catches_a_dtype_change(tmp_path, monkeypatch):
+    """Values surviving is not enough — a dtype change must also abort.
+
+    An integer study code arriving back as a float would still compare equal
+    numerically, but the engines index with it.
+    """
+    frame = _bivariate_frame()
+    path = tmp_path / "synthetic.parquet"
+
+    def _dtype_shifting_read(read_path):
+        loaded = _read_frame(read_path)
+        loaded["study_code"] = loaded["study_code"].astype(float)
+        return loaded
+
+    monkeypatch.setattr(
+        "vocab_growth.recovery.simulate._read_frame", _dtype_shifting_read
+    )
+    with pytest.raises(RuntimeError, match="changed dtype on the Parquet round trip"):
+        _write_frame(frame, str(path))
+
+
+def test_reading_a_missing_frame_says_so(tmp_path):
+    with pytest.raises(FileNotFoundError, match="No synthetic frame"):
+        _read_frame(str(tmp_path / "absent.parquet"))
 
 
 def test_truth_draws_are_spread_and_distinct_within_a_chain():


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

## Summary

Closes acceptance criterion 1 of #178: the recovery harness persists its intermediate synthetic frame as Parquet written and read through **DuckDB**, replacing CSV plus a recorded dtype schema.

The CSV fallback was chosen after `frame.to_parquet()` failed, which I misdiagnosed as a broken local `pyarrow`. Investigating properly for #178 showed otherwise: the environment installs `pyarrow-core` (Arrow buffers only, pulled in by **nutpie**) with **no `libparquet` on either locked platform**, so the failure was deterministic and would have happened identically on the VM. Meanwhile `duckdb>=1.5.4` is an explicitly declared dependency, carries its own Parquet reader and writer, and is already this project's storage layer for the prepared data. The columnar format was available all along, with no new dependency.

## Why this is better than the CSV path it replaces

Parquet keeps dtypes, integer widths and missingness exactly, so **nothing has to be reconstructed from a recorded schema on load**. Two concrete hazards go away:

- A numeric-looking `subject_id` (`"0012"`, `"34"`) cannot come back as an integer.
- Integer `study_code` / `subject_code` cannot arrive as floats, which matters because the engines index with them.

Verified on VG15's real prepared frame: all 18 columns round-trip with identical dtypes, `subject_id` included.

The write-time round-trip verification is **kept and strengthened** — it now asserts dtype identity as well as value equality, which a text round trip could never offer. A lossy write still fails during simulation, in seconds, rather than surfacing as an unexplained difference in a refit hours later. The schema is still recorded in `simulation.json` as provenance, but is no longer load-bearing.

## Notes

- Paths are escaped into the SQL string literal DuckDB requires for a `COPY … TO` target, rather than interpolated raw — DuckDB takes that target as a literal, not a bound parameter.
- Clean switch, no dual-format read path. Nothing has been run for real yet, so there are no artefacts to stay compatible with, and a new feature is better off without legacy branches. A pre-existing CSV simulation directory now fails with a clear `No synthetic frame at …`.
- The runbook gains a description of the simulation directory's contents and why it sits outside `models/`.

## Validation

- Tests updated and extended: dtype identity through the round trip; an all-numeric-looking string id surviving; a **dtype-only** corruption being caught (value equality alone is not sufficient); a missing frame reporting itself clearly.
- Full suite green (204 tests), `ruff`, `cspell`, Prettier clean — the last three run with `npm ci` installed versions this time, after #177's version-skew lesson.
- End to end at `dev` tier: VG15 simulation (nine coherence checks pass, 18/18 dtypes preserved) and a complete VG07 simulate → refit → score loop, in which the refit loads the Parquet frame through the pipeline's substituted stage.

## Not in scope

The other two decisions in #178 stay open: whether this repo declares `pyarrow` at all (recommendation: no — DuckDB covers columnar I/O, per the shared core's own layering), and declaring `pyarrow-core` in the canonical core, which is dseinternational/research#75.

Refs #163, #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
