### PR TITLE
refactor(plots): rename the misleading joint_trajectory_hdi figure

### DIFF
--- a/docs/models/OUTPUT_TEMPLATE_REVIEW.md
+++ b/docs/models/OUTPUT_TEMPLATE_REVIEW.md
@@ -235,7 +235,7 @@ templates for rendered model outputs.
 - Diagnostics are present but should add a diagnostic readout for study-effect
   scales and anchored GP parameters.
 - Posterior exploration is currently too thin. The same bivariate plotting
-  pipeline should provide many existing artefacts: `joint_trajectory_hdi`,
+  pipeline should provide many existing artefacts: `joint_trajectory_intervals`,
   `posterior_summary_s.csv`, `posterior_summary_q.csv`,
   `production_rate_by_understood`, `production_rate_predictive`,
   `understood_vs_spoken`, `understood_vs_spoken_predictive`, outcome PMFs/CDFs,

--- a/docs/models/vg05/index.qmd
+++ b/docs/models/vg05/index.qmd
@@ -179,7 +179,7 @@ The bivariate geometry depends on the understood anchors, `q` anchors, GP hyperp
 
 ![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_intervals.png){#fig-joint-trajectory-intervals .lightbox fig-align="left"}
 
 ## Production ratio
 

--- a/docs/models/vg07/index.qmd
+++ b/docs/models/vg07/index.qmd
@@ -184,7 +184,7 @@ Check `tau_u`, `tau_q`, the study intercepts, and the GP level parameters for ev
 
 ![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_intervals.png){#fig-joint-trajectory-intervals .lightbox fig-align="left"}
 
 ## Production ratio
 

--- a/docs/models/vg08/index.qmd
+++ b/docs/models/vg08/index.qmd
@@ -186,7 +186,7 @@ Check `tau_subj_u`, `tau_u`, the understood GP level, and `kappa_u`. If the subj
 
 ![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_intervals.png){#fig-joint-trajectory-intervals .lightbox fig-align="left"}
 
 ## Production ratio
 

--- a/docs/models/vg09/index.qmd
+++ b/docs/models/vg09/index.qmd
@@ -184,7 +184,7 @@ VG09 is ridge-prone. Focus on the `q` GP length-scale and amplitude, `tau_q`, `t
 
 ![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_intervals.png){#fig-joint-trajectory-intervals .lightbox fig-align="left"}
 
 ## Production ratio
 

--- a/docs/models/vg10/index.qmd
+++ b/docs/models/vg10/index.qmd
@@ -199,7 +199,7 @@ The critical question is whether the VG09 geometry issue is resolved. Check R-ha
 
 ![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_intervals.png){#fig-joint-trajectory-intervals .lightbox fig-align="left"}
 
 ## Production ratio
 

--- a/docs/models/vg13/index.qmd
+++ b/docs/models/vg13/index.qmd
@@ -186,7 +186,7 @@ For this model the main geometry checks are the study-effect scales, the anchore
 
 ![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_intervals.png){#fig-joint-trajectory-intervals .lightbox fig-align="left"}
 
 ::: {.callout-warning title="Age restriction"}
 

--- a/docs/models/vg16/index.qmd
+++ b/docs/models/vg16/index.qmd
@@ -131,7 +131,7 @@ diagnostics
 
 ![Joint posterior predictive trajectory for words understood and spoken](joint_trajectory.png){#fig-joint-trajectory .lightbox fig-align="left"}
 
-![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_hdi.png){#fig-joint-trajectory-hdi .lightbox fig-align="left"}
+![Joint posterior predictive trajectory with 50% and 89% intervals](joint_trajectory_intervals.png){#fig-joint-trajectory-intervals .lightbox fig-align="left"}
 
 ## Production ratio
 

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -1206,13 +1206,18 @@ def plot_understood_spoken_trajectory(
     return fig
 
 
-def plot_understood_spoken_trajectory_hdi(
+def plot_understood_spoken_trajectory_intervals(
     samples: BivariateModelSamples,
     n_trials: int,
     output_dir: str | None = None,
     filename: str | None = None,
 ):
-    """Plot understood and spoken posterior predictive medians with 50% and 89% intervals."""
+    """Plot understood and spoken posterior predictive medians with 50% and 89% equal-tailed intervals.
+
+    The bands summarise the posterior predictive draws (``y_u_plot`` / ``y_s_plot``),
+    not the mean trajectory, and are equal-tailed per the house convention in
+    :mod:`vocab_growth.intervals` — counts are not on the HDI short-list.
+    """
     X_plot = samples.X_plot
     outer, inner = intervals.DEFAULT_CI_PROB, intervals.INNER_CI_PROB
     pct = int(round(outer * 100))
@@ -1691,15 +1696,15 @@ def _run_bivariate_joint_plots(
     context.plots["joint_trajectory"] = fig
     plt.close(fig)
 
-    # ---- Joint trajectory HDI plot ----
+    # ---- Joint trajectory interval plot ----
 
-    fig = plot_understood_spoken_trajectory_hdi(
+    fig = plot_understood_spoken_trajectory_intervals(
         samples,
         n_trials=context.model_data.n_trials,
         output_dir=context.reporting.output_dir,
-        filename="joint_trajectory_hdi",
+        filename="joint_trajectory_intervals",
     )
-    context.plots["joint_trajectory_hdi"] = fig
+    context.plots["joint_trajectory_intervals"] = fig
     plt.close(fig)
 
     # ---- Production rate q(a) ----


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

## What

Renames the bivariate joint-trajectory interval figure, which was doubly misnamed:

| | Before | After |
| --- | --- | --- |
| Function | `plot_understood_spoken_trajectory_hdi` | `plot_understood_spoken_trajectory_intervals` |
| Artefact | `joint_trajectory_hdi.{png,svg,csv}` | `joint_trajectory_intervals.{png,svg,csv}` |
| Quarto anchor | `#fig-joint-trajectory-hdi` | `#fig-joint-trajectory-intervals` |

## Why

The `hdi` in the name was wrong on two counts.

**The bands are not highest-density.** They are computed with `intervals.bands(..., "eti", ...)` — explicitly equal-tailed. The house convention in `src/vocab_growth/intervals.py` reserves HDI for the skewed, boundary-censored short-list (`HDI_ESTIMANDS`: `psi`, `conc`/`kappa`, `peak_age`, `milestone_age`, `attainment_age`); counts and proportions are ETI by default, and this figure plots counts.

**The bands are predictive, not a credible interval on the mean.** They summarise `y_u_plot` / `y_s_plot`, which for the random-effects models draw a fresh subject random effect per draw and then a Beta-Binomial count. The mean-trajectory estimand is carried by the `Ey_*` columns; `Y_*` is the predictive one. Calling the figure "hdi" invited both misreadings at once.

Nothing about the computation changes — the ETI bands and the predictive draws are both correct as they stand. This is purely a naming fix. The figure captions already read "with 50% and 89% intervals" and were correct, so they are untouched; the docstring is expanded to state both facts the old name obscured.

## Scope

Nine files: `src/vocab_growth/models/common_bivariate.py` (function, filename, `context.plots` key, section comment, docstring), the seven bivariate dashboards that embed the figure (VG05, VG07, VG08, VG09, VG10, VG13, VG16), and the one prose mention in `docs/models/OUTPUT_TEMPLATE_REVIEW.md`. 19 insertions, 14 deletions.

Checked and found clean, so not touched: `common_trivariate.py` has no equivalent — `plot_understood_spoken_signed_trajectory` already writes `joint_trajectory` with no `_hdi` suffix, and there is no trivariate counterpart to this interval figure. There are no `@fig-joint-trajectory-hdi` cross-references anywhere in the repo, `docs/report/` never referenced the artefact, and no test or manifest enumerates figure names. The new name does not collide with the existing separate `joint_trajectory` figure.

## Reviewer notes — regeneration required

**This PR alone will leave the reports unable to find the figure.** It changes artefact filenames that the Quarto dashboards read, so every affected model's output directory and the `docs/report/figures/` cache must be regenerated (refit, then `scripts/sync_report_figures.py`) before the reports render. That is why this is best merged alongside the full refit tracked in #186 rather than shipped standalone.

Both promotion paths are whole-directory swaps, so no stale artefacts survive locally: `promote_staged_fit` (`src/vocab_growth/fit_artifacts.py:521`) replaces the entire canonical model output directory, and `sync_report_figures.py` stages into a fresh directory and swaps it in with `os.replace`.

One caveat: the blob upload is copy-style rather than a mirroring sync, so any previously uploaded `joint_trajectory_hdi.png/.svg/.csv` will linger in blob storage as orphans after the refit. Nothing in a rendered report will reference them, so this is cosmetic — but clearing them needs a manual delete.

## Verification

`ruff check src/ scripts/` clean, `pytest` 300 passed, `npm run spellcheck` 0 issues, `npm run format:check` clean.

Related to #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
