### PR TITLE
ci(dependabot): ignore numpy 2.5+ so the ceiling is not widened

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
       python-dependencies:
         patterns:
           - "*"
+    ignore:
+      # numpy 2.5 is unreachable for anything depending on pymc: pytensor 3.2.x
+      # pins numba <=0.66.0, and numba 0.66.0 still pins numpy <2.5. The ceiling
+      # in pyproject.toml mirrors the shared conda core; raising it only declares
+      # a range no resolver can use. Remove once numba supports numpy 2.5.
+      - dependency-name: "numpy"
+        versions: [">=2.5.0"]
     assignees:
       - frankbuckley
 


### PR DESCRIPTION
> [!NOTE]
> Drafted by a LLM-based AI tool (Claude Code/Opus 5).

Adds a pip-ecosystem `ignore` rule for numpy 2.5+, so the deliberate `numpy>=2.4.6,<2.5` ceiling in `pyproject.toml` is not widened by a daily run.

## Why

That ceiling is not a stale floor — it mirrors the shared conda core and reflects a real constraint:

| package | constraint |
| --- | --- |
| `pytensor` 3.2.4 | `numba<=0.66.0,>=0.58` |
| `numba` 0.66.0 | `numpy<2.5,>=1.22` |

numpy 2.5 is therefore unreachable for anything depending on pymc, and a wider ceiling only declares a range no resolver can use.

Nothing currently prevents dependabot proposing that widening. It did exactly that in dseinternational/language-reading-predictors#467, which carries the identical ceiling — merged at 05:45 today and now being reverted in dseinternational/language-reading-predictors#469. This repo is exposed to the same bump.

An equivalent rule used to exist upstream on the conda ecosystem and was dropped along with it in dseinternational/research@f8d3c4f; the pip ecosystem never had one.

## Scope

Config only — no dependency or source changes. The comment records why the ceiling exists and the condition for removing the rule (numba supporting numpy 2.5).
