### PR TITLE
build(env): sync the numba cap to 0.66.0 from the canonical core

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,11 +10,11 @@ dependencies:
   - scipy>=1.18.0
   - pandas>=3.0.5
   - pyarrow>=24.0.0 # pandas 3.x's default `str` dtype is Arrow-backed; floor held at 24 by jaxlib's libabseil pin
-  - numba>=0.58,<=0.65.1 # every pytensor 3.x caps numba here (verified through 3.2.3); this is what pymc>=6.2.0 commits us to
+  - numba>=0.58,<=0.66.0 # cap tracks the admitted pytensor: 3.2.4 raised its own cap from <=0.65.1 to <=0.66.0, and pymc>=6.2.0 admits 3.2.4. Does not lift the numpy cap — numba 0.66.0 still pins numpy <2.5
   - matplotlib>=3.11.1
   - scikit-learn>=1.9.0
   - statsmodels>=0.14.6
-  - pymc>=6.2.0 # pulls pytensor + a C toolchain from conda-forge; requires pytensor >=3.2.2,<3.3 -> numba <=0.65.1 -> numpy <2.5
+  - pymc>=6.2.0 # pulls pytensor + a C toolchain from conda-forge; requires pytensor >=3.2.2,<3.3 -> numba <=0.66.0 -> numpy <2.5
   - nutpie>=0.16.11
   - numpyro>=0.21.0
   - jax>=0.10.2 # CPU build; GPU acceleration via an environment-gpu.yml overlay
@@ -41,7 +41,7 @@ dependencies:
       # notebook (ipython/ipywidgets/notebook/jupytext), io (orjson/tabulate).
       # This also pulls dse-research-utils' own runtime deps (azure-identity/
       # -storage-blob, rich, psutil, pyyaml, …) — no need to list them here.
-      - dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.9.0#subdirectory=src/python
+      - dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.9.1#subdirectory=src/python
       - -e ./
       # Local-dev override — to develop against a sibling checkout of research,
       # comment the git line above and uncomment this instead:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "arviz-stats>=1.2.0",
   "arviz>=1.2.0",
   "duckdb>=1.5.5",
-  "dse-research-utils>=0.9.0",
+  "dse-research-utils>=0.9.1",
   # jaxlib is conda-owned but only arrives transitively via jax; environment.yml
   # does not declare it (nothing here imports it directly — it is numpyro's
   # backend). Keep this floor at or below what the conda layer may solve to —
@@ -49,7 +49,7 @@ dev = [
 # dse-research-utils isn't published to PyPI — resolve it from the public git
 # tag. (The conda env in environment.yml installs it from the same tag in its
 # pip layer; this entry is only consumed by uv.)
-dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.9.0" }
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.9.1" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"


### PR DESCRIPTION
> [!NOTE]
> Drafted by a LLM-based AI tool (Claude Code/Opus 5).

Mirrors the canonical core change in dseinternational/research#80: the shared conda-forge core's numba cap moves from `<=0.65.1` to `<=0.66.0`.

## Why

`pytensor-base` 3.2.4 raised its own cap from `numba >=0.58,<=0.65.1` to `>=0.58,<=0.66.0`. pymc 6.2.0 requires `pytensor>=3.2.2,<3.3`, so 3.2.4 is admitted and numba 0.66.0 becomes reachable. The old comment ("every pytensor 3.x caps numba here (verified through 3.2.3)") no longer holds for 3.2.4.

`numpy>=2.4.6,<2.5` is deliberately unchanged — numba 0.66.0 still pins `numpy <2.5`.

## Changes

- `environment.yml` — numba cap to `<=0.66.0`, refreshed numba/pymc comments, `dse-research-utils` git pin to `v0.9.1`.
- `pyproject.toml` — `dse-research-utils>=0.9.1` and the `[tool.uv.sources]` tag to `v0.9.1`.

## ⚠️ Merge order

CI will fail until the upstream tag exists. `dse-check-env` validates `environment.yml` against the core bundled in the **installed** `dse-research-utils`, so this PR is only valid against `v0.9.1`:

1. Merge dseinternational/research#80.
2. Tag `v0.9.1` on `research`'s `main`.
3. Re-run CI here.

Verified locally against the updated core: `dse-check-env environment.yml` passes.
