### PR TITLE
docs: document the high-anchor clamp, and withdraw the unevidenced teaching claim about psi

### DIFF
--- a/docs/report/methods-models.qmd
+++ b/docs/report/methods-models.qmd
@@ -90,6 +90,25 @@ $$
 
 This gives an interpretable baseline on the logit scale while the GP captures smooth departures. The reference ages and the priors on $p_{x_a}, p_{x_b}$ are **model-specific** (e.g. 24 and 84 months for the Down syndrome models; 12 and 26 months for the typically developing models) and are tabulated in each model's appendix.
 
+### Levelling the trend above the high anchor {#sec-clamp}
+
+The Down syndrome joint models evaluate the trajectory over 8–115 months while their anchors sit at 24 and 84, so about a quarter of the domain lies above the high anchor, where no prior constrains the trend. On the logit scale a line steep enough to climb between the anchors saturates over that distance. Extrapolated to 115 months, VG10's production-ratio mean alone reaches 0.993 — $P(\text{mean} > 0.99) = 0.90$ across the posterior — against a realised 0.842. The GP is then spent hauling the mean back, $-3.3$ logits at the top of the range, while sitting idle ($+0.08$) at 48 months where the data are.
+
+We therefore level the trend off above the high anchor, replacing $z$ in the linear term with
+
+$$
+z_{\text{eff}} = z_b - \frac{1}{\beta}\operatorname{softplus}\!\big(\beta\,(z_b - z)\big),
+\qquad \beta = \frac{50}{z_b - z_a},
+$$
+
+so the mean rises linearly below $z_b$ and flattens above it, leaving the GP free to carry departures rather than correct an asymptote. The same coordinate is used for the projection basis in @sec-gpanchor, so the two constraints stay consistent.
+
+Three properties are deliberate. **The clamp is one-sided:** below the low anchor the line extrapolates accurately — VG10's production ratio at 12 months is 0.019 by extrapolation against 0.022 fitted — and clamping there would instead pin young-age values at the 24-month level, which is much worse. **The transition is smooth rather than a hard minimum:** $\min(z, z_b)$ is continuous but its derivative jumps at the anchor and the fitted curve inherits a visible elbow, which in the first VG10 refit made the spoken trajectory briefly non-monotone, falling from 428.6 words at 84.3 months to 426.6 at 85.6. **The softness is scale-free:** setting $\beta$ from the anchor span makes the largest departure from the hard-clamped form $\beta_1 \log 2 / \beta$, or 1.4% of the anchor span — about 0.8 months of age for the Down syndrome models — whatever the age standardisation.
+
+The cost is that $p_{x_b}$ is no longer exactly the mean at the high anchor age, falling short by that same amount. Between the anchors the mean is untouched, so both anchor priors carry over unchanged.
+
+This applies to the Down syndrome joint and signing models (VG05, VG07–VG10, VG14–VG16), set by `clamp_mean_above_hi_anchor` in each model definition. The typically developing models do not use it: their evaluation domains extend barely beyond their high anchors. The univariate Down syndrome baselines, VG01 and VG02, extrapolate the line across the full domain.
+
 ### HSGP approximation {#sec-hsgp}
 
 Exact GP inference requires an $O(n^3)$ Cholesky factorisation. With several hundred observations per model this is feasible but costly inside MCMC, so we use the **Hilbert-space GP (HSGP)** approximation [@solinHilbertSpaceMethods2020; @riutort-mayolPracticalHilbertSpace2022], a finite basis-function representation that generates $g_{\mathrm{unit}}$ from a unit-variance kernel and then rescales by $\eta$. Approximation quality depends on the basis size $m$ (accuracy vs cost), the boundary factor $c$ (the approximation domain, $c$ times the half-range of the standardised evaluation grid about its midpoint, must cover every point the basis is evaluated at), and the length-scale $\ell$ (shorter scales need more basis functions). We select $m$ and $c$ following PyMC's `approx_hsgp_hyperparams` recommendations for the specified range of $\ell$ [@abril-plaPyMCModernComprehensive2023; @riutort-mayolPracticalHilbertSpace2022].

--- a/notes/202608121030-psi-heterogeneity-and-age-invariance.md
+++ b/notes/202608121030-psi-heterogeneity-and-age-invariance.md
@@ -62,7 +62,7 @@ By the study's own matching stratum, both groups start in strong substitution an
 | 6        | 0.88 | 3.53 |
 | 7        | 0.80 | 1.48 |
 
