### PR TITLE
Filter uncovered points from the age-indexed expressive panels

### DIFF
--- a/scripts/compare_ds_td_expressive.py
+++ b/scripts/compare_ds_td_expressive.py
@@ -89,7 +89,24 @@ COL_D = plot_styles.COLOUR_GREEN
 COL_ALT = plot_styles.COLOUR_PURPLE if hasattr(plot_styles, "COLOUR_PURPLE") else "C3"
 
 
-def _band(ax, frame, x, label, colour, *, cov=0.0):
+def _band(ax, frame, x, label, colour, *, cov=MIN_COVERAGE):
+    """Plot a median line and interval band, dropping low-coverage grid points.
+
+    The default is :data:`MIN_COVERAGE` deliberately. It used to be ``0.0``,
+    which silently overrode ``plot_summary_band``'s own 0.80 default and made
+    *this wrapper* weaker than the library function it delegates to — so the
+    level-indexed panels, which pass ``cov`` explicitly, were filtered while
+    every age-indexed panel was not. On the delay-by-age panel that drew the
+    curves a third of the way past the point where the typically-developing
+    comparator runs out: both equivalent ages saturate at VG13's 18-month
+    ceiling, so the delays rise 1:1 with age and their difference is forced to
+    zero, and at 40 months the plotted interval was a single draw (coverage
+    2.8e-05). Filtering removes exactly that region and nothing else — the
+    sign-inclusive and below-percentile panels are fully covered, so the
+    default costs them no points.
+
+    Pass ``cov=0.0`` to opt out, deliberately and visibly.
+    """
     C.plot_summary_band(ax, frame, x, label, colour, min_coverage=cov)
 
 

--- a/tests/test_expressive_panel_coverage.py
+++ b/tests/test_expressive_panel_coverage.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""The expressive-comparison panels must not plot uncovered grid points.
+
+``scripts/compare_ds_td_expressive.py`` wraps ``comparison.plot_summary_band``
+in a local ``_band`` helper. That helper used to default ``cov=0.0``, which
+overrode the library function's own 0.80 default and made the wrapper weaker
+than the thing it delegates to. Only the three level-indexed calls passed
+``cov`` explicitly, so every age-indexed panel was drawn unfiltered.
+
+On ``ds_td_expressive_delay_by_age`` that mattered: both equivalent ages
+saturate at VG13's 18-month ceiling, above which the delays rise 1:1 with age
+and their difference is forced to zero by arithmetic rather than by anything
+about the children. At 40 months the plotted interval was a single draw
+(coverage 2.8e-05, lower = median = upper).
+
+These tests pin the default and the behaviour, since the regression is
+invisible in the output — an unfiltered panel renders as a longer, smoother
+curve, not as an error.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import matplotlib
+import pandas as pd
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402  (backend must be set first)
+
+_SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "compare_ds_td_expressive.py"
+_SPEC = importlib.util.spec_from_file_location("compare_ds_td_expressive_script", _SCRIPT_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+
+def _frame() -> pd.DataFrame:
+    """Five grid points, the last two below the coverage floor."""
+    return pd.DataFrame({
+        "age_months": [10.0, 20.0, 30.0, 40.0, 50.0],
+        "coverage": [1.0, 1.0, 0.9, 0.03, 0.0000278],
+        "median": [1.0, 2.0, 3.0, 4.0, 5.0],
+        "ci50_lo": [0.5, 1.5, 2.5, 4.0, 5.0],
+        "ci50_hi": [1.5, 2.5, 3.5, 4.0, 5.0],
+        "ci_lo": [0.0, 1.0, 2.0, 4.0, 5.0],
+        "ci_hi": [2.0, 3.0, 4.0, 4.0, 5.0],
+    })
+
+
+def test_band_defaults_to_the_module_coverage_floor():
+    # The bug was a default, not a call site, so the default is what to pin.
+    assert _MODULE._band.__kwdefaults__["cov"] == _MODULE.MIN_COVERAGE
+    assert _MODULE.MIN_COVERAGE == 0.80
+
+
+def test_band_drops_uncovered_points_by_default():
+    fig, ax = plt.subplots()
+    try:
+        _MODULE._band(ax, _frame(), "age_months", "test", "C0")
+        drawn = [line.get_xdata() for line in ax.lines if len(line.get_xdata()) > 1]
+        assert drawn, "expected a median line"
+        assert max(drawn[0]) == 30.0, "the 0.03 and 2.8e-05 coverage points must not be plotted"
+    finally:
+        plt.close(fig)
+
+
+def test_band_can_still_opt_out_explicitly():
+    fig, ax = plt.subplots()
+    try:
+        _MODULE._band(ax, _frame(), "age_months", "test", "C0", cov=0.0)
+        drawn = [line.get_xdata() for line in ax.lines if len(line.get_xdata()) > 1]
+        assert max(drawn[0]) == 50.0
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

Fixes the coverage-filter defect flagged while investigating the sign–speech association.

## The bug

`_band` in `scripts/compare_ds_td_expressive.py` defaulted to `cov=0.0`, which overrode `plot_summary_band`'s own `DEFAULT_MIN_COVERAGE = 0.80` — a wrapper that silently made itself weaker than the library function it delegates to. Only the three level-indexed calls passed `cov` explicitly, so **every age-indexed panel was drawn unfiltered**.

It matters most on `ds_td_expressive_delay_by_age`. VG13's window ends at 18 months, so above roughly 35 months both the comprehension- and production-equivalent ages are pinned at that ceiling. The delays then rise 1:1 with chronological age and their difference is forced to zero *by arithmetic*, not because children are catching up — and the panel drew all of it as if it were signal. At 40 months the plotted interval was a single draw: coverage 2.8 × 10⁻⁵, with lower = median = upper.

## The fix

Changed the **default**, not the call sites, so filtering is what the wrapper does unless a caller opts out visibly. Measured against the cached comparison output:

| panel | grid points before | after |
| --- | ---: | ---: |
| receptive delay | 53 | 19 (16–34 mo) |
| expressive delay | 53 | 21 (16–36 mo) |
| extra expressive Δ_exp | 53 | 19 (16–34 mo) |
| comprehension-equivalent age | 53 | 19 (16–34 mo) |
| sign-inclusive gap / credit | 23 | **23 (unchanged)** |
| below-TD-p10 spoken / understood | 23 / 18 | **23 / 18 (unchanged)** |

The stricter default removes exactly the uncovered region and costs nothing on the other panels, which are fully covered.

CSV output is unchanged — the `coverage` column stays and the frames still carry every grid point. Only what is plotted changes.

## Tests

`tests/test_expressive_panel_coverage.py` pins the default and the behaviour, plus the explicit opt-out. The regression is invisible in the output — an unfiltered panel renders as a longer, smoother curve rather than as an error — so it needs a test rather than review attention.

## Note for whoever regenerates figures

The cached figures under `docs/report/figures/` are gitignored and stale until `compare_ds_td_expressive.py` and `sync_report_figures.py` are re-run. I did not regenerate them: that needs the VG10 (10 GB) and VG13 (41 GB) traces loaded together, which does not fit on a 48 GB machine.

Full suite passes apart from two pre-existing `test_sensitivity_overrides.py` failures (`assert 51 == 49`) that come from uncommitted registry work, not from this change — verified against a clean `origin/main` worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
