### PR TITLE
feat(report): surface the posterior-predictive calibration evidence (#163)

### DIFF
--- a/docs/models/vg01/index.qmd
+++ b/docs/models/vg01/index.qmd
@@ -222,9 +222,7 @@ Lower $\kappa$ values indicate greater overdispersion (greater between-child var
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg01/index.qmd
+++ b/docs/models/vg01/index.qmd
@@ -219,3 +219,17 @@ The posterior distribution of the derivative of expected spoken words with respe
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean). The plot shows how the estimated dispersion parameter $\kappa$ changes with age, along with uncertainty intervals.
 
 ![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg02/index.qmd
+++ b/docs/models/vg02/index.qmd
@@ -222,9 +222,7 @@ Lower $\kappa$ values indicate greater overdispersion (greater between-child var
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg02/index.qmd
+++ b/docs/models/vg02/index.qmd
@@ -219,3 +219,17 @@ The posterior distribution of the derivative of expected understood words with r
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean). The plot shows how the estimated dispersion parameter $\kappa$ changes with age, along with uncertainty intervals.
 
 ![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg03/index.qmd
+++ b/docs/models/vg03/index.qmd
@@ -222,9 +222,7 @@ Lower $\kappa$ values indicate greater overdispersion (greater between-child var
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg03/index.qmd
+++ b/docs/models/vg03/index.qmd
@@ -219,3 +219,17 @@ The posterior distribution of the derivative of expected spoken words with respe
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean). The plot shows how the estimated dispersion parameter $\kappa$ changes with age, along with uncertainty intervals.
 
 ![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg04/index.qmd
+++ b/docs/models/vg04/index.qmd
@@ -222,9 +222,7 @@ Lower $\kappa$ values indicate greater overdispersion (greater between-child var
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg04/index.qmd
+++ b/docs/models/vg04/index.qmd
@@ -219,3 +219,17 @@ The posterior distribution of the derivative of expected understood words with r
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean). The plot shows how the estimated dispersion parameter $\kappa$ changes with age, along with uncertainty intervals.
 
 ![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -307,9 +307,7 @@ Smoothed:
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -304,3 +304,17 @@ Smoothed:
 ### Dispersion $\kappa$ -- spoken
 
 ![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg07/index.qmd
+++ b/docs/models/vg07/index.qmd
@@ -302,9 +302,7 @@ Smoothed:
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg07/index.qmd
+++ b/docs/models/vg07/index.qmd
@@ -299,3 +299,17 @@ Smoothed:
 ### Dispersion $\kappa$ -- spoken
 
 ![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg08/index.qmd
+++ b/docs/models/vg08/index.qmd
@@ -318,9 +318,7 @@ Smoothed:
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg08/index.qmd
+++ b/docs/models/vg08/index.qmd
@@ -315,3 +315,17 @@ Smoothed:
 ### Dispersion $\kappa$ -- spoken
 
 ![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -316,9 +316,7 @@ Smoothed:
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -313,3 +313,17 @@ Smoothed:
 ### Dispersion $\kappa$ -- spoken
 
 ![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -327,3 +327,17 @@ Smoothed:
 ### Dispersion $\kappa$ -- spoken
 
 ![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -330,9 +330,7 @@ Smoothed:
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg11/index.qmd
+++ b/docs/models/vg11/index.qmd
@@ -224,3 +224,17 @@ The posterior distribution of the derivative of expected spoken words with respe
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean).
 
 ![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg11/index.qmd
+++ b/docs/models/vg11/index.qmd
@@ -227,9 +227,7 @@ Lower $\kappa$ values indicate greater overdispersion (greater between-child var
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg12/index.qmd
+++ b/docs/models/vg12/index.qmd
@@ -227,9 +227,7 @@ Lower $\kappa$ values indicate greater overdispersion (greater between-child var
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg12/index.qmd
+++ b/docs/models/vg12/index.qmd
@@ -224,3 +224,17 @@ The posterior distribution of the derivative of expected understood words with r
 Lower $\kappa$ values indicate greater overdispersion (greater between-child variability relative to the mean), while higher $\kappa$ values indicate less overdispersion (less between-child variability relative to the mean).
 
 ![posterior_kappa](posterior_kappa.png){#fig-posterior-kappa .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -315,9 +315,7 @@ ppc_count_distribution_gallery("posterior_predictive_count_distributions_s")
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -312,3 +312,17 @@ ppc_count_distribution_gallery("posterior_predictive_count_distributions_s")
 ### Dispersion $\kappa$ -- spoken
 
 ![posterior_kappa_s](posterior_kappa_s.png){#fig-kappa-s .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg14/index.qmd
+++ b/docs/models/vg14/index.qmd
@@ -431,9 +431,7 @@ Smoothed:
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg14/index.qmd
+++ b/docs/models/vg14/index.qmd
@@ -428,3 +428,17 @@ Smoothed:
 ### Dispersion $\kappa$ -- signed
 
 ![posterior_kappa_sign](posterior_kappa_sign.png){#fig-kappa-sign .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -339,9 +339,7 @@ Observed vs predicted totals for the four within-understood cells (uk_02), check
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg15/index.qmd
+++ b/docs/models/vg15/index.qmd
@@ -336,3 +336,17 @@ summary_r
 Observed vs predicted totals for the four within-understood cells (uk_02), checking the Dirichlet-Multinomial fit that identifies $\psi$.
 
 ![uk_02 four-cell PPC](uk02_cell_ppc.png){#fig-ppc .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/models/vg16/index.qmd
+++ b/docs/models/vg16/index.qmd
@@ -147,9 +147,7 @@ diagnostics
 
 ## Predictive calibration
 
-Quantitative counterpart to the posterior predictive checks above: how often each
-predictive interval contains the observation it predicts, and where the
-observations sit within their predictive distributions.
+Quantitative counterpart to the posterior predictive checks above: how often each predictive interval contains the observation it predicts, and where the observations sit within their predictive distributions.
 
 ```{python}
 #| echo: false

--- a/docs/models/vg16/index.qmd
+++ b/docs/models/vg16/index.qmd
@@ -144,3 +144,17 @@ diagnostics
 ## Words understood vs words spoken
 
 ![Expected words understood vs spoken](understood_vs_spoken.png){#fig-understood-vs-spoken .lightbox fig-align="left"}
+
+## Predictive calibration
+
+Quantitative counterpart to the posterior predictive checks above: how often each
+predictive interval contains the observation it predicts, and where the
+observations sit within their predictive distributions.
+
+```{python}
+#| echo: false
+#| output: asis
+from vocab_growth.models.calibration import render_calibration_section
+
+render_calibration_section()
+```

--- a/docs/report/methods-workflow.qmd
+++ b/docs/report/methods-workflow.qmd
@@ -57,7 +57,7 @@ Two limits on how far these numbers can be pushed. First, they are **in-sample**
 #| echo: false
 import pandas as pd
 
-from vocab_growth.models.calibration import nominal_level, overall_calibration
+from vocab_growth.models.calibration import overall_calibration
 from vocab_growth.models.definitions import MODEL_REGISTRY
 
 _rows = []

--- a/docs/report/methods-workflow.qmd
+++ b/docs/report/methods-workflow.qmd
@@ -3,6 +3,8 @@ title: "Bayesian workflow and model validation"
 abstract: "*This chapter describes the iterative Bayesian workflow used to develop, fit and validate the models: the fitting pipeline and sampling configurations, the validation checks every model is held to (prior predictive, convergence diagnostics, posterior predictive), and the formal basis on which one model is said to supersede another — tabulated out-of-sample model comparison together with identified structural issues.*"
 ---
 
+{{< include _report_data.qmd >}}
+
 ::: {.callout-note}
 Drafted by LLM-based AI tools (Claude Code/Opus 4.8 and OpenAI Codex/GPT-5).
 :::
@@ -40,6 +42,50 @@ Bulk and tail ESS are both gated because they govern different summaries: bulk-E
 ### Posterior predictive checks
 
 Posterior predictive checks generate replicated outcomes from each fitted model and compare them with the observations. We inspect probability-mass and cumulative-distribution overlays, the distribution of bounded counts across age, and age-specific summaries. For joint models we check understood and produced outcomes together, including violations and fallback rows in the nested likelihood. The signing model additionally checks the four sign-by-speech cells used to identify their association. A model can pass sampler diagnostics yet fail these checks: convergence shows that computation characterised the specified posterior, not that the specification adequately represents the data.
+
+### Quantitative predictive calibration {#sec-predictive-calibration}
+
+The overlays above are read by eye. Every fit additionally writes a numerical calibration table, so the same question is answered in numbers that can be compared across models, outcomes and ages. For each outcome it records, pooled overall and within 12-month age bands: the mean observed and predicted counts and their difference; the **empirical coverage** of the predictive interval at each reported width; and the distribution of the **probability integral transform** (PIT) — the position of each observation within its own predictive distribution, summarised by its mean, its variance, and the proportion falling in the extreme 5% tails. Because the outcomes are discrete counts, the mid-PIT is used, which assigns half the replicated mass equal to the observation.
+
+A well-calibrated model has coverage near nominal, a PIT mean near 0.5, and a PIT variance near $1/12 \approx 0.083$, the variance of a standard uniform. Departures are directional: PIT variance *below* that value with coverage *above* nominal means the predictive distribution is wider than the data warrant; PIT variance above it with coverage below nominal means the model is overconfident. A PIT mean away from 0.5 indicates systematic bias, and an inflated extreme rate indicates observations the model treats as near-impossible.
+
+Two limits on how far these numbers can be pushed. First, they are **in-sample**: the replications condition on parameters that the same observations informed, so the PIT is expected to be somewhat under-dispersed and coverage somewhat above nominal even for a well-specified model. The direction of a departure is therefore not by itself evidence that the reported intervals are conservative for a *new* child; the out-of-sample counterpart is the LOO/ELPD comparison in @sec-supersedes. Their value is in comparison — between models, between outcomes, and across age — and in catching gross misfit, which is where an interval-coverage failure would first appear. Second, pooling over ages can conceal an age-specific failure, which is why each model's own report carries the age-banded breakdown; bands holding a handful of observations are uninformative by construction.
+
+```{python}
+#| label: tbl-calibration-cross-model
+#| tbl-cap: "Posterior-predictive calibration of each model of record, pooled over ages. Nominal is the outer predictive width each fit tabulated. PIT variance is compared against 1/12 = 0.083."
+#| echo: false
+import pandas as pd
+
+from vocab_growth.models.calibration import nominal_level, overall_calibration
+from vocab_growth.models.definitions import MODEL_REGISTRY
+
+_rows = []
+for _model in MODEL_REGISTRY.values():
+    _table = load_summary(_model.model_id, "posterior_predictive_calibration")
+    if _table is None or _table.empty:
+        continue
+    _overall, _level = overall_calibration(_table)
+    for _, _row in _overall.iterrows():
+        _rows.append(
+            {
+                "Model": _model.model_id,
+                "Outcome": _row["outcome"],
+                "n": int(_row["n_observations"]),
+                "Nominal": f"{_level:.0%}",
+                "Coverage": round(float(_row["empirical_coverage"]), 3),
+                "Mean error": round(float(_row["mean_error"]), 1),
+                "PIT mean": round(float(_row["mid_pit_mean"]), 3),
+                "PIT variance": round(float(_row["mid_pit_variance"]), 3),
+                "PIT extreme rate": round(float(_row["mid_pit_extreme_rate"]), 3),
+            }
+        )
+
+show_or_pending(
+    pd.DataFrame(_rows) if _rows else None,
+    "the per-model posterior-predictive calibration tables",
+)
+```
 
 ### Reporting estimates: lead with the interval
 

--- a/src/vocab_growth/models/calibration.py
+++ b/src/vocab_growth/models/calibration.py
@@ -319,8 +319,19 @@ def render_calibration_section(directory: str = ".") -> None:
         f"near {level:.0%}, a PIT mean near 0.5, and a PIT variance near "
         f"{UNIFORM_PIT_VARIANCE:.3f} (the variance of a standard uniform). Coverage "
         "above nominal with PIT variance below that value means the predictive "
-        "distribution is wider than the data warrant — conservative rather than "
-        "overconfident.\n"
+        "distribution is wider than the data warrant.\n"
+    )
+    # The caveat travels with the numbers. Without it a reader of this page alone
+    # would take over-coverage as evidence that the reported intervals are
+    # conservative for a new child, which these in-sample checks cannot support.
+    print(
+        "These are **in-sample** checks: the replications condition on parameters "
+        "that these same observations informed, so some over-coverage and an "
+        "under-dispersed PIT are expected even for a well-specified model. That "
+        "direction is therefore *not* evidence that the reported intervals are "
+        "conservative for a new child — read these numbers for comparison across "
+        "outcomes and ages, and for gross misfit. The out-of-sample counterpart is "
+        "the LOO/ELPD comparison.\n"
     )
     print(format_calibration(overall).to_markdown(index=False))
     print("\n: Predictive calibration pooled over ages {#tbl-calibration-overall}\n")

--- a/src/vocab_growth/models/calibration.py
+++ b/src/vocab_growth/models/calibration.py
@@ -1,7 +1,19 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""Quantitative posterior-predictive calibration summaries."""
+"""Quantitative posterior-predictive calibration summaries.
+
+Every fit writes one of these tables. It answers a different question from the
+convergence gate: the gate establishes that the sampler characterised the
+specified posterior, while this establishes whether the fitted model's replicated
+outcomes look like the observed ones — how often a predictive interval contains
+the observation it is predicting, and whether the observations sit uniformly
+within their predictive distributions.
+
+The reporting helpers at the foot of this module turn a written table into the
+form the report and the per-model dashboards present, so the interpretation
+cannot drift between them.
+"""
 
 import os
 
@@ -9,13 +21,31 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+from vocab_growth import intervals
+
+# Nominal levels tabulated by default. The inner and outer levels are the
+# project's reporting convention (vocab_growth.intervals), so predictive coverage
+# is reported at the same widths as every credible interval in the report rather
+# than at an unrelated round number. The middle level is an intermediate
+# reference point.
+DEFAULT_INTERVAL_PROBS: tuple[float, ...] = (
+    intervals.INNER_CI_PROB,
+    0.80,
+    intervals.DEFAULT_CI_PROB,
+)
+
+# Variance of a standard uniform, the value a perfectly calibrated probability
+# integral transform has. Below it the predictive distribution is wider than the
+# data warrant (conservative intervals); above it, too narrow (overconfident).
+UNIFORM_PIT_VARIANCE: float = 1.0 / 12.0
+
 
 def predictive_calibration_table(
     observed: np.ndarray,
     predictive: np.ndarray,
     ages: np.ndarray,
     *,
-    interval_probs: tuple[float, ...] = (0.50, 0.80, 0.90),
+    interval_probs: tuple[float, ...] = DEFAULT_INTERVAL_PROBS,
     age_band_months: int = 12,
     observation_chunk_size: int = 256,
 ) -> pd.DataFrame:
@@ -155,3 +185,153 @@ def write_trace_calibration(
         index=False,
     )
     return result
+
+
+# ==========================================================================
+# Reporting helpers
+# ==========================================================================
+#
+# A written table carries every tabulated nominal level and every age band. The
+# report and the per-model dashboards present one level at a time, so these
+# helpers resolve the level and label the columns in one place — the numbers in
+# the report and the numbers on a model's page are then the same numbers,
+# selected the same way.
+
+# Display labels, in presentation order.
+_DISPLAY_COLUMNS: dict[str, str] = {
+    "outcome": "Outcome",
+    "age_band_months": "Age band (mo)",
+    "n_observations": "n",
+    "observed_mean": "Observed mean",
+    "predictive_mean": "Predicted mean",
+    "mean_error": "Mean error",
+    "empirical_coverage": "Coverage",
+    "mid_pit_mean": "PIT mean",
+    "mid_pit_variance": "PIT variance",
+    "mid_pit_extreme_rate": "PIT extreme rate",
+}
+
+OVERALL_BAND = "all"
+
+
+def nominal_level(table: pd.DataFrame, target: float | None = None) -> float:
+    """The tabulated nominal level closest to the reporting convention.
+
+    Resolved from the table rather than assumed, because a table written before
+    the tabulated levels were tied to :mod:`vocab_growth.intervals` carries a 0.90
+    outer level where a current one carries 0.89. Reporting the level actually
+    found — and labelling it — keeps an older fit's table readable and honest
+    instead of silently mislabelling it.
+    """
+    if "interval_probability" not in table.columns or table.empty:
+        raise ValueError("Not a calibration table: no interval_probability column.")
+    wanted = intervals.DEFAULT_CI_PROB if target is None else target
+    levels = np.asarray(sorted(table["interval_probability"].dropna().unique()), dtype=float)
+    if levels.size == 0:
+        raise ValueError("Calibration table has no tabulated interval levels.")
+    return float(levels[int(np.argmin(np.abs(levels - wanted)))])
+
+
+def _at_level(table: pd.DataFrame, level: float | None) -> tuple[pd.DataFrame, float]:
+    resolved = nominal_level(table) if level is None else level
+    rows = table[np.isclose(table["interval_probability"], resolved)]
+    return rows, resolved
+
+
+def overall_calibration(
+    table: pd.DataFrame, level: float | None = None
+) -> tuple[pd.DataFrame, float]:
+    """Per-outcome calibration pooled over ages, with the level it is reported at.
+
+    Returns ``(frame, level)``. The frame has one row per outcome.
+    """
+    rows, resolved = _at_level(table, level)
+    rows = rows[rows["age_band_months"] == OVERALL_BAND]
+    return rows.reset_index(drop=True), resolved
+
+
+def calibration_by_age(
+    table: pd.DataFrame, level: float | None = None
+) -> tuple[pd.DataFrame, float]:
+    """Per-outcome, per-age-band calibration, with the level it is reported at.
+
+    Age bands sort by their lower bound rather than lexically, so ``[108, 120)``
+    follows ``[96, 108)`` instead of ``[12, 24)``.
+    """
+    rows, resolved = _at_level(table, level)
+    rows = rows[rows["age_band_months"] != OVERALL_BAND].copy()
+    if rows.empty:
+        return rows.reset_index(drop=True), resolved
+    rows["_lower"] = (
+        rows["age_band_months"].str.extract(r"\[(-?\d+)", expand=False).astype(float)
+    )
+    sort_columns = ["outcome", "_lower"] if "outcome" in rows.columns else ["_lower"]
+    rows = rows.sort_values(sort_columns).drop(columns="_lower")
+    return rows.reset_index(drop=True), resolved
+
+
+def format_calibration(frame: pd.DataFrame) -> pd.DataFrame:
+    """Select and label the presentation columns of a calibration selection."""
+    columns = [column for column in _DISPLAY_COLUMNS if column in frame.columns]
+    out = frame[columns].rename(columns=_DISPLAY_COLUMNS)
+    for label, places in (
+        ("Observed mean", 1),
+        ("Predicted mean", 1),
+        ("Mean error", 1),
+        ("Coverage", 3),
+        ("PIT mean", 3),
+        ("PIT variance", 3),
+        ("PIT extreme rate", 3),
+    ):
+        if label in out.columns:
+            out[label] = out[label].astype(float).round(places)
+    if "n" in out.columns:
+        out["n"] = out["n"].astype(int)
+    return out
+
+
+def render_calibration_section(directory: str = ".") -> None:
+    """Print the calibration evidence for a per-model report cell.
+
+    Intended for a report cell with ``#| output: asis``, mirroring
+    :func:`vocab_growth.plotting.ppc_count_distribution_gallery`. Prints a note
+    recording the nominal level actually tabulated, the per-outcome table pooled
+    over ages, and the per-age-band breakdown. Prints an explanatory line rather
+    than failing when the fit predates the calibration table, so the section is
+    never silently empty.
+    """
+    path = os.path.join(directory, "posterior_predictive_calibration.csv")
+    if not os.path.exists(path):
+        print(
+            "_No calibration table for this fit "
+            "(`posterior_predictive_calibration.csv` absent — refit to generate it)._"
+        )
+        return
+    table = pd.read_csv(path)
+    if table.empty:
+        print("_The calibration table for this fit is empty._")
+        return
+
+    overall, level = overall_calibration(table)
+    print(
+        f"Predictive coverage is reported at the **{level:.0%}** nominal level, the "
+        "outer interval this fit tabulated. A well-calibrated model has coverage "
+        f"near {level:.0%}, a PIT mean near 0.5, and a PIT variance near "
+        f"{UNIFORM_PIT_VARIANCE:.3f} (the variance of a standard uniform). Coverage "
+        "above nominal with PIT variance below that value means the predictive "
+        "distribution is wider than the data warrant — conservative rather than "
+        "overconfident.\n"
+    )
+    print(format_calibration(overall).to_markdown(index=False))
+    print("\n: Predictive calibration pooled over ages {#tbl-calibration-overall}\n")
+
+    by_age, _ = calibration_by_age(table)
+    if not by_age.empty:
+        print("\n### By age band\n")
+        print(
+            "_Bands with few observations are uninformative: a single-observation "
+            "band reports a coverage of 0 or 1 and a PIT variance of 0 by "
+            "construction._\n"
+        )
+        print(format_calibration(by_age).to_markdown(index=False))
+        print("\n: Predictive calibration by age band {#tbl-calibration-by-age}\n")

--- a/tests/test_predictive_calibration.py
+++ b/tests/test_predictive_calibration.py
@@ -7,7 +7,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from vocab_growth.models.calibration import predictive_calibration_table
+from vocab_growth.models.calibration import (
+    DEFAULT_INTERVAL_PROBS,
+    predictive_calibration_table,
+)
 
 
 def test_predictive_calibration_reports_overall_and_age_bands():
@@ -25,7 +28,10 @@ def test_predictive_calibration_reports_overall_and_age_bands():
     table = predictive_calibration_table(observed, predictive, ages)
 
     assert set(table["age_band_months"]) == {"all", "[0, 12)", "[12, 24)"}
-    assert set(table["interval_probability"]) == {0.5, 0.8, 0.9}
+    # Asserted against the convention rather than literals: the tabulated levels
+    # are tied to vocab_growth.intervals so predictive coverage is reported at the
+    # same widths as every credible interval in the report.
+    assert set(table["interval_probability"]) == set(DEFAULT_INTERVAL_PROBS)
     overall = table[table["age_band_months"] == "all"]
     assert (overall["empirical_coverage"] == 1.0).all()
     assert (overall["n_observations"] == 4).all()
@@ -57,3 +63,128 @@ def test_predictive_calibration_chunking_preserves_results():
     )
 
     pd.testing.assert_frame_equal(chunked, expected)
+
+
+def _written_table(levels=(0.5, 0.8, 0.9)):
+    """A calibration table in the written schema, with chosen nominal levels."""
+    rows = []
+    for outcome in ("understood", "spoken"):
+        for band, n in (("all", 40), ("[0, 12)", 10), ("[12, 24)", 25), ("[108, 120)", 5)):
+            for level in levels:
+                rows.append(
+                    {
+                        "outcome": outcome,
+                        "age_band_months": band,
+                        "n_observations": n,
+                        "observed_mean": 100.0,
+                        "predictive_mean": 101.0,
+                        "mean_error": 1.0,
+                        "observed_zero_rate": 0.0,
+                        "predictive_zero_rate": 0.0,
+                        "mid_pit_mean": 0.5,
+                        "mid_pit_variance": 0.06,
+                        "mid_pit_extreme_rate": 0.05,
+                        "interval_probability": level,
+                        "empirical_coverage": 0.9,
+                        "mean_interval_width": 50.0,
+                    }
+                )
+    return pd.DataFrame(rows)
+
+
+def test_default_levels_follow_the_reporting_convention():
+    """Predictive coverage must be tabulated at the widths the report leads with.
+
+    Otherwise the report can only quote coverage at some unrelated round number
+    while every credible interval beside it is an 89% one.
+    """
+    from vocab_growth import intervals
+    from vocab_growth.models.calibration import DEFAULT_INTERVAL_PROBS
+
+    assert intervals.INNER_CI_PROB in DEFAULT_INTERVAL_PROBS
+    assert intervals.DEFAULT_CI_PROB in DEFAULT_INTERVAL_PROBS
+
+
+def test_nominal_level_resolves_from_the_table_not_from_an_assumption():
+    """An older table tabulated 0.90; a current one tabulates 0.89.
+
+    The reporting helpers must read whichever is present so an older fit's table
+    is labelled with the level it actually holds rather than mislabelled.
+    """
+    from vocab_growth.models.calibration import nominal_level
+
+    assert nominal_level(_written_table(levels=(0.5, 0.8, 0.9))) == 0.9
+    assert nominal_level(_written_table(levels=(0.5, 0.8, 0.89))) == 0.89
+    # An explicit target still wins, so the inner interval can be reported too.
+    assert nominal_level(_written_table(), target=0.5) == 0.5
+
+
+def test_nominal_level_rejects_a_frame_that_is_not_a_calibration_table():
+    from vocab_growth.models.calibration import nominal_level
+
+    with pytest.raises(ValueError, match="calibration table|no interval"):
+        nominal_level(pd.DataFrame({"outcome": ["understood"]}))
+
+
+def test_overall_calibration_selects_the_pooled_rows_only():
+    from vocab_growth.models.calibration import overall_calibration
+
+    frame, level = overall_calibration(_written_table())
+
+    assert level == 0.9
+    assert set(frame["age_band_months"]) == {"all"}
+    assert list(frame["outcome"]) == ["understood", "spoken"]
+
+
+def test_calibration_by_age_sorts_bands_numerically():
+    """``[108, 120)`` must follow ``[12, 24)``, not precede it.
+
+    Age bands are strings, so a lexical sort would put the 9-year band second and
+    make the age trend unreadable.
+    """
+    from vocab_growth.models.calibration import calibration_by_age
+
+    frame, _ = calibration_by_age(_written_table())
+
+    understood = frame[frame["outcome"] == "understood"]
+    assert list(understood["age_band_months"]) == ["[0, 12)", "[12, 24)", "[108, 120)"]
+    assert "all" not in set(frame["age_band_months"])
+
+
+def test_format_calibration_labels_and_rounds_the_reported_columns():
+    from vocab_growth.models.calibration import format_calibration, overall_calibration
+
+    frame, _ = overall_calibration(_written_table())
+    display = format_calibration(frame)
+
+    assert list(display.columns)[:3] == ["Outcome", "Age band (mo)", "n"]
+    assert "Coverage" in display.columns and "PIT variance" in display.columns
+    # Internal column names must not leak into a reported table.
+    assert not {"mid_pit_mean", "empirical_coverage"} & set(display.columns)
+    assert display["n"].dtype.kind in "iu"
+
+
+def test_render_calibration_section_explains_an_absent_table(tmp_path, capsys):
+    """A fit predating the calibration table must not render an empty section."""
+    from vocab_growth.models.calibration import render_calibration_section
+
+    render_calibration_section(str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert "No calibration table" in out
+    assert "refit" in out
+
+
+def test_render_calibration_section_reports_the_level_and_both_tables(tmp_path, capsys):
+    from vocab_growth.models.calibration import render_calibration_section
+
+    _written_table().to_csv(
+        tmp_path / "posterior_predictive_calibration.csv", index=False
+    )
+    render_calibration_section(str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert "**90%**" in out  # the level actually tabulated, not an assumed one
+    assert "0.083" in out  # the uniform-PIT reference value
+    assert "pooled over ages" in out and "by age band" in out.lower()
+    assert "| Outcome" in out  # rendered as a markdown table

--- a/tests/test_predictive_calibration.py
+++ b/tests/test_predictive_calibration.py
@@ -188,3 +188,23 @@ def test_render_calibration_section_reports_the_level_and_both_tables(tmp_path, 
     assert "0.083" in out  # the uniform-PIT reference value
     assert "pooled over ages" in out and "by age band" in out.lower()
     assert "| Outcome" in out  # rendered as a markdown table
+
+
+def test_render_calibration_section_carries_the_in_sample_caveat(tmp_path, capsys):
+    """The caveat must travel with the numbers, not live only in the report.
+
+    A reader of a single model's page would otherwise take over-coverage as
+    evidence that the reported intervals are conservative for a new child, which
+    an in-sample posterior predictive check cannot support.
+    """
+    from vocab_growth.models.calibration import render_calibration_section
+
+    _written_table().to_csv(
+        tmp_path / "posterior_predictive_calibration.csv", index=False
+    )
+    render_calibration_section(str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert "in-sample" in out.lower()
+    assert "not* evidence" in out or "not evidence" in out
+    assert "LOO" in out  # points at the out-of-sample counterpart


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

## Summary

Closes the quantitative-calibration half of #163's acceptance item "add quantitative posterior-predictive calibration plus simulation/parameter-recovery checks for the preferred models". The parameter-recovery half landed in #177.

**No fitting is involved.** Every fit has written `posterior_predictive_calibration.csv` since #164, and no report has ever read it — `grep -rl calibration docs/**/*.qmd` returned nothing. The evidence was computed, synced into the figure cache, and invisible. This surfaces it.

## What is reported, and where

Two places, both generated from the written tables so no number is hand-entered:

- **The workflow chapter** gains a `Quantitative predictive calibration` section: what is measured (per-outcome empirical coverage at the reported widths, mid-PIT mean/variance/extreme rate, mean error, pooled and in 12-month age bands), how to read it, and a cross-model table of every model of record.
- **All 15 per-model reports** gain a `Predictive calibration` section with their own per-outcome table and an age-banded breakdown, placed next to the posterior-predictive overlays it quantifies.

Both routes go through shared helpers in `models/calibration.py`, so the selection and the interpretation cannot drift between the report and a model's own page.

## Two things the prose is deliberately careful about

**These are in-sample diagnostics.** The tempting reading is that coverage above nominal with PIT variance below $1/12$ shows the reported intervals are conservative. That is not sound: the replications condition on parameters the same observations informed, so an under-dispersed PIT and coverage above nominal are *expected* even for a well-specified model. The chapter states this and points to the LOO/ELPD comparison as the out-of-sample counterpart, rather than letting an artefact of in-sample checking read as reassurance about a new child. For a report written partly for a clinical audience that distinction matters.

**No narrative about the current numbers.** The cached tables are all from the paused pre-#176 run — nine models, dated 16–18 July — so any pattern in them is superseded. The prose gives the reading rules and lets the generated table speak; the numbers arrive with the next figure sync. This is the same discipline `notes/202607251055-combined-sensitivity-recovery-run-plan.md` asks for.

## An inconsistency fixed on the way

Calibration was tabulated at (0.50, 0.80, **0.90**) while every credible interval in the report is **89%** — so the report could not have quoted predictive coverage at its own reported width. The tabulated levels are now tied to `vocab_growth.intervals` (0.50 / 0.89).

Tables written before this change carry a 0.90 outer level, so the reporting helpers **resolve the level from the table and label what they found**. An older fit's table stays readable and correctly labelled rather than being silently mislabelled as 89%, and the cross-model table carries a `Nominal` column so a mixed cache is honest. Both cases are covered by tests.

## Validation

Verified by **rendering**, not only by unit tests:

- The workflow chapter builds with the cross-model table populated for the nine models that have a cached table, and the other six absent without error (`show_or_pending` handles a partial cache).
- A per-model section renders both its tables with the nominal level stated and age bands ordered numerically — `[108, 120)` after `[96, 108)`, which a lexical sort would have put second and made the age trend unreadable.
- Full suite green (206 tests), `ruff`, `cspell` and Prettier clean.

New tests cover: the tabulated levels following the reporting convention; level resolution for both a 0.90 and a 0.89 table; numeric age-band ordering; display labels not leaking internal column names; and the per-model section explaining an absent table rather than rendering empty.

The one existing test that asserted the old levels now asserts against the convention rather than literals, so it cannot drift from `vocab_growth.intervals` again.

## Noted, not fixed

Rendering surfaces one pre-existing warning: `@sec-appendix-b1` is dangling because Appendix B is still a five-line `TODO` stub, while the workflow chapter says "the per-model evidence is in Appendix B". That sentence is now doubly stale, since the calibration evidence lives in the per-model reports. Worth its own issue.

Refs #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