-TD climbs to 2.6–3.5; DS plateaus near 1 and never converges. (Sparse 2×2 tables bias odds ratios toward 0, so the lowest levels overstate the floor.) The substantive reading is that TD children gesture words they are also learning to say, while DS children — who have a specific expressive-speech deficit relative to comprehension — gesture what they _cannot_ say. Where signing is **taught** as sign-and-say pairs, as it is in the UK and New Zealand, both modalities land on the same words by construction.
+TD climbs to 2.6–3.5; DS plateaus near 1 and never converges. (Sparse 2×2 tables bias odds ratios toward 0, so the lowest levels overstate the floor.) One reading is that TD children gesture words they are also learning to say, while DS children — who have a specific expressive-speech deficit relative to comprehension — gesture what they cannot yet say; another is that where signing is taught as sign-and-say pairs both modalities land on the same words by construction. **Neither is evidenced here.** No source in this pool records whether its children were taught to sign, so the teaching contrast is background assumption rather than measurement, and the pooled es_01 figure (0.90, with 45% of children individually below 1) is independence rather than the substitution the first reading implies. What is measured is that es_01's DS and TD groups differ on the identical instrument — which excludes instrument, language and country, but does not identify what differs.
 
 ### It is not uk_07's intervention
 
@@ -138,7 +138,7 @@ Against expressive vocabulary the study-specific slopes are large, individually 
 | DS          | −0.096                         | −0.80 |
 | TD          | −0.109                         | −0.94 |
 
-So `es_01`'s apparent fall was the circularity. The taught-sign side cannot be tested this way — neither `uk_02` nor `uk_07` carries an external developmental measure in its CSV.
+So `es_01`'s apparent fall was the circularity. The high-association sources cannot be tested this way — neither `uk_02` nor `uk_07` carries an external developmental measure in its CSV.
 
 **This is the open question, and it is cheap to close.** `uk_07`'s UK Data Service deposit holds Mullen Scales visual-reception and fine-motor age equivalents at all three assessment points (`T{1,2,3}MullenCombinedAE`); they were simply not extracted, since only the CDI, age, sex and arm were carried across. Extracting them and re-running §5 would establish whether uk_07's +0.731 survives a covariate external to the cells. If it does, a level-varying $\psi$ with **study-specific slopes** is worth building — not age, and not a shared trend. If it does not, the study-varying scalar is the right stopping point.
 
@@ -169,4 +169,4 @@ With four groups `tau_psi` is weakly identified and the prior does real work. **
 - [ ] Extract `uk_07`'s Mullen age equivalents upstream and re-run §5 (the deciding evidence for a level-varying $\psi$).
 - [ ] Refit VG15 at `rep` — the graph changed; no other model reads this engine.
 - [ ] `docs/models/vg15/index.qmd` still says $\psi$ is identified by "~60 uk_02 rows" and calls it a single scalar. Both are now wrong.
