### PR TITLE
Contrast between-child heterogeneity, not just residual dispersion

### DIFF
--- a/docs/comparison/index.qmd
+++ b/docs/comparison/index.qmd
@@ -292,11 +292,33 @@ vocabulary explodes. (Understood is identified only to ~25 mo on TD support.)
 
 ## Between-child variability
 
-Beyond the mean, how does the _spread_ between children compare? Two quantities:
-the implied per-child word-count SD $\sigma_Y$ (absolute spread, which scales with
-the mean), and the mean-independent overdispersion factor $\varphi$ (pure
-concentration). The ratio $\varphi_{TD}/\varphi_{DS}$ > 1 means TD is more
-overdispersed at that age.
+Beyond the mean, how does the _spread_ between children compare? Both comparators
+carry study **and** child random effects, which splits the question in two, and the
+halves have to be read separately:
+
+- **Between-child heterogeneity** — how far children of the same age sit from one
+  another — lives in the subject random-effect scale $\tau$. This is the quantity
+  that answers "are children in this population more alike?", and it is reported in
+  @sec-between-child below.
+- **Residual dispersion** — what the Beta-Binomial layer still has to absorb once
+  the study and child effects have taken their share — lives in $\kappa$ and the
+  quantities derived from it, $\sigma_Y$ and $\varphi$. That is this section.
+
+Treating the second as if it were the first is the standard trap here, and in the
+TD models it is a specific one: $\tau_{subject}$ and $\kappa$ are an explicit
+reparameterisation of a *single* logit-scale scatter budget (see
+`models.gp_utils.build_variance_partition`), so reading either alone silently
+attributes the whole budget to whichever half is in view.
+
+Two derived quantities: the implied per-child word-count SD $\sigma_Y$ (absolute
+spread, which scales with the mean) and the overdispersion factor $\varphi =
+(\kappa + n)/(\kappa + 1)$, the variance inflation over a Binomial at the same
+mean. $\varphi$ removes the explicit $p(1-p)$ term that $\sigma_Y$ carries, but it
+is **not** mean-independent: $\kappa$ is itself level-driven in this family, so a
+cross-population contrast still carries part of the difference in where the two
+populations sit. A ratio $\varphi_{TD}/\varphi_{DS} > 1$ means TD counts are the
+more overdispersed *given the model's fitted means*, not that TD children vary
+more.
 
 ```{python}
 ds_s = pd.read_csv("ds_td_spoken_re_dispersion.csv")
@@ -319,8 +341,9 @@ pd.DataFrame(rows).set_index("Age (mo)")
 Two distinct stories:
 
 - **Comprehension:** the overdispersion factor is comparable across groups at all
-  ages (φ_TD/φ_DS ≈ 1); TD's larger _absolute_ spread σ_Y is essentially a
-  consequence of its larger mean. Relative between-child heterogeneity is similar.
+  ages (φ_TD/φ_DS ≈ 1) — the residual the Beta-Binomial layer carries is of similar
+  relative size in both. TD's larger _absolute_ spread σ_Y is essentially a
+  consequence of its larger mean.
 - **Production:** early DS spoken counts are slightly _more_ overdispersed than TD
   (φ_TD/φ_DS < 1 in the first months), but the ordering **reverses during the
   second year**: as TD production explodes its absolute spread balloons (σ_Y ~5 →
@@ -328,13 +351,76 @@ Two distinct stories:
   TD becomes the more overdispersed group. DS production is not just lower — it is
   also far less variable in absolute terms across the overlap.
 
+Read the second bullet with the floor in mind. At 8 months almost every TD child
+produces no words at all, so TD counts are near-Binomial there and φ is close to
+its lower limit; that is a floor, not a population of unusually similar children.
+The same mechanism compresses DS production across the whole overlap window.
+
 ![Between-child spread σ_Y — spoken](ds_td_spoken_re_spread.png){#fig-sd-s .lightbox fig-align="left"}
 
-![Concentration (overdispersion φ, study-RE only) — spoken](ds_td_spoken_re_overdispersion.png){#fig-phi-s .lightbox fig-align="left"}
+![Residual overdispersion φ (study + subject REs) — spoken](ds_td_spoken_re_overdispersion.png){#fig-phi-s .lightbox fig-align="left"}
 
 ![Between-child spread σ_Y — understood](ds_td_understood_re_spread.png){#fig-sd-u .lightbox fig-align="left"}
 
-![Concentration (overdispersion φ, study-RE only) — understood](ds_td_understood_re_overdispersion.png){#fig-phi-u .lightbox fig-align="left"}
+![Residual overdispersion φ (study + subject REs) — understood](ds_td_understood_re_overdispersion.png){#fig-phi-u .lightbox fig-align="left"}
+
+## Between-child heterogeneity {#sec-between-child}
+
+The contrast the previous section cannot make. $\tau$ is the SD, across children of
+the same age, of the child's own logit for this outcome — the population-relative
+measure of how much children differ — and $\sigma_{child}$ is the spread in
+expected words it induces, which is what a clinician would see. $\sigma_{child}$
+counts only persistent between-child differences: unlike $\sigma_Y$ it excludes
+the Beta-Binomial noise.
+
+$\tau$ is a parameter on the TD side (`tau_subject`, constant in age) but a
+*derived* quantity on the DS side. VG10 places its child effects on understood
+(`tau_subj_u`) and on the production ratio (`tau_subj_q`), with spoken built as
+$p_S = p_U \cdot q$, so it has no spoken child scale to read off, and the induced
+spoken $\tau$ varies with age even though both underlying scales are constants.
+Contrasting `tau_subj_q` against `tau_subject` directly would set the spread of a
+*conversion ratio* against the spread of a *level*; the derivation in
+`comparison.subject_heterogeneity` avoids that.
+
+```{python}
+he_s = pd.read_csv("ds_td_spoken_re_subject_heterogeneity.csv")
+he_u = pd.read_csv("ds_td_understood_re_subject_heterogeneity.csv")
+rows = []
+for a in [8, 12, 18, 24]:
+    rs, ru = _nearest(he_s, "age_months", a), _nearest(he_u, "age_months", a)
+    rows.append({
+        "Age (mo)": a,
+        "Spoken τ TD": f"{rs['tau_TD_median']:.2f}",
+        "Spoken τ DS": f"{rs['tau_DS_median']:.2f}",
+        "Spoken τ TD/DS": f"{rs['tau_ratio_median']:.2f}",
+        "Spoken σ_child TD": f"{rs['sdchild_TD_median']:.0f}",
+        "Spoken σ_child DS": f"{rs['sdchild_DS_median']:.0f}",
+        "Understood τ TD": f"{ru['tau_TD_median']:.2f}",
+        "Understood τ DS": f"{ru['tau_DS_median']:.2f}",
+        "Understood τ TD/DS": f"{ru['tau_ratio_median']:.2f}",
+    })
+pd.DataFrame(rows).set_index("Age (mo)")
+```
+
+![Between-child heterogeneity τ — spoken](ds_td_spoken_re_subject_tau.png){#fig-tau-s .lightbox fig-align="left"}
+
+![Between-child spread in expected words σ_child — spoken](ds_td_spoken_re_subject_spread.png){#fig-sdc-s .lightbox fig-align="left"}
+
+![Between-child heterogeneity τ — understood](ds_td_understood_re_subject_tau.png){#fig-tau-u .lightbox fig-align="left"}
+
+![Between-child spread in expected words σ_child — understood](ds_td_understood_re_subject_spread.png){#fig-sdc-u .lightbox fig-align="left"}
+
+Two caveats bound how far this contrast can be pushed. First, the priors are not
+symmetric: on the TD side $\tau_{subject}$ and $\kappa$ are sampled through the
+shared-budget reparameterisation, with an informative prior on how the budget
+splits, while on the DS side they are two free scales — so part of any $\tau$
+difference is a difference in prior structure, and the TD pool averages 1.21
+observations per child, which is what made that reparameterisation necessary in
+the first place. Second, $\tau$ is matched on *age*. At matched age the DS group
+sits near a floor where any spread measure is mechanically small, so a like-for-like
+reading of "are these children more alike" also wants the comparison at matched
+vocabulary level — which is what the attainment-delay and matched-comprehension
+sections provide.
 
 ## Sign-inclusive expressive gap
 
@@ -372,8 +458,10 @@ DS early vocabulary is best described as a **developmental stretch with a
 production-specific deficit**: comprehension is delayed and the delay widens with
 level; production is delayed _substantially more_ (~12–17 extra months at matched
 low vocabulary size, P > 0 ≈ 1.00), peaks several years later, and leaves ~90% of
-2-year-old children below the TD 10th centile for spoken words. Between-child
-_relative_ variability is comparable for comprehension but production stays
-compressed near the floor across the overlap. Signing partially — not wholly —
-compensates in the early years. Every headline here is recovered from the disjoint
+2-year-old children below the TD 10th centile for spoken words. Residual
+Beta-Binomial dispersion is comparable for comprehension, while DS production
+stays compressed near the floor across the overlap; how much children within each
+population differ from one another is a separate question, answered by $\tau$ in
+@sec-between-child rather than by anything in the dispersion section. Signing
+partially — not wholly — compensates in the early years. Every headline here is recovered from the disjoint
 fits with exact intervals, with no joint model required.

--- a/docs/comparison/index.qmd
+++ b/docs/comparison/index.qmd
@@ -410,6 +410,13 @@ pd.DataFrame(rows).set_index("Age (mo)")
 
 ![Between-child spread in expected words σ_child — understood](ds_td_understood_re_subject_spread.png){#fig-sdc-u .lightbox fig-align="left"}
 
+**The two scales disagree, and the relative one reverses the absolute reading.**
+Children with Down syndrome differ from one another _more_ than typically developing children do, on both outcomes and at every age in the overlap, with posterior probability ≈ 1.00. For spoken words τ_DS runs 1.44 at 8 months to 1.27 at 30, against a constant τ_TD of 1.04 (ratio 0.72 rising to 0.82); for comprehension τ_DS is 0.79 against τ_TD 0.69 (ratio 0.87). Yet σ_child in words runs the other way by a wide margin — 173 words TD against 36 DS for spoken at 30 months — because the typically developing group sits at a far higher level, and the same relative spread around a larger mean is a larger absolute spread.
+
+Both statements describe the same posterior. Which one answers "are these children more alike?" depends on what is being asked: on the population-relative scale Down syndrome vocabulary is the _more_ variable of the two, while in absolute word counts it is much the less variable. Neither is the reading a glance at the overdispersion panel above would suggest, which is the point of separating the two sections.
+
+The age profiles differ by construction, and are worth reading as a check on the derivation. τ_TD is flat because the univariate models place a single intercept on the outcome's logit; τ_DS for comprehension is flat for the same reason. τ_DS for _spoken_ declines with age even though both of VG10's subject scales are constants, because the spoken logit is reached through $p_U$ and $q$ — that decline is a property of the product form, not a finding about children becoming more alike.
+
 Two caveats bound how far this contrast can be pushed. First, the priors are not
 symmetric: on the TD side $\tau_{subject}$ and $\kappa$ are sampled through the
 shared-budget reparameterisation, with an informative prior on how the budget

--- a/docs/report/glossary.qmd
+++ b/docs/report/glossary.qmd
@@ -22,8 +22,11 @@ Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 **Conditional probability**
 : The probability of one outcome given another. In the joint models, $q(a)=P(\text{spoken}\mid\text{understood},a)$ is the fraction of understood words expected also to be spoken at age $a$.
 
+**Between-child heterogeneity ($\tau$)**
+: The standard deviation, across children of the same age, of a child's own value on the logit scale — how much children within a population differ from one another. It is the scale of the subject random intercept, and it is a different quantity from the concentration $\kappa$: in a model carrying subject random effects, persistent between-child differences are absorbed by $\tau$ and $\kappa$ describes what remains.
+
 **Concentration ($\kappa$)**
-: The Beta-Binomial parameter controlling extra variation around the mean. Larger values approach a Binomial distribution; smaller values allow more dispersion.
+: The Beta-Binomial parameter controlling extra variation around the mean. Larger values approach a Binomial distribution; smaller values allow more dispersion. In models with subject random intercepts it is an observation-level residual, not a measure of how much children differ.
 
 **Credible interval**
 : An interval containing a stated proportion of the posterior probability for a parameter or derived quantity, conditional on the model, priors, and data.
@@ -63,6 +66,9 @@ Drafted by an LLM-based AI tool (OpenAI Codex/GPT-5).
 
 **NUTS (No-U-Turn Sampler)**
 : The adaptive Hamiltonian Monte Carlo algorithm used to explore each model's posterior distribution. The project runs NUTS through PyMC with the nutpie sampler.
+
+**Overdispersion factor ($\varphi$)**
+: How much more variable a Beta-Binomial outcome is than a Binomial one with the same mean, equal to $(\kappa + n)/(\kappa + 1)$ for a checklist of $n$ items. It removes the explicit $p(1-p)$ term but is not mean-independent, because $\kappa$ itself moves with the level; comparing it across populations at different vocabulary levels therefore still carries part of that level difference.
 
 **Posterior distribution**
 : The probability distribution for parameters or derived quantities after combining the prior and likelihood for the observed data.

--- a/notes/202608081445-trace-persistence-tiers.md
+++ b/notes/202608081445-trace-persistence-tiers.md
@@ -1,0 +1,145 @@
+# Trace persistence tiers: cutting artifact size without touching inference
+
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 5).
+
+## 1. Why now
+
+A full reporting output tree is ~257 GB, and ~256 GB of that is `.nc` traces: the figures, tables, diagnostics and rendered HTML together come to ~0.65 GB (1,251 PNG + 1,188 SVG + 546 CSV + assets). Individual rep traces run to VG11 53.6 GB, VG13 40.6 GB, VG12 21.3 GB, VG10 9.8 GB. This is not merely inconvenient: VG12's recovery replicate r08 died with `ENOSPC` on the VM's `/scratch` on 2026-08-06 partway through writing its own trace, and re-downloading the tree on 2026-08-08 took a 926 GB workstation to 94% full.
+
+The alternative lever — subsampling the typically-developing pool — was considered and rejected in [`202608050900-td-hierarchical-geometry.md`](202608050900-td-hierarchical-geometry.md) §10. Within-child replication is the binding constraint on the TD hierarchical geometry, and any subsampling removes repeat-measured children; a row-wise draw reproduces the pathology outright. That note set the order of resort: plain `rep` alone; then stop storing the observation-sized deterministics, which are recomputable functions of the parameters and cost nothing statistically; and only then subsample. This note scopes the middle step.
+
+## 2. What is actually in a trace
+
+Measured directly from two completed reporting traces (`h5py`, uncompressed sizes).
+
+**VG03** (TD spoken, no random effects) — 10.94 GB on disk, 4,075 observations, 6 chains × 6,000 draws:
+
+| GB   | shape           | variable                         | class                                 |
+| ---- | --------------- | -------------------------------- | ------------------------------------- |
+| 1.23 | (6, 6000, 4583) | `f_all`                          | concatenated obs+plot+query predictor |
+| 1.23 | (6, 6000, 4583) | `g`                              | GP, derived                           |
+| 1.23 | (6, 6000, 4583) | `g_unit`                         | GP, raw                               |
+| 1.09 | (6, 6000, 4075) | `f_obs`                          | obs deterministic                     |
+| 1.09 | (6, 6000, 4075) | `kappa_obs`                      | obs deterministic                     |
+| 1.09 | (6, 6000, 4075) | `p_obs`                          | obs deterministic                     |
+| 1.09 | (6, 6000, 4075) | `posterior_predictive/y_obs`     | predictive                            |
+| 1.09 | (6, 6000, 4075) | `log_likelihood/y_obs`           | likelihood                            |
+| ~0.1 | —               | free parameters + `sample_stats` | **irreplaceable**                     |
+
+**VG15** (DS joint sign+speech, subject REs on three trajectories) — 6.24 GB, 1,349 observations, 737 subjects:
+
+| GB    | shape               | variable                                            | class                                      |
+| ----- | ------------------- | --------------------------------------------------- | ------------------------------------------ |
+| 1.50  | (6, 6000, 1864)     | `g_unit_u`, `g_unit_q`, `g_unit_sign`               | GP, raw                                    |
+| 0.72  | (6, 6000, 1349)     | `kappa_sign_obs`, `z_obs`                           | obs deterministic                          |
+| 1.20  | (6, 6000, 737)      | `delta_subj_{u,q,sign}` **and** `z_subj_{u,q,sign}` | subject RE, **scaled and raw both stored** |
+| 1.12  | (6, 6000, 905/1179) | `log_likelihood` + `posterior_predictive`           |                                            |
+| 0.101 | —                   | everything under 0.02 GB, i.e. the free parameters  | **irreplaceable**                          |
+
+Three conclusions:
+
+1. **The parameters are a rounding error.** ~0.1 GB in both models. Everything else is a deterministic function of them evaluated at observation, grid, or subject index.
+2. **Subject-sized arrays matter too, and are stored twice.** `delta_subj_u = tau_subj_u * z_subj_u` is persisted alongside `z_subj_u`. That is the same information twice, 1.20 GB on a model with only 737 children. VG11 has 1,947 repeatedly-measured children out of a much larger pool across 18,522 observations, so its subject-sized block will be far bigger — VG03 has no random effects and therefore understates the VG11 profile.
+3. **VG03 is the cheap case.** It is a no-RE model at 4,075 observations. VG11 is 18,522 observations with subject REs, which is most of why it is 53.6 GB.
+
+## 3. Consumer audit
+
+Who actually reads these variables back off disk, checked across `src/`, `scripts/` and `docs/`:
+
+| Consumer                             | Reads                                                                                   | Affected?                                               |
+| ------------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `docs/models/*/index.qmd`            | `chain`/`draw` **dimension sizes only**, via `h5netcdf` header                          | No                                                      |
+| `vocab_growth.comparison`            | plot-grid vars (`p_plot`, `f_plot`, `kappa_plot`, `f_u_plot`, `h_plot`) + scalar scales | No                                                      |
+| `recovery/simulate.py`               | free RV names                                                                           | No                                                      |
+| `fit_artifacts.validate_fit`         | existence of `trace.nc` only — no variable-level checks                                 | No                                                      |
+| `scripts/kfold_loso.py`              | `p_u_obs`, `p_s_obs`, `q_obs`                                                           | **Yes**                                                 |
+| `scripts/loso_compare.py`            | `f_u_obs`, `h_obs`                                                                      | **Yes**                                                 |
+| `extract_model_samples` (in-process) | `f_obs`, `f_plot`                                                                       | No — reads the in-memory trace, and runs after the save |
+
+So exactly two post-hoc consumers depend on observation-sized posterior variables, both cross-validation tools. Everything on the reporting path — render, comparison, recovery, validation — is indifferent.
+
+Note that the newly added between-child estimand (`comparison.subject_heterogeneity`) reads only the scalar subject scales `tau_subject` / `tau_subj_u` / `tau_subj_q`, never the per-child arrays. The heterogeneity contrast is therefore compatible with dropping `delta_subj_*` entirely.
+
+## 4. Design
+
+**Tiers**, selected at fit time, applied only at save:
+
+- `full` — today's behaviour. Default initially.
+- `compact` — drop observation-sized posterior deterministics and the redundant scaled random effects. Keeps `log_likelihood` and `posterior_predictive`.
+- `minimal` — additionally drop `log_likelihood` and `posterior_predictive/y_*_obs`.
+
+Expected effect on VG03: `compact` ≈ 10.9 → 3.9 GB (−64%), `minimal` ≈ 1.7 GB (−84%). On VG11, proportionally more, because its obs and subject blocks dominate a larger share.
+
+**Select by dimension, not by name.** A hardcoded name list would need maintaining across six engine modules and every future model. The rule should be: drop posterior variables whose dims intersect `{obs_id}`, plus the concatenated `*_all` grids, plus scaled random-effect deterministics whose raw counterpart and scale are both retained. Keep an explicit allowlist for anything grid-shaped (`*_plot`, `*_query`) that the reporting path needs. Dimension-based selection is robust to new models in a way a name list is not.
+
+**Where the setting lives — not in the model definition.** This is the one design point that must not be got wrong. `ModelDefinition` fields are part of the model graph and its fingerprint: `td_languages` is documented as a definition field precisely because changing it requires a refit. Trace persistence changes nothing about the posterior, so putting it in the definition would invalidate every fitted model for a storage decision. It belongs on the CLI (`fit_model.py --trace-persistence=`) with an environment-variable default, alongside `--output-dir`, and must be excluded from the fingerprint.
+
+**Record it in the manifest.** `fit_manifest.json` should carry the tier and the list of dropped variable names, so a later reader can tell "absent by policy" from "corrupt or truncated trace" — the failure mode we have already seen once this week.
+
+## 5. Risks and guardrails
+
+- **The two LOSO scripts must fail loudly.** On a compacted trace they would currently raise a bare `KeyError` on `p_u_obs`. They need an explicit check that reads the manifest tier and says "this fit was saved at `compact`; refit at `full` to run leave-one-study-out".
+- **`log_likelihood` and `posterior_predictive` are a genuine trade, unlike the deterministics.** LOO and the PPC plots are computed during the fit and their outputs persisted as CSVs and figures, so `minimal` costs nothing for the _current_ report — but it forecloses recomputing LOO, running new model comparison, or plotting a new predictive view without a refit. `compact` is free; `minimal` is a decision.
+- **Dropping `delta_subj_*` forecloses per-child prediction.** The reported estimands (τ, and the derived σ_child) need only the scales. Anything wanting a specific child's intercept would need `full`.
+- **Do not mutate the in-memory trace.** Later pipeline stages — `extract_model_samples` reads `f_obs` — run against `context.trace` after the save call. The filter must build a copy.
+- **Compression is a separate, orthogonal lever.** These are stored uncompressed; netCDF4/HDF5 chunked deflate on the large float arrays is worth measuring independently, and would help `full` too.
+
+## 6. Files touched
+
+- **Prerequisite refactor.** Six modules each call `trace.to_netcdf(...)` directly: `common.py`, `common_bivariate.py`, `common_joint_modality.py`, `common_trivariate.py`, `common_univariate_re.py`, `model_vg17.py`. (`common_bivariate_re.py` reuses `common_bivariate`'s.) These should route through one helper — otherwise the policy has to be repeated six times and will drift.
+- New: the tier enum, the dimension-based filter, and its unit tests.
+- `scripts/fit_model.py`: flag, env-var default, plumbed to the engines.
+- `fit_artifacts.py`: manifest field; keep `validate_fit` indifferent to it.
+- `scripts/kfold_loso.py`, `scripts/loso_compare.py`: tier guard with a clear message.
+- Docs: `CLAUDE.md` / `AGENTS.md` / `.github/copilot-instructions.md` command section, and the full-refit runbook.
+
+Roughly a day, with the shared-save refactor the bulk of it and the highest-risk part, since it touches every engine's fit path.
+
+## 7. Rollout
+
+Ship with `full` as the default so nothing about existing artifacts or reproduction changes. Fit one model at `compact` and one at `minimal`, and confirm byte-for-byte that the reporting path — `--render-only`, `sync_report_figures.py`, the comparison suite — produces identical output to the `full` fit. Flip the default at the next full refit, not before.
+
+## 8. Reducing draws: the other half of `n_draws × n_obs`
+
+Raised 2026-08-08 alongside this note. Trace size is linear in draws, so cutting them shrinks everything — including the ~0.1 GB of parameters that §2 calls irreplaceable — and speeds every downstream load. Unlike §4 it is not free: it costs precision in every reported interval. The question is whether there is headroom.
+
+**There is, but it is thin, and it is thinnest where it would help most.** Effective sample sizes at the current `rep` (6 chains × 6,000 = 36,000 draws), from each model's `diagnostics.csv`:
+
+| model    | worst `ess_bulk` | worst `ess_tail` | efficiency | worst parameters                |
+| -------- | ---------------- | ---------------- | ---------- | ------------------------------- |
+| **VG11** | **1,008**        | 1,718            | **2.8%**   | `eta`, `ell_unit`, `ell`        |
+| VG13     | 1,432            | 2,556            | 4.0%       | `tau_u`, `tau_q`                |
+| VG10     | 2,819            | 2,456            | 7.8%       | `kappa_min_s`, `a_kappa_s`      |
+| VG12     | 2,901            | 4,504            | 8.1%       | `eta`, `subject_variance_share` |
+
+Nothing sits below 400. But the binding constraint is VG11's GP hyperparameters at 2.8% efficiency, and VG11 is the 53.6 GB trace — the model most worth shrinking has the least room to shrink. Scaling ESS roughly linearly in draws:
+
+| config            | draws  | VG11 worst `ess_bulk` | verdict          |
+| ----------------- | ------ | --------------------- | ---------------- |
+| `rep` 6×6000      | 36,000 | 1,008                 | current          |
+| 6×4000            | 24,000 | ~672                  | comfortable      |
+| 6×3000            | 18,000 | ~504                  | marginal         |
+| `rep-lite` 4×4000 | 16,000 | ~448                  | at the 400 floor |
+| 6×1500            | 9,000  | ~252                  | below the floor  |
+
+**The sensitivity test is nearly free, and it is exact rather than approximate.** Truncating each chain to its first _N_ post-warmup draws reproduces exactly what a shorter sampling run would have produced: post-warmup NUTS draws are a deterministic function of the RNG stream, so holding warmup and adaptation fixed and cutting sampling iterations does not change the first _N_. What 6×3000 would have given is already sitting in the existing traces. This is a stronger guarantee than a refit-and-compare, which would confound the draw count with a different random seed.
+
+Note the contrast with thinning by stride: taking every _k_-th draw estimates the information content of a thinned chain, which is **not** what a shorter run produces. Truncation is the correct operation here, and the exactness depends on it.
+
+The test:
+
+1. For each model and each candidate _N_, truncate chains to the first _N_ draws.
+2. Re-run the existing convergence gate — R-hat, ESS bulk/tail, divergences, energy BFMI. Does it still pass?
+3. Recompute every reported estimand and every DS/TD contrast; compare against the full-draw values relative to MCSE and to reported interval width.
+4. Report the smallest _N_ at which all models clear the gate and no headline moves by more than a stated fraction of its interval.
+
+No sampling at all. The cost is I/O — reading the traces once — plus perhaps half a day to write it against the existing diagnostics code, and it should reuse the gate rather than reimplement it.
+
+**The one caveat, and it is the whole caveat.** Exactness holds only if warmup is unchanged. If a shorter configuration would also shorten warmup, adaptation differs and truncation no longer simulates it; that variant needs a genuine refit to confirm. Any recommendation coming out of this test should therefore state the warmup it assumes.
+
+**Order of resort.** For both stated goals — smaller artifacts and faster analysis — draws is the weaker lever. On VG11, 6×4000 gives 53.6 → ~36 GB while §4's `compact` gives roughly 10 GB, because the deterministics dominate. The persistence change is free and dominates on both axes; draws costs precision in every interval. Take §4 first, and treat draws as a separate decision on its own evidence. The two compose: 6×4000 plus `compact` is roughly −76%.
+
+## 9. What this does not solve
+
+Trace size scales with `n_draws × n_obs`, and §4 changes neither. It buys roughly a 3–6× reduction in stored bytes; it does not make VG11 a small model, and it does not touch the underlying geometry problem that §10 of the hierarchical-geometry note describes. It is a storage fix, deliberately chosen because it is the one lever in this area with **zero statistical cost**.

--- a/notes/202608081445-trace-persistence-tiers.md
+++ b/notes/202608081445-trace-persistence-tiers.md
@@ -136,7 +136,33 @@ The test:
 
 No sampling at all. The cost is I/O — reading the traces once — plus perhaps half a day to write it against the existing diagnostics code, and it should reuse the gate rather than reimplement it.
 
-**The one caveat, and it is the whole caveat.** Exactness holds only if warmup is unchanged. If a shorter configuration would also shorten warmup, adaptation differs and truncation no longer simulates it; that variant needs a genuine refit to confirm. Any recommendation coming out of this test should therefore state the warmup it assumes.
+**The one caveat, and it bites immediately.** Exactness holds only if warmup is unchanged — and **no existing named configuration isolates the draw count.** `tune` scales with `draws` in every one: `dev` 500/500 (2 chains), `test` 2000/2000 (4), `rep` 6000/6000 (6), `rep-lite` 4000/4000 (4). So a `rep` → `rep-lite` comparison changes chains, tuning and draws together, so truncation cannot reproduce it; only a "`rep` tuning, fewer draws" shape can be reproduced that way, and no such config exists today. The test therefore needs one new config shape, and any recommendation from it must state the warmup it assumes. Comparing a genuinely shorter _warmup_ still requires a refit.
+
+### 8.1 Per-model draws, or overrides for a few models?
+
+Raised 2026-08-08: if efficiency varies this much between models, should draws be set per model at each of `dev` / `test` / `rep`, rather than one blanket level?
+
+**Overrides for specific models, yes; a full per-model matrix, no** — and the number should be derived from an ESS target rather than chosen. Against a ~1,000 working target for the worst parameter (2.5× the gate's 400 floor, since 400 is the minimum for R-hat reliability, not for stable 89% interval bounds):
+
+| model    | worst `ess_bulk` at 36,000 | draws for ESS ≈ 1,000 | trace          |
+| -------- | -------------------------- | --------------------- | -------------- |
+| **VG11** | 1,008                      | **~35,700 — no room** | 53.6 GB        |
+| VG13     | 1,432                      | ~25,100 (70%)         | 40.6 → ~28 GB  |
+| VG10     | 2,819                      | ~12,800 (35%)         | 9.8 → ~3.5 GB  |
+| VG12     | 2,901                      | ~12,400 (34%)         | 21.3 → ~7.3 GB |
+
+**It saves least where it matters most.** Equalising ESS takes those four from ~125 GB to ~93 GB, a 26% cut, while VG11 — 43% of the total on its own — is untouched or needs _more_. The worst-mixing model is also the largest. So per-model draws is a defensible way to equalise inferential precision across the model set; it is a weak lever for artifact size, where §4 still dominates.
+
+It is also aimed at the wrong parameter. VG11's 2.8% efficiency is a geometry symptom — the worst movers are `eta`, `ell` and `ell_unit`, the GP hyperparameters — and its 22 divergences, like VG12's and VG13's BFMI failures, point at `target_accept` and `tune` rather than at draw count. If per-model overrides are introduced, those are the parameters more likely to earn one; spending draws instead institutionalises a workaround for something reparameterisation or a tighter length-scale prior should address, exactly as the variance partition was handled.
+
+Four mechanical constraints, all verified against the current code:
+
+1. **The configurations are shared.** They come from `dse_research_utils.statistics.models.sampling` and are used across DSE research repos, so per-model overrides must live in this repository rather than by editing those definitions.
+2. **The model reports would mark every override "approximate".** `docs/models/*/index.qmd` maps `(chains, draws)` to a configuration name, with `(6, 6000)` alone meaning reporting-grade. Any override renders as a bare "N chains × M draws" flagged approximate — which is already why VG08 and VG09, fitted at 6×8000, misreport. The companion change is to read the configuration name from `fit_manifest.json`, which records it, instead of inferring it from trace dimensions.
+3. **Validation has to learn the override too.** `validate_fit_output` compares `expected_sampling_parameters` against the manifest; an override that feeds the fit but not the check makes every overridden fit fail `sync_report_figures.py`.
+4. **Overrides already happen, unmanaged.** VG08 and VG09 at 6×8000 match no named configuration. The question is not whether exceptions exist but whether they are explicit, validated and visible in the report.
+
+Sequence: run the §8 truncation test at fixed `tune = 6000` to establish each model's actual draw requirement; adopt §4 for storage regardless of the outcome; then add overrides only where the test shows a model over- or under-sampled, with manifest-based configuration detection as a prerequisite for the report not to misdescribe them.
 
 **Order of resort.** For both stated goals — smaller artifacts and faster analysis — draws is the weaker lever. On VG11, 6×4000 gives 53.6 → ~36 GB while §4's `compact` gives roughly 10 GB, because the deterministics dominate. The persistence change is free and dominates on both axes; draws costs precision in every interval. Take §4 first, and treat draws as a separate decision on its own evidence. The two compose: 6×4000 plus `compact` is roughly −76%.
 

--- a/notes/202608081530-ds-td-between-child-heterogeneity.md
+++ b/notes/202608081530-ds-td-between-child-heterogeneity.md
@@ -1,0 +1,51 @@
+# Between-child heterogeneity: DS is the more variable population on the relative scale
+
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 5).
+
+## 1. The question and why the existing figures could not answer it
+
+Asked on 2026-08-08, looking at `ds_td_spoken_re_overdispersion`: does the overdispersion panel imply less heterogeneity in the Down syndrome population? The panel shows DS above TD until roughly 24 months and below it thereafter, with TD's φ rising steeply as production explodes.
+
+It does not, and it cannot, for a reason that predates the figure. φ = (κ + n)/(κ + 1) is a function of the Beta-Binomial concentration, and κ is an **observation-level** parameter applied to a `p_obs` that already carries the study and subject random effects. Since [#164](https://github.com/dseinternational/vocabulary-growth/pull/164) put subject REs on VG11/VG12/VG13 — and with VG10 on the DS side — persistent between-child differences are absorbed by the subject scale, and κ describes what is left. So the dispersion panels answer "how much residual noise does the likelihood carry", not "how much do children differ from one another".
+
+The two are not merely different, they are complementary: in the TD models `tau_subject` and `kappa` are an explicit reparameterisation of one shared logit-scale scatter budget (`models.gp_utils.build_variance_partition`), so reading either alone attributes the whole budget to whichever half is in view. `overdispersion_factor`'s own docstring already warned that φ is not mean-independent, because κ is level-driven in this family; the report's prose had nonetheless described it as "mean-independent" and "pure concentration", and had drawn a between-child conclusion for comprehension from it. That prose is corrected in the same change as this analysis.
+
+## 2. Why the obvious contrast is not available
+
+The subject scales are not commensurable across the two sides. VG11/VG12 place a single child intercept on the logit of the outcome (`tau_subject`). VG10 places one on the logit of understood (`tau_subj_u`) and one on the logit of the production **ratio** (`tau_subj_q`), with spoken derived as $p_S = p_U \cdot q$. So VG10 has no spoken child scale to read off, and contrasting `tau_subj_q` against `tau_subject` would set the spread of a conversion ratio against the spread of a level.
+
+What both parameterisations _do_ define is the between-child distribution of a child's own logit for the outcome in question. That is the estimand `comparison.subject_heterogeneity` computes: exactly for a single intercept, and by tensor Gauss–Hermite quadrature over the two independent subject effects for the product form. It also returns σ_child, the induced spread in expected words, which — unlike σ_Y — counts only persistent between-child variation and excludes the Beta-Binomial noise.
+
+The quadrature was checked against 2,000,000-draw Monte Carlo (agreement to ~4 significant figures), verified converged at the shipped 21 nodes against an 81-node grid at the most extreme scales the DS fits could produce, and made stable in the far lower tail via `logit(σ(a)σ(b))` computed as a log-sum-exp rather than a clipped `log p − log(1−p)`, because DS spoken proportions at the young end are small enough that the naive form would report the clip rather than the model.
+
+## 3. Result
+
+DS = VG10, TD = VG11 (spoken) / VG12 (understood), reporting-quality fits, per-draw contrasts on the empirical age overlap.
+
+|                     | τ_TD  | τ_DS      | ratio TD/DS | P(TD > DS) | σ_child TD     | σ_child DS   |
+| ------------------- | ----- | --------- | ----------- | ---------- | -------------- | ------------ |
+| spoken, 8 mo        | 1.038 | **1.442** | 0.72        | 0.00       | 1.8 w          | 0.7 w        |
+| spoken, 18 mo       | 1.038 | **1.389** | 0.75        | 0.00       | 68.3 w         | 6.8 w        |
+| spoken, 30 mo       | 1.038 | **1.273** | 0.82        | 0.00       | 172.9 w        | 35.5 w       |
+| understood, 8–24 mo | 0.686 | **0.785** | 0.87        | 0.00       | 24.2 → 123.9 w | 9.0 → 84.2 w |
+
+**Children with Down syndrome differ from one another more than typically developing children do**, on both outcomes, at every age in the overlap, with posterior probability ≈ 1.00. The gap narrows with age for spoken (ratio 0.72 → 0.82).
+
+**And the absolute scale says the opposite.** σ_child in words is far larger for TD — 173 against 36 for spoken at 30 months — because TD sits at a much higher level, and the same relative spread around a larger mean is a larger absolute spread. Both statements describe the same posterior. This is the substantive finding: which population is "more variable" depends entirely on the scale, and the absolute reading is the one the σ_Y and φ panels invite.
+
+## 4. Two structural checks that came out as predicted
+
+- τ_TD is **flat in age** on both outcomes, and τ_DS is flat for comprehension — correct, because those are single intercepts on the outcome's own logit, so the SD of the child's logit is the parameter itself.
+- τ_DS for **spoken declines with age** (1.442 → 1.273) even though `tau_subj_u` and `tau_subj_q` are both constants. That is a property of the product form passing through two non-linearities, not a finding about children becoming more alike, and it is precisely the reason the contrast cannot be made by reading a parameter off the trace.
+
+## 5. What bounds the claim
+
+- **The priors are not symmetric.** On the TD side `tau_subject` and `kappa` are sampled through the shared-budget reparameterisation with an informative prior on the split; on the DS side they are two free scales. Part of any τ difference is a difference in prior structure.
+- **Identification is thin on the TD side.** The TD pool averages 1.21 observations per child, and only repeatedly-measured children identify the τ/κ split at all. `202608050900-td-hierarchical-geometry.md` §12 notes that `tau_subject`'s strikingly tight interval owes substantially to the Beta-Binomial functional form separating child variance from dispersion, not to replication in the data.
+- **The intervals are the least trustworthy part.** VG11 carries 22 divergent transitions and VG12 an energy BFMI of 0.207; the same note observes that low BFMI means poor exploration of the energy tails, and tail quantiles are what interval bounds are made of. τ is an interval on a weakly-identified variance split in exactly those models. **The point estimates and the sign of the contrast are the safer part of this result; the interval widths are not.** The figures were published with `sync_report_figures.py --allow-caveats`, so the caveats travel into Appendix B with the numbers.
+- **Matched on age, not on level.** At matched age the DS group sits near a floor where absolute spread is mechanically small. A full answer to "are these children more alike" also wants the comparison at matched vocabulary level, which the attainment-delay and matched-comprehension sections provide.
+
+## 6. Artifacts
+
+`comparison.subject_heterogeneity`, `child_spread_single`, `child_spread_product` in `src/vocab_growth/comparison.py`; wired into `scripts/compare_ds_td_re.py`, which now emits `ds_td_<outcome>_re_subject_heterogeneity.csv` plus `subject_tau` and `subject_spread` panels. Reported in the comparison book's "Between-child heterogeneity" section. Six unit tests in `tests/test_comparison.py`; a Monte-Carlo cross-check in the script's `--verify` self-check.

--- a/scripts/compare_ds_td_re.py
+++ b/scripts/compare_ds_td_re.py
@@ -32,15 +32,22 @@ Estimands, per outcome, written to the configured comparisons dir (default
   many months behind TD the DS population reaches each vocabulary level v
   (a flat D(v) ⇒ pure shift; a rising D(v) ⇒ developmental stretch).
 * ``ds_td_<outcome>_re_dispersion.csv``        — concentration κ, implied word
-  SD σ_Y, and the mean-independent overdispersion factor φ for each population,
-  with the contrasts Δκ, Δσ_Y, φ_TD/φ_DS. (κ and σ_Y tell different stories;
-  φ isolates pure concentration.)
+  SD σ_Y, and the overdispersion factor φ for each population, with the contrasts
+  Δκ, Δσ_Y, φ_TD/φ_DS. All three are *observation*-level: in these models κ is
+  what the Beta-Binomial layer carries once the study and subject random effects
+  have taken their share, so none of them is the between-child contrast.
+* ``ds_td_<outcome>_re_subject_heterogeneity.csv`` — the between-child contrast
+  proper: τ, the SD across children of the child's own logit for this outcome,
+  and the spread in expected words σ_child it induces, per population, with
+  Δτ, τ_TD/τ_DS and Δσ_child. See ``comparison.subject_heterogeneity`` for why
+  this is not simply VG10's ``tau_subj_q`` read against VG11's ``tau_subject``.
 
 Each panel is emitted as its own standalone figure (linear axes, no subplot
 grids) so the figures are usable individually:
 ``ds_td_<outcome>_re_{expected_words,learning_rate,attainment_delay,spread,
-spread_contrast,overdispersion}.{png,svg}`` and, for the comprehension-matched
-view, ``ds_td_comprehension_{q_at_U,dq,latency,q_at_age}.{png,svg}``.
+spread_contrast,overdispersion,subject_tau,subject_spread}.{png,svg}`` and, for
+the comprehension-matched view,
+``ds_td_comprehension_{q_at_U,dq,latency,q_at_age}.{png,svg}``.
 
 Usage::
 
@@ -218,6 +225,29 @@ def run_outcome(outcome: str) -> None:
         phi_ratio=C.summarise_draws(PHI_td / PHI_ds, grid),
     )
 
+    # ---- 5. Between-child heterogeneity: the subject random-effect scale ----
+    # Everything in block 4 is observation-level. With subject REs on both sides
+    # kappa is the *residual* left after persistent child differences are absorbed,
+    # so it cannot answer "do DS children differ from one another more or less than
+    # TD children do" — the subject scale answers that, and the two are two halves
+    # of one scatter budget in the TD models. tau is the SD of the child's own
+    # logit for this outcome, which is defined identically in both
+    # parameterisations even though VG10 reaches it through p_u and q rather than
+    # through a single spoken intercept (comparison.subject_heterogeneity).
+    _, TAU_ds, SDC_ds, _ = C.subject_heterogeneity(
+        DISP_DS_KEY, outcome, ages=grid, draws=i_disp)
+    _, TAU_td, SDC_td, _ = C.subject_heterogeneity(
+        td_key, outcome, ages=grid, draws=ib)
+    het = _merge(
+        grid, "age_months",
+        tau_TD=C.summarise_draws(TAU_td, grid), tau_DS=C.summarise_draws(TAU_ds, grid),
+        dtau=C.summarise_draws(TAU_td - TAU_ds, grid, with_p_gt0=True),
+        tau_ratio=C.summarise_draws(TAU_td / TAU_ds, grid),
+        sdchild_TD=C.summarise_draws(SDC_td, grid),
+        sdchild_DS=C.summarise_draws(SDC_ds, grid),
+        dsdchild=C.summarise_draws(SDC_td - SDC_ds, grid, with_p_gt0=True),
+    )
+
     # ---- Write CSVs ----
     os.makedirs(OUT_DIR, exist_ok=True)
     prefix = os.path.join(OUT_DIR, f"ds_td_{outcome}_re_")
@@ -225,6 +255,7 @@ def run_outcome(outcome: str) -> None:
     lr.to_csv(prefix + "learning_rate.csv", index=False)
     ad.to_csv(prefix + "attainment_delay.csv", index=False)
     disp.to_csv(prefix + "dispersion.csv", index=False)
+    het.to_csv(prefix + "subject_heterogeneity.csv", index=False)
 
     _plot_outcome(outcome, td_key, grid,
                   C.summarise_draws(W_td, grid), C.summarise_draws(W_ds, grid),
@@ -233,9 +264,11 @@ def run_outcome(outcome: str) -> None:
                   C.summarise_draws(SD_td, grid), C.summarise_draws(SD_ds, grid),
                   C.summarise_draws(SD_td - SD_ds, grid),
                   C.summarise_draws(PHI_td, grid), C.summarise_draws(PHI_ds, grid),
+                  C.summarise_draws(TAU_td, grid), C.summarise_draws(TAU_ds, grid),
+                  C.summarise_draws(SDC_td, grid), C.summarise_draws(SDC_ds, grid),
                   C.model_label(DISP_DS_KEY))
 
-    _print_summary(outcome, ew, lr, ad, disp, C.model_label(DISP_DS_KEY))
+    _print_summary(outcome, ew, lr, ad, disp, het, C.model_label(DISP_DS_KEY))
 
 
 # ----------------------------------------------------------------------------
@@ -252,7 +285,8 @@ def _save_single(filename: str, ax_setup: dict, draw) -> None:
 
 
 def _plot_outcome(outcome, td_key, grid, W_td, W_ds, R_td, R_ds, ad,
-                  SD_td, SD_ds, dSD, PHI_td, PHI_ds, disp_ds_lab) -> None:
+                  SD_td, SD_ds, dSD, PHI_td, PHI_ds,
+                  TAU_td, TAU_ds, SDC_td, SDC_ds, disp_ds_lab) -> None:
     td_lab, ds_lab = C.model_label(td_key), C.model_label(DS_KEY)
     pre = f"ds_td_{outcome}_re_"
 
@@ -329,6 +363,29 @@ def _plot_outcome(outcome, td_key, grid, W_td, W_ds, R_td, R_ds, ad,
         overdispersion,
     )
 
+    def subject_tau(ax):
+        _band(ax, TAU_td, "age_months", td_lab, COL_TD)
+        _band(ax, TAU_ds, "age_months", disp_ds_lab, COL_DS)
+
+    _save_single(
+        pre + "subject_tau",
+        dict(xlabel="Age (months)", ylabel=r"Between-child SD $\tau$ (logit)",
+             title=f"Between-child heterogeneity — words {outcome}"),
+        subject_tau,
+    )
+
+    def subject_spread(ax):
+        _band(ax, SDC_td, "age_months", td_lab, COL_TD)
+        _band(ax, SDC_ds, "age_months", disp_ds_lab, COL_DS)
+
+    _save_single(
+        pre + "subject_spread",
+        dict(xlabel="Age (months)",
+             ylabel=r"Between-child SD $\sigma_{child}$ (words)",
+             title=f"Between-child spread in expected words — {outcome}"),
+        subject_spread,
+    )
+
 
 def _plot_comprehension(ds_key, td_key, q_td_s, q_ds_s, dq_s,
                         da_td, da_ds, qa_td, qa_ds) -> None:
@@ -384,7 +441,7 @@ def _plot_comprehension(ds_key, td_key, q_td_s, q_ds_s, dq_s,
     )
 
 
-def _print_summary(outcome, ew, lr, ad, disp, disp_ds_lab) -> None:
+def _print_summary(outcome, ew, lr, ad, disp, het, disp_ds_lab) -> None:
     print(f"  Expected words & learning rate at key ages ({outcome}):")
     for a in KEY_AGES:
         print(f"    {a:>2} mo: TD={_at_age(ew,a,'TD_median'):6.1f}  "
@@ -397,7 +454,8 @@ def _print_summary(outcome, ew, lr, ad, disp, disp_ds_lab) -> None:
     for _, r in ad[ad["coverage"] >= MIN_COVERAGE].iterrows():
         print(f"    {int(r['words']):>3} words: {r['median']:5.1f} "
               f"[{r['ci_lo']:.1f}, {r['ci_hi']:.1f}]")
-    print(f"  Dispersion contrasts at key ages (DS={disp_ds_lab}, study + subject REs):")
+    print(f"  Residual (observation-level) dispersion at key ages "
+          f"(DS={disp_ds_lab}, study + subject REs):")
     for a in KEY_AGES:
         print(f"    {a:>2} mo: kappa TD={_at_age(disp,a,'kappa_TD_median'):4.1f} "
               f"DS={_at_age(disp,a,'kappa_DS_median'):4.1f} "
@@ -406,6 +464,15 @@ def _print_summary(outcome, ew, lr, ad, disp, disp_ds_lab) -> None:
               f"DS={_at_age(disp,a,'sdY_DS_median'):4.1f} "
               f"(Δσ_Y P>0={_at_age(disp,a,'dsdY_p_gt0'):.2f})  |  "
               f"φ_TD/φ_DS={_at_age(disp,a,'phi_ratio_median'):.2f}")
+    print("  Between-child heterogeneity at key ages (the subject scale):")
+    for a in KEY_AGES:
+        print(f"    {a:>2} mo: tau TD={_at_age(het,a,'tau_TD_median'):5.2f} "
+              f"DS={_at_age(het,a,'tau_DS_median'):5.2f} "
+              f"(ratio={_at_age(het,a,'tau_ratio_median'):4.2f}, "
+              f"P(TD>DS)={_at_age(het,a,'dtau_p_gt0'):.2f})  |  "
+              f"σ_child TD={_at_age(het,a,'sdchild_TD_median'):5.1f} "
+              f"DS={_at_age(het,a,'sdchild_DS_median'):5.1f} words "
+              f"(P(TD>DS)={_at_age(het,a,'dsdchild_p_gt0'):.2f})")
 
 
 # ----------------------------------------------------------------------------
@@ -483,8 +550,29 @@ def _verify() -> None:
     for v in (50.0, 100.0, 200.0):
         d = C.first_crossing_age(w_ds, ages, v) - C.first_crossing_age(w_td, ages, v)
         assert np.allclose(d, shift, atol=0.2), (v, d)
+
+    # Between-child quadrature against brute-force Monte Carlo over the subject
+    # REs. The product form is the one worth checking: its tau is an induced
+    # quantity, not a parameter, so an error here would be invisible downstream.
+    rng = np.random.default_rng(SEED)
+    f_u = np.array([[-4.0, -1.5, 0.5]])
+    h = np.array([[-3.0, -1.0, 0.0]])
+    tau_u, tau_q = np.array([0.9]), np.array([1.3])
+    tau_g, sd_g = C.child_spread_product(f_u, h, tau_u, tau_q, n)
+    z1 = rng.standard_normal((400_000, 1))
+    z2 = rng.standard_normal((400_000, 1))
+    p_mc = (1 / (1 + np.exp(-(f_u + tau_u[0] * z1)))) * (
+        1 / (1 + np.exp(-(h + tau_q[0] * z2))))
+    lg_mc = np.log(p_mc) - np.log1p(-p_mc)
+    assert np.allclose(tau_g[0], lg_mc.std(axis=0), rtol=0.02), (tau_g, lg_mc.std(axis=0))
+    assert np.allclose(sd_g[0], n * p_mc.std(axis=0), rtol=0.02), (sd_g, n * p_mc.std(axis=0))
+    # The single-intercept form must return tau itself, exactly.
+    tau_s, _ = C.child_spread_single(np.zeros((1, 3)), np.array([0.7]), n)
+    assert np.allclose(tau_s, 0.7), tau_s
+
     print("self-check OK: implied_sd_y == scipy.betabinom.std; "
-          "D(v) recovers a constant age shift.\n")
+          "D(v) recovers a constant age shift; between-child quadrature "
+          "matches Monte Carlo.\n")
 
 
 def main() -> None:

--- a/src/vocab_growth/comparison.py
+++ b/src/vocab_growth/comparison.py
@@ -85,15 +85,22 @@ def _dataset(idata: az.InferenceData, group: str):
 
 
 def _load_reshaped_draws(
-    path: str, var_names: tuple[str, ...]
-) -> tuple[np.ndarray, list[np.ndarray]]:
+    path: str,
+    var_names: tuple[str, ...],
+    scalar_names: tuple[str, ...] = (),
+) -> tuple[np.ndarray, list[np.ndarray], dict[str, np.ndarray]]:
     """Load named posterior variables over the ``X_plot`` grid, draw-flattened.
 
     Shared tail of every population-trajectory loader below: opens the trace,
     reshapes each named posterior variable from ``(chain, draw, n_age)`` to
     ``(chain*draw, n_age)``, and age-sorts both the variables and the grid.
-    Returns ``(ages_sorted, [var_sorted, ...])`` in the same order as
-    ``var_names``.
+    Returns ``(ages_sorted, [var_sorted, ...], {scalar: draws})`` with the
+    grid variables in the same order as ``var_names``.
+
+    ``scalar_names`` additionally pulls per-draw *scalar* parameters (shape
+    ``(chain, draw)``, e.g. a random-effect scale) and flattens them the same
+    C-order way, so index ``i`` of a scalar and row ``i`` of a grid variable are
+    the same posterior draw.
     """
     d = az.from_netcdf(path)
     post = _dataset(d, "posterior")
@@ -105,7 +112,15 @@ def _load_reshaped_draws(
         arr = post[name].values  # (chain, draw, n_age)
         n_chain, n_draw, n_age = arr.shape
         arrays.append(arr.reshape(n_chain * n_draw, n_age)[:, order])
-    return ages[order], arrays
+    scalars = {}
+    for name in scalar_names:
+        if name not in post:
+            raise KeyError(
+                f"{os.path.basename(os.path.dirname(path))}: posterior has no "
+                f"variable {name!r}."
+            )
+        scalars[name] = np.asarray(post[name].values, dtype=float).reshape(-1)
+    return ages[order], arrays, scalars
 
 
 def load_population_trajectory(
@@ -117,7 +132,7 @@ def load_population_trajectory(
     over the plot grid; ``ages`` is sorted ascending in months. ``n_trials_``
     must match the checklist size used at fit time (see definitions.py).
     """
-    ages, (p_u, p_s) = _load_reshaped_draws(path, ("p_u_plot", "p_s_plot"))
+    ages, (p_u, p_s), _ = _load_reshaped_draws(path, ("p_u_plot", "p_s_plot"))
     return ages, p_u * n_trials_, p_s * n_trials_
 
 
@@ -130,7 +145,7 @@ def load_univariate_trajectory(
     plot grid; ``ages`` is sorted ascending. The single-outcome analogue of
     :func:`load_population_trajectory`.
     """
-    ages, (p,) = _load_reshaped_draws(path, ("p_plot",))
+    ages, (p,), _ = _load_reshaped_draws(path, ("p_plot",))
     return ages, p * n_trials_
 
 
@@ -479,7 +494,7 @@ def load_outcome_trajectory(
             f"{key}: model_type {mt} is not supported by load_outcome_trajectory."
         )
 
-    ages, (p, k) = _load_reshaped_draws(trace_path(key), (p_name, k_name))
+    ages, (p, k), _ = _load_reshaped_draws(trace_path(key), (p_name, k_name))
     return ages, p, k, n_trials(key)
 
 
@@ -510,6 +525,227 @@ def overdispersion_factor(kappa: np.ndarray, n: int) -> np.ndarray:
     isolate what the name suggests.
     """
     return (kappa + n) / (kappa + 1.0)
+
+
+# ----------------------------------------------------------------------------
+# Between-child heterogeneity (the subject random-effect scale)
+# ----------------------------------------------------------------------------
+# `kappa` — and therefore `overdispersion_factor` above — is an *observation*-level
+# parameter, applied to a child-and-study-specific `p_obs`. In a model carrying
+# subject random effects it is what is left after persistent between-child
+# differences have been absorbed, so it does not answer "how much do children in
+# this population differ from one another": that is the subject scale's job. The
+# two are not merely different, they are complementary — in the TD models they are
+# an explicit reparameterisation of one shared logit-scale scatter budget (see
+# `models.gp_utils.build_variance_partition`), so reading either alone attributes
+# the whole budget to whichever half is being looked at.
+#
+# The obstacle to contrasting the scales directly is that they do not all live on
+# the same latent scale. The univariate TD models put one subject intercept on the
+# logit of the outcome (`tau_subject`); the joint DS models put one on the logit of
+# *understood* (`tau_subj_u`) and one on the logit of the production *ratio*
+# (`tau_subj_q`), with spoken derived as p_u * q. So VG10 has no spoken subject
+# scale to read off, and `tau_subj_q` is not VG11's `tau_subject` in different
+# clothing. What both parameterisations *do* define is the between-child
+# distribution of the child's own logit p for the outcome in question, which is a
+# well-defined estimand in either. The functions below evaluate it — exactly for a
+# single logit intercept, by quadrature for the product form.
+
+
+def _gauss_hermite_standard_normal(n_nodes: int) -> tuple[np.ndarray, np.ndarray]:
+    """Nodes/weights for ``E[g(Z)] = sum(w * g(x))`` under ``Z ~ Normal(0, 1)``."""
+    x, w = np.polynomial.hermite_e.hermegauss(n_nodes)
+    return x, w / w.sum()
+
+
+def _log_sigmoid(x: np.ndarray) -> np.ndarray:
+    """``log(sigmoid(x))``, stable for large |x|."""
+    return -np.logaddexp(0.0, -x)
+
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    """Logistic function, overflow-free at both tails (underflows to 0 / 1)."""
+    return np.exp(_log_sigmoid(x))
+
+
+def _logit_sigmoid_product(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """``logit(sigmoid(a) * sigmoid(b))``, stable in both tails.
+
+    Uses ``1 - s(a)s(b) = s(-a) + s(a)s(-b)`` so the upper tail is a log-sum-exp
+    of two log-sigmoids rather than a cancelling subtraction. Needed because DS
+    spoken proportions at the young end of the grid are small enough that a naive
+    ``log(p) - log(1-p)`` on a clipped ``p`` would report the clip, not the model.
+    """
+    log_p = _log_sigmoid(a) + _log_sigmoid(b)
+    log_1mp = np.logaddexp(_log_sigmoid(-a), _log_sigmoid(a) + _log_sigmoid(-b))
+    return log_p - log_1mp
+
+
+def child_spread_single(
+    f: np.ndarray, tau: np.ndarray, n: int, *, n_nodes: int = 21
+) -> tuple[np.ndarray, np.ndarray]:
+    """Between-child spread when one Normal intercept sits on the outcome's logit.
+
+    ``f`` is the population logit ``(n_draw, n_age)``, ``tau`` the per-draw subject
+    scale ``(n_draw,)``; a child's logit is ``f + tau*Z``, ``Z ~ Normal(0, 1)``.
+    Returns ``(tau_logit, sd_child_words)``, both ``(n_draw, n_age)``: the SD of the
+    child's logit p — here exactly ``tau``, broadcast — and the SD across children
+    of that child's *expected* word count ``n*p`` (Beta-Binomial noise excluded,
+    since this is persistent between-child variation only).
+    """
+    x, w = _gauss_hermite_standard_normal(n_nodes)
+    tau_col = np.asarray(tau, dtype=float)[:, None]
+    m1 = np.zeros_like(f)
+    m2 = np.zeros_like(f)
+    for xi, wi in zip(x, w, strict=True):
+        p = _sigmoid(f + tau_col * xi)
+        m1 += wi * p
+        m2 += wi * p * p
+    sd_words = n * np.sqrt(np.maximum(m2 - m1 * m1, 0.0))
+    return np.broadcast_to(tau_col, f.shape).copy(), sd_words
+
+
+def child_spread_product(
+    f_u: np.ndarray,
+    h: np.ndarray,
+    tau_u: np.ndarray,
+    tau_q: np.ndarray,
+    n: int,
+    *,
+    n_nodes: int = 21,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Between-child spread of spoken in a joint ``p_s = p_u * q`` model.
+
+    A child's spoken proportion is ``sigmoid(f_u + tau_u*Z1) * sigmoid(h + tau_q*Z2)``
+    with independent standard Normal ``Z1``, ``Z2``, so the SD of the child's
+    *spoken* logit is neither ``tau_u`` nor ``tau_q`` and is age-varying even though
+    both scales are constants. Returns the same ``(tau_logit, sd_child_words)`` pair
+    as :func:`child_spread_single`, evaluated on a tensor Gauss-Hermite grid.
+
+    This is the quantity that is like-for-like with a univariate model's
+    ``tau_subject``; contrasting ``tau_subj_q`` against it instead would compare the
+    spread of a conversion ratio with the spread of a level.
+    """
+    x, w = _gauss_hermite_standard_normal(n_nodes)
+    tu = np.asarray(tau_u, dtype=float)[:, None]
+    tq = np.asarray(tau_q, dtype=float)[:, None]
+    p1 = np.zeros_like(f_u)
+    p2 = np.zeros_like(f_u)
+    l1 = np.zeros_like(f_u)
+    l2 = np.zeros_like(f_u)
+    for xi, wi in zip(x, w, strict=True):
+        a = f_u + tu * xi
+        for xj, wj in zip(x, w, strict=True):
+            b = h + tq * xj
+            weight = wi * wj
+            p = _sigmoid(a) * _sigmoid(b)
+            lg = _logit_sigmoid_product(a, b)
+            p1 += weight * p
+            p2 += weight * p * p
+            l1 += weight * lg
+            l2 += weight * lg * lg
+    tau_logit = np.sqrt(np.maximum(l2 - l1 * l1, 0.0))
+    sd_words = n * np.sqrt(np.maximum(p2 - p1 * p1, 0.0))
+    return tau_logit, sd_words
+
+
+def subject_heterogeneity(
+    key: str,
+    outcome: str = "spoken",
+    *,
+    ages: np.ndarray | None = None,
+    draws: np.ndarray | None = None,
+    n_nodes: int = 21,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+    """Return ``(ages, tau_logit, sd_child_words, n_trials)`` for one outcome.
+
+    The between-child counterpart of :func:`load_outcome_trajectory`: how far
+    children of the same age in this population sit from one another, on the
+    outcome's own logit scale and in expected words. Study effects are excluded
+    throughout, matching every other population-level curve in this module.
+
+    Dispatches on model type, mirroring :func:`load_outcome_trajectory`: univariate
+    RE models read ``f_plot`` + ``tau_subject``; bivariate RE models read
+    ``f_u_plot`` + ``tau_subj_u`` for understood, and additionally ``h_plot`` +
+    ``tau_subj_q`` for spoken, which needs :func:`child_spread_product`.
+
+    ``ages`` evaluates on a caller-supplied grid instead of the model's own plot
+    grid. The population logits are interpolated *before* the quadrature (they are
+    smooth in age; the derived SD need not be), which for a 0.5-month comparison
+    grid also keeps the tensor-quadrature cost an order of magnitude down.
+
+    ``draws`` selects posterior draws (an index array from :func:`align_draws`)
+    *before* the quadrature rather than after. The result is identical either way —
+    draws do not interact — but on a reporting-quality trace the tensor grid is the
+    expensive part, so subsetting first is worth the argument.
+    """
+    d = MODEL_REGISTRY[key]
+    mt = d.model_type
+    n = n_trials(key)
+    path = trace_path(key)
+
+    def _prepare(
+        native: np.ndarray, Y: np.ndarray, tau: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        if draws is not None:
+            Y, tau = Y[draws], tau[draws]
+        if ages is None:
+            return native, Y, tau
+        out = np.asarray(ages, dtype=float)
+        return out, interp_draws(native, Y, out), tau
+
+    if mt is ModelType.UNIVARIATE:
+        if d.outcome.value != outcome:
+            raise ValueError(
+                f"{key} is a '{d.outcome.value}' model; cannot serve '{outcome}'."
+            )
+        if not getattr(d, "use_subject_re", False):
+            raise ValueError(
+                f"{key} carries no subject random effect; it has no between-child "
+                "scale to report. Use a model with use_subject_re=True."
+            )
+        native, (f,), scal = _load_reshaped_draws(path, ("f_plot",), ("tau_subject",))
+        grid, f, tau = _prepare(native, f, scal["tau_subject"])
+        tau_logit, sd_words = child_spread_single(f, tau, n, n_nodes=n_nodes)
+        return grid, tau_logit, sd_words, n
+
+    if mt is ModelType.BIVARIATE:
+        if outcome == "understood":
+            if not getattr(d, "use_subject_re_u", False):
+                raise ValueError(
+                    f"{key} carries no understood subject random effect "
+                    "(use_subject_re_u=False)."
+                )
+            native, (f_u,), scal = _load_reshaped_draws(
+                path, ("f_u_plot",), ("tau_subj_u",)
+            )
+            grid, f_u, tau_u = _prepare(native, f_u, scal["tau_subj_u"])
+            tau_logit, sd_words = child_spread_single(f_u, tau_u, n, n_nodes=n_nodes)
+            return grid, tau_logit, sd_words, n
+        if outcome == "spoken":
+            if not (
+                getattr(d, "use_subject_re_u", False)
+                and getattr(d, "use_subject_re_q", False)
+            ):
+                raise ValueError(
+                    f"{key}: the spoken between-child scale is induced by the "
+                    "understood *and* ratio subject effects; both use_subject_re_u "
+                    "and use_subject_re_q must be set."
+                )
+            native, (f_u, h), scal = _load_reshaped_draws(
+                path, ("f_u_plot", "h_plot"), ("tau_subj_u", "tau_subj_q")
+            )
+            grid, f_u, tau_u = _prepare(native, f_u, scal["tau_subj_u"])
+            _, h, tau_q = _prepare(native, h, scal["tau_subj_q"])
+            tau_logit, sd_words = child_spread_product(
+                f_u, h, tau_u, tau_q, n, n_nodes=n_nodes
+            )
+            return grid, tau_logit, sd_words, n
+        raise ValueError(f"outcome must be 'spoken' or 'understood', got {outcome!r}.")
+
+    raise ValueError(
+        f"{key}: model_type {mt} is not supported by subject_heterogeneity."
+    )
 
 
 def align_draws(
@@ -770,7 +1006,7 @@ def load_p_any_trajectory(
     ``p_any_words`` is ``(n_draw, n_age)`` expected word counts over the plot
     grid (signing included), for the DS sign-inclusive expressive contrast.
     """
-    ages, (p_any,) = _load_reshaped_draws(path, ("p_any_plot",))
+    ages, (p_any,), _ = _load_reshaped_draws(path, ("p_any_plot",))
     return ages, p_any * n_trials_
 
 

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -1626,7 +1626,15 @@ def enforce_convergence_gate(
                 "carries sampling caveats:\n\n"
                 + "".join(f"  - {caveat}\n" for caveat in caveats)
                 + "\nThe fit remains reportable; publication as a clean fit is "
-                "blocked (sync_report_figures.py --allow-provisional overrides).\n"
+                "blocked. To publish it as what it is, use\n"
+                "  sync_report_figures.py --allow-caveats\n"
+                "which relaxes only this check and keeps every other publication "
+                "requirement — reporting quality, rendered report, clean fit "
+                "provenance, matching definition, sampling effort and raw-data "
+                "fingerprint. --allow-provisional also proceeds, but it relaxes "
+                "publication provenance more broadly for local development work, "
+                "so it is not the publication path. Either way these caveats are "
+                "written to the figure cache and reported with the numbers.\n"
             )
         console.print()
         for caveat in caveats:

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -232,3 +232,87 @@ def test_dq_contrast_facts_direction_undefined_for_two_points():
     ]))
     assert facts["rises"] is None              # no monotone claim from two points
     assert facts["positive"] == (100.0, 150.0)
+
+
+# ---- between-child heterogeneity (subject random-effect scale) ----
+def test_child_spread_single_returns_tau_exactly():
+    # One Normal intercept on the outcome's own logit: the SD of the child's logit
+    # p *is* tau, at every age and whatever the population trajectory does.
+    f = np.array([[-6.0, -2.0, 0.0, 3.0], [-1.0, -1.0, -1.0, -1.0]])
+    tau = np.array([0.4, 1.7])
+    tau_logit, _ = comparison.child_spread_single(f, tau, 810)
+    assert tau_logit.shape == f.shape
+    assert np.allclose(tau_logit[0], 0.4)
+    assert np.allclose(tau_logit[1], 1.7)
+
+
+def test_child_spread_single_word_sd_matches_monte_carlo():
+    rng = np.random.default_rng(20260808)
+    f = np.array([[-4.0, -1.0, 0.5]])
+    tau, n = 0.9, 810
+    _, sd_words = comparison.child_spread_single(f, np.array([tau]), n)
+    z = rng.standard_normal((400_000, 1))
+    p = 1.0 / (1.0 + np.exp(-(f + tau * z)))
+    assert np.allclose(sd_words[0], n * p.std(axis=0), rtol=0.02)
+
+
+def test_child_spread_product_matches_monte_carlo():
+    # The joint model's induced spoken scale is the quantity with no parameter to
+    # read off, so it is the one that has to be checked against brute force. Kept
+    # to moderate proportions: out in the lower tail the *Monte Carlo* estimate of
+    # a word SD is the noisy one, and the comparison stops testing the quadrature.
+    rng = np.random.default_rng(20260808)
+    f_u = np.array([[-2.0, 0.0, 1.0]])
+    h = np.array([[-1.5, 0.0, 0.5]])
+    tau_u, tau_q, n = 0.8, 1.4, 810
+    tau_logit, sd_words = comparison.child_spread_product(
+        f_u, h, np.array([tau_u]), np.array([tau_q]), n
+    )
+    z1 = rng.standard_normal((400_000, 1))
+    z2 = rng.standard_normal((400_000, 1))
+    p = (1.0 / (1.0 + np.exp(-(f_u + tau_u * z1)))) * (
+        1.0 / (1.0 + np.exp(-(h + tau_q * z2)))
+    )
+    logit_p = np.log(p) - np.log1p(-p)
+    assert np.allclose(tau_logit[0], logit_p.std(axis=0), rtol=0.02)
+    assert np.allclose(sd_words[0], n * p.std(axis=0), rtol=0.02)
+
+
+def test_child_spread_product_tau_varies_with_age_at_constant_scales():
+    # Both subject scales are constants, yet the induced spoken tau is age-varying
+    # because the product passes through two nonlinearities. This is why the joint
+    # model has no single spoken subject scale to contrast directly.
+    f_u = np.array([[-6.0, -3.0, 0.0]])
+    h = np.array([[-5.0, -2.0, 0.5]])
+    tau_logit, _ = comparison.child_spread_product(
+        f_u, h, np.array([1.0]), np.array([1.0]), 810
+    )
+    assert tau_logit[0, 0] > tau_logit[0, -1]
+    assert not np.allclose(tau_logit[0, 0], tau_logit[0, -1])
+
+
+def test_child_spread_product_quadrature_has_converged_at_the_default_node_count():
+    # Monte Carlo cannot referee the far lower tail (see above), so the tail is
+    # checked for node convergence instead: the shipped default must already agree
+    # with a far finer grid on the most extreme scales the DS fits could produce.
+    f_u = np.array([[-12.0, -6.0, -2.0]])
+    h = np.array([[-10.0, -4.0, -1.0]])
+    tau_u, tau_q = np.array([3.0]), np.array([3.0])
+    coarse = comparison.child_spread_product(f_u, h, tau_u, tau_q, 810)
+    fine = comparison.child_spread_product(f_u, h, tau_u, tau_q, 810, n_nodes=81)
+    assert np.allclose(coarse[0], fine[0], rtol=1e-4)     # tau
+    assert np.allclose(coarse[1], fine[1], rtol=5e-3)     # sd in words
+
+
+def test_child_spread_product_is_stable_in_the_far_lower_tail():
+    # DS spoken proportions at the young end are small enough that a naive
+    # log(p) - log(1-p) on a clipped p would report the clip. Nothing may be
+    # non-finite here.
+    f_u = np.array([[-30.0, -20.0, -12.0]])
+    h = np.array([[-25.0, -18.0, -10.0]])
+    tau_logit, sd_words = comparison.child_spread_product(
+        f_u, h, np.array([1.5]), np.array([2.0]), 810
+    )
+    assert np.all(np.isfinite(tau_logit))
+    assert np.all(np.isfinite(sd_words))
+    assert np.all(sd_words >= 0.0)


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

## Why

The DS/TD dispersion panels were being read as a statement about how much children differ from one another. They cannot be. φ = (κ + n)/(κ + 1) is a function of the Beta-Binomial concentration, and since #164 put subject random effects on VG11/VG12/VG13 — with VG10 on the DS side — κ is an *observation-level* residual applied to a `p_obs` that already carries the study and child effects. Persistent between-child differences are absorbed by the subject scale; κ describes what is left. In the TD models the two are an explicit reparameterisation of one shared logit-scale scatter budget, so reading either alone attributes the whole budget to whichever half is in view.

The report had also drifted from what the code says: two figure captions still read "study-RE only" (stale since the dispersion comparator moved to VG10), the prose called φ "mean-independent" and "pure concentration" against the explicit caveat in `overdispersion_factor`'s docstring, and it drew a between-child conclusion for comprehension from a parameter that no longer carries between-child variance.

## What changed

**A new estimand.** The obvious contrast is unavailable: VG11/VG12 place a single child intercept on the outcome's logit (`tau_subject`), while VG10 places one on logit understood and one on the logit of the production *ratio*, with spoken derived as p_S = p_U · q. VG10 therefore has no spoken child scale, and contrasting `tau_subj_q` against `tau_subject` would set the spread of a conversion ratio against the spread of a level. `comparison.subject_heterogeneity` instead computes what both parameterisations do define — τ, the SD across children of a child's own logit for the outcome — exactly for a single intercept and by tensor Gauss–Hermite quadrature for the product form. It also returns σ_child, the induced spread in expected words, which unlike σ_Y excludes Beta-Binomial noise.

**The result.** On the population-relative scale the Down syndrome group is the *more* variable of the two, on both outcomes, at every age in the overlap, with P(TD > DS) = 0.00: τ_DS 1.44 → 1.27 against a constant τ_TD of 1.04 for spoken, 0.79 against 0.69 for understood. In absolute words the ordering reverses — 173 against 36 at 30 months — purely because the TD group sits at a higher level. Both describe the same posterior; the absolute reading is the one the σ_Y and φ panels invite, which is why the report now separates the two sections.

**Report corrections**, the caveats-file pointer fix (`CONVERGENCE_CAVEATS.txt` sent readers to `--allow-provisional`, the local-dev override, rather than `--allow-caveats`, the publication path built for this case), two glossary entries, and two scoping notes — one on trace persistence tiers, one recording this analysis.

## For the reviewer

- **τ_DS for spoken is derived, not read off the trace.** The quadrature is checked against 2,000,000-draw Monte Carlo (~4 significant figures), verified converged at the shipped 21 nodes against an 81-node grid at the most extreme scales the DS fits could produce, and made stable in the far lower tail via a log-sum-exp form, because DS spoken proportions at the young end would otherwise report the clip rather than the model. Six unit tests plus a Monte-Carlo cross-check in `compare_ds_td_re.py --verify`.
- **Two structural checks came out as predicted** and are worth confirming: τ_TD is flat in age (single logit intercept), and the induced spoken τ_DS declines with age even though both of VG10's subject scales are constants — a property of the product form, not a finding.
- **The intervals are the weak part.** VG11 carries 22 divergent transitions and VG12 an energy BFMI of 0.207; low BFMI means poor exploration of the energy tails, and tail quantiles are what interval bounds are made of. τ is an interval on a weakly-identified variance split in exactly those models, and the TD pool averages 1.21 observations per child. The sign of the contrast is not in doubt; the interval widths are the part to read cautiously. This is stated in the note rather than buried.
- **Figures were synced with `--allow-caveats`**, which keeps every other publication check and carries all four caveats into Appendix B.
- **The notes are scoping only** — no implementation. The persistence work would start with a shared-save refactor across six engine modules.

## Verification

`ruff` clean; `pytest tests/test_comparison.py` (26 passed, six new); diagnostics-gate and fit-artifact suites pass; Prettier and CSpell clean. `compare_ds_td_re.py --verify` and `sync_report_figures.py --allow-caveats` both run against the reporting fits. Two pre-existing failures in `tests/test_data_utils.py` are unrelated — a stale local `vocabulary.duckdb`, fixed by re-running `prepare_data.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)