### PR TITLE
fix(render): pin QUARTO_PYTHON to the fitting interpreter

### DIFF
--- a/docs/runbooks/full-refit.md
+++ b/docs/runbooks/full-refit.md
@@ -1,7 +1,7 @@
 # Runbook: full reporting-config refit of all models
 
 > [!NOTE]
-> Drafted by LLM-based AI tools (Claude Code/Opus 4.8 and OpenAI Codex/GPT-5).
+> Drafted by LLM-based AI tools (Claude Code/Opus 4.8 and OpenAI Codex/GPT-5; the Quarto kernel-resolution section by Claude Code/Opus 5).
 
 How to refit the whole `VG01`–`VG16` family at reporting quality (`rep`) on a
 large VM, render every report, and produce comparisons — with the pitfalls that a
@@ -20,7 +20,7 @@ naive run hits. Distilled from the 2026-07-12 run
 
 ## 0. Prerequisites
 
-- Conda env `dse-vocab-growth` active; `dse-check-env environment.yml` clean.
+- Conda env `dse-vocab-growth` active; `dse-check-env environment.yml` clean. Activation matters for **rendering**, not only fitting — read [Rendering without an activated environment](#rendering-without-an-activated-environment) first if you drive the scripts by absolute interpreter path instead.
 - **`dse-research-utils >= v0.6.0`** — earlier versions' convergence gate rounds
   R-hat/ESS to 2 significant figures and can certify a fit that truly fails the
   ≤1.01 gate (research#65). A banner reading exactly `max R-hat = 1.0` is the
@@ -184,6 +184,12 @@ scratch `--output-dir`) makes quarto exit non-zero on the `code-links: [repo]`
 post-processor ("not a GitHub project") — the HTML is still produced and complete;
 it just lacks the repo source-link button. It's clean when output lives under the
 in-repo `output/`.
+
+### Rendering without an activated environment
+
+Quarto resolves the Jupyter kernel for a report's python cells from `PATH`, independently of the interpreter running the fit. Driving the scripts by absolute interpreter path (`~/miniconda3/envs/dse-vocab-growth/bin/python scripts/fit_model.py …`) without also putting that `bin/` on `PATH` therefore renders against whichever `python` `PATH` finds — on macOS the system framework python, which has no `h5netcdf` and cannot open `trace.nc`. The tell-tale is a fit that samples, gates, and promotes normally, followed by `ModuleNotFoundError: No module named 'h5netcdf'` from the render (2026-08-03 `test`-config refit: fifteen clean fits, fifteen failed renders, all recovered with `--render-only`).
+
+`fit_model.py` pins `QUARTO_PYTHON` to its own `sys.executable`, so per-model reports are immune. The two `quarto render` calls above are bare shell invocations and are not: either activate the env, or `export QUARTO_PYTHON=/Users/…/envs/dse-vocab-growth/bin/python` before rendering the books. `run_replication.sh` activates the env itself and needs neither.
 
 ## 4. Completion checklist
 

--- a/scripts/fit_model.py
+++ b/scripts/fit_model.py
@@ -60,7 +60,12 @@ def _render_output(output_dir: str) -> None:
     qmd_path = os.path.join(output_dir, "index.qmd")
     if not os.path.isfile(qmd_path):
         raise FileNotFoundError(f"Quarto source is missing: {qmd_path}")
-    subprocess.run(["quarto", "render", qmd_path], check=True)
+    # Quarto otherwise resolves the Jupyter kernel for the report's python cells
+    # from PATH, which is not this interpreter when the environment's python was
+    # invoked by absolute path without activation. The report then renders against
+    # whichever python PATH finds and cannot open the trace this fit just wrote.
+    render_env = {**os.environ, "QUARTO_PYTHON": sys.executable}
+    subprocess.run(["quarto", "render", qmd_path], check=True, env=render_env)
     if not os.path.isfile(os.path.join(output_dir, "index.html")):
         raise RuntimeError("Quarto render completed without producing index.html.")
 

--- a/tests/test_fit_model_batch.py
+++ b/tests/test_fit_model_batch.py
@@ -67,3 +67,27 @@ def test_batch_render_continues_after_one_model_fails(monkeypatch):
     assert calls == ["/first", "/bad", "/last"]
     assert set(timings) == {"first", "bad", "last"}
     assert failures == {"bad": "RuntimeError: quarto failed"}
+
+
+def test_render_pins_quarto_python_to_the_fitting_interpreter(monkeypatch, tmp_path):
+    (tmp_path / "index.qmd").write_text("")
+    (tmp_path / "index.html").write_text("")
+    captured: dict[str, object] = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["env"] = kwargs["env"]
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(_MODULE.subprocess, "run", fake_run)
+    monkeypatch.setenv("QUARTO_PYTHON", "/usr/bin/python3")
+    monkeypatch.setenv("DSE_RENDER_ENV_SENTINEL", "inherited")
+
+    _MODULE._render_output(str(tmp_path))
+
+    assert captured["command"] == ["quarto", "render", str(tmp_path / "index.qmd")]
+    env = captured["env"]
+    # An inherited QUARTO_PYTHON is the failure mode, not an override to respect:
+    # the report must be rendered by the interpreter that produced the fit.
+    assert env["QUARTO_PYTHON"] == sys.executable
+    assert env["DSE_RENDER_ENV_SENTINEL"] == "inherited"


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

## What changed

`_render_output` in `scripts/fit_model.py` now passes an explicit environment to `quarto render` with `QUARTO_PYTHON` pinned to `sys.executable`, so a model report is always rendered by the same interpreter that produced the fit.

## Why

`_render_output` inherited the parent environment, and Quarto resolves the Jupyter kernel for a report's python cells from `PATH` — independently of the interpreter running the fit. Invoking the environment's python by absolute path (`~/miniconda3/envs/dse-vocab-growth/bin/python scripts/fit_model.py …`) without also putting that `bin/` on `PATH` therefore rendered against whichever `python` `PATH` found: on macOS the system framework python, which has no `h5netcdf` and cannot open the `.nc` trace the report cells load.

The failure is quiet in a misleading way. The fit samples, passes the convergence gate, and atomically promotes normally; only the render fails, with `ModuleNotFoundError: No module named 'h5netcdf'`. This bit the 2026-08-03 `test`-config refit: all fifteen fits were clean and every one of the fifteen renders failed, needing a separate `--render-only` pass.

## Verification

Beyond the test suite, the mechanism was checked against a minimal `.qmd` whose only python cell does `import h5netcdf`, rendered twice with an identical `PATH` that resolves `python` to the system framework interpreter:

- **without** `QUARTO_PYTHON` → `ModuleNotFoundError: No module named 'h5netcdf'`, reproducing the reported error exactly;
- **with** `QUARTO_PYTHON` → `rendered by: /Users/…/envs/dse-vocab-growth/bin/python`, `h5netcdf: 1.8.1`.

So `QUARTO_PYTHON` is the right knob and Quarto 1.9.36 honours it over `PATH`. Incidentally, the framework python *does* have `jupyter_client`, which is why Quarto gets far enough to start a kernel and fail on the import rather than refusing outright.

Full suite passes (440 tests); `ruff check src/ scripts/`, `npm run format:check`, and `npm run spellcheck` are clean.

## Notes for a reviewer

**An inherited `QUARTO_PYTHON` is replaced, not respected.** That is deliberate and the new test pins it: deferring to an inherited value is the failure mode being fixed, and if the inherited value already points at the right environment then `sys.executable` is the same path anyway.

**Other `quarto render` call sites were audited; only this one needed changing.**

- `scripts/fit_sensitivity.py` never shells out to Quarto at all (no `subprocess` import) — rendering is not part of its pipeline.
- `scripts/run_replication.sh` runs two bare `quarto render` calls, but it activates the conda environment itself whenever `CONDA_PREFIX` does not already match, so its `PATH` is correct by construction.
- The remaining mentions in `src/vocab_growth/models/common.py` are console hint strings, not invocations.

**One residual exposure is documented rather than fixed in code.** The manual `quarto render docs/report` and `quarto render docs/comparison/index.qmd` steps in the refit runbook are bare shell invocations, and `docs/report/_quarto.yml` sets `jupyter: python3`, so they resolve from `PATH` and no change to `fit_model.py` can reach them. `docs/runbooks/full-refit.md` gains a **Rendering without an activated environment** section recording the mechanism, the 2026-08-03 incident as the tell-tale, which invocations are now immune, and the `export QUARTO_PYTHON=…` workaround for the two book renders. Prerequisites §0 cross-links it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
