### PR TITLE
build(env): declare polars from the canonical core

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - matplotlib>=3.11.1
   - scikit-learn>=1.9.0
   - statsmodels>=0.14.6
+  - polars>=1.43.2 # canonical core (not used by this repo, but the core is a single lockstep spec)
   - pymc>=6.2.0 # pulls pytensor + a C toolchain from conda-forge; requires pytensor >=3.2.2,<3.3 -> numba <=0.66.0 -> numpy <2.5
   - nutpie>=0.16.11
   - numpyro>=0.21.0
@@ -41,7 +42,7 @@ dependencies:
       # notebook (ipython/ipywidgets/notebook/jupytext), io (orjson/tabulate).
       # This also pulls dse-research-utils' own runtime deps (azure-identity/
       # -storage-blob, rich, psutil, pyyaml, …) — no need to list them here.
-      - dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.9.1#subdirectory=src/python
+      - dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.9.2#subdirectory=src/python
       - -e ./
       # Local-dev override — to develop against a sibling checkout of research,
       # comment the git line above and uncomment this instead:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "arviz-stats>=1.2.0",
   "arviz>=1.2.0",
   "duckdb>=1.5.5",
-  "dse-research-utils>=0.9.1",
+  "dse-research-utils>=0.9.2",
   # jaxlib is conda-owned but only arrives transitively via jax; environment.yml
   # does not declare it (nothing here imports it directly — it is numpyro's
   # backend). Keep this floor at or below what the conda layer may solve to —
@@ -49,7 +49,7 @@ dev = [
 # dse-research-utils isn't published to PyPI — resolve it from the public git
 # tag. (The conda env in environment.yml installs it from the same tag in its
 # pip layer; this entry is only consumed by uv.)
-dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.9.1" }
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.9.2" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"


### PR DESCRIPTION
> [!NOTE]
> Drafted by a LLM-based AI tool (Claude Code/Opus 5).

Adds `polars>=1.43.2` to `environment.yml`, following its promotion into the shared conda core in dseinternational/research#82.

## Note: this repo does not use polars

There are no `import polars` sites here. It is declared because `dse-check-env` treats a missing core package as drift — the core is a single lockstep spec, not an à-la-carte list — so without this line CI fails with:

```
missing core package 'polars' (canonical: polars>=1.43.2)
```

That trade-off was made deliberately upstream: polars had drifted to two different floors across repos because nothing validated it. The cost is that this environment gains a compiled dependency it does not import.

## Changes

- `environment.yml` — `polars>=1.43.2` in the core block, and the `dse-research-utils` git pin to `v0.9.2`.
- `pyproject.toml` — `dse-research-utils>=0.9.2` and the `[tool.uv.sources]` tag to `v0.9.2`.

## ⚠️ Merge order

`dse-check-env` validates against the core bundled in the **installed** `dse-research-utils`, so this needs `v0.9.2` to exist:

1. Merge dseinternational/research#82.
2. Tag `v0.9.2` on `research`'s `main`.
3. Re-run CI here.

Verified locally against the updated core: `dse-check-env environment.yml` passes.

## Related

#197 (the dependabot numpy ignore) is still open and independent of this PR.