-- [ ] Consider whether the substantive reading — that $\psi$ marks whether the non-vocal lexicon was _taught alongside_ speech or arose _as compensation for its absence_ — belongs in the report's discussion. It is the most interpretable thing this parameter has produced, and it is a claim about practice that the data support but cannot prove.
+- [ ] Decide how the between-source spread is described in the report's discussion. The tempting reading — that $\psi$ marks whether the non-vocal lexicon was _taught alongside_ speech or arose _as compensation for its absence_ — is **not supported by anything measured here** and should not be stated as a finding. No source records its children's signing instruction, so the teaching contrast rests on assumed background practice; and `uk_07`, the one source with experimental variation in instruction, has the **higher** association in its _control_ arm (17.93 against 11.65, §3), which cuts against the mechanism rather than for it. If the reading appears at all it must be labelled a hypothesis, with the arm contrast disclosed beside it. Closing §5's Mullen extraction is the cheapest route to evidence that would bear on it.

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -435,8 +435,8 @@ def prepare_joint_data(
     (marginal likelihoods); nz_01 contributes a within-produced three-cell DM.
 
     es_01's non-vocal modality is called gestural by its source but is scored per
-    lexical item on an adapted CDI, so it is the same construct as the taught-sign
-    counts -- see ``JointModelDefinition.include_es01_cells``.
+    lexical item on an adapted CDI, so it is the same construct as the other
+    sources' signed counts -- see ``JointModelDefinition.include_es01_cells``.
     """
     # Subject random intercepts (issue #59) need a per-child identifier in both
     # data sources (the merged view and the raw uk_02 cross-tab CSV).

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -1189,9 +1189,12 @@ class JointModelDefinition:
     expressive vocabulary (30-300 words) it is 1.05 against 4.80 and 9.68. On the
     conditioning-free share-also-spoken measure it is the low end of a continuous
     gradient rather than categorically apart. Either way the spread across sources
-    is large, plausibly reflecting whether signing was taught alongside speech —
-    both UK sources come from contexts where it is, and uk_07 is an intervention
-    trial — though four studies cannot test that.
+    is large and its cause is not identified. Signing instruction is the obvious
+    candidate, but no source records whether its children were taught to sign, so
+    that contrast is background assumption rather than measurement; and uk_07, the
+    one source with experimental variation in instruction, carries the *higher*
+    association in its control arm (17.93 against 11.65), which cuts against the
+    mechanism rather than for it. Treat the spread as unexplained.
 
     That heterogeneity was disqualifying only because **``psi`` was the only latent
     in this model with no study-level term.** ``delta_u``, ``delta_q`` and ``delta_sign``


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

Two documentation corrections, both prose and comments only. No model, prior, definition or data changes, so no refit is implied and no fitted output is invalidated.

## 1. The high-anchor mean clamp was undocumented

`clamp_mean_above_hi_anchor` levels the logit-linear mean off above the high anchor on the Down syndrome joint and signing models (VG05, VG07–VG10, VG14–VG16), but `methods-models.qmd` presented the mean trajectory as $f(z) = \beta_0 + \beta_1 z + g(z)$ with no mention of it. It is documented thoroughly in `gp_utils.trend_and_gp` and `notes/202608042030-q-mean-extrapolation.md`, but nowhere a reader of the report would look.

This is visible, not theoretical. Comparing VG01 (no clamp) with VG10 (clamped), VG10's expected spoken slope falls from 9.2 words/month over 78–83 months to 2.2 over 84–89 before recovering to 4.4 over 90–100, and its sharpest curvature anywhere between 30 and 110 months is at the anchor itself. A reader sees the gradient change at exactly seven years with nothing in the text to explain it.

The new `{#sec-clamp}` subsection covers the soft-clamp coordinate, why the transition is a softplus rather than a hard minimum (a hard clamp made the first VG10 refit's spoken curve briefly non-monotone, 428.6 words at 84.3 months dipping to 426.6 at 85.6), why it is deliberately one-sided, the bounded cost to the high anchor's interpretation, and which models set it.

## 2. The psi teaching claim is not evidenced

The four within-understood cross-tab sources disagree by an order of magnitude — es_01 0.90, uk_02 6.09, uk_07 13.90, nz_01 14.63 — and `notes/202608121030` explained that spread by whether signing is taught as sign-and-say pairs. Nothing in this repository evidences it. No source records whether its children were taught to sign; `data/vocab_data_es_01.md` describes the CDI-Down instrument in detail and says nothing about instruction. The contrast rests on assumed background practice rather than on measurement.

The note already labelled the reading as unproven in its outstanding list, but stated it flatly in the body, and it had since propagated into two docstrings.

More seriously, `tau_psi`'s docstring offered uk_07 being an intervention trial as *support* for the mechanism. The same note's arm analysis shows the **control** arm carries the higher association (17.93 against 11.65), with the gap present at t1 before any intervention — which cuts against the mechanism rather than for it. That reasoning sat directly alongside a prior specification.

Each site now records the between-source spread as unexplained and keeps the teaching reading as a hypothesis with the arm contrast disclosed beside it. The note's substitution reading is also corrected: es_01's pooled 0.90, with 45% of children individually below 1, is independence rather than substitution.

**Retained deliberately:** the literature review's citations to published work on taught baby signs (real findings, correctly attributed, and not claims about our samples); the note's record of the withdrawn construct framing, which is history worth keeping; and `docs/models/vg15/index.qmd`, which was already hedged correctly. The claim never reached the report prose — `discussion.qmd` and `results-words-signed-total-expressive.qmd` have no instances — so nothing published was affected.

## Checks

`ruff check src/ scripts/`, `npm run spellcheck` and `npm run format:check` all pass. The full `pytest` suite was not run in the authoring environment (no `dse_research_utils`/PyMC available); these changes touch only docstrings and Markdown, but CI should confirm.

## Not included

A behavioural change to *which* means are clamped is held back deliberately. `clamp_mean_above_hi_anchor` applies to both the understood mean and the production ratio, while the recorded justification covers `q` alone, and the evidence suggests clamping `p_U` buys nothing — extrapolating VG10's fitted understood slope from 50–83 months gives $p_U(115) \approx 0.80$–$0.83$ against the clamped fit's 0.826, because the GP absorbs what the linear term stops supplying. That change needs a refit to validate and will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
