### PR TITLE
build(env): adopt dse-research-utils 0.10

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,14 +11,14 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.7.1` (see [Environment setup](#environment-setup)); a commented local-dev override in `environment.yml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.10.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `environment.yml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 
 Hybrid two-layer environment (shared across DSE research repos):
 
 - **Compiled core** — the scientific stack (`numpy`/`scipy`/`pandas`/`pymc`/`nutpie`/`jax`/`arviz`, …) comes from **conda-forge** and must match the canonical spec shipped in `dse-research-utils` (`data/environment-core.yml`) so it cannot drift across repos. Verify with `dse-check-env environment.yml`.
-- **Pip layer** — the pure-Python tail and the shared library. `dse-research-utils` installs from the public git tag `v0.7.1` (`dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.7.1#subdirectory=src/python`); the package itself installs editable (`-e ./`).
+- **Pip layer** — the pure-Python tail and the shared library. `dse-research-utils` installs from the public git tag `v0.10.0` (`dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.10.0#subdirectory=src/python`); the package itself installs editable (`-e ./`).
 
 - **Python environment**: Conda/mamba (environment name `dse-vocab-growth`), Python 3.14, channel `conda-forge`. Create with `mamba env create -f environment.yml`; update with `conda env update -f environment.yml`.
 - **Exact replication**: `conda-lock.yml` pins the compiled environment for `linux-64` and `osx-arm64`; `requirements-pip.lock` pins the pip layer. See `docs/runbooks/environment-locks.md`. Refresh both with `scripts/lock_environment.py` only after an intentional dependency change.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
         patterns:
           - "*"
     ignore:
-      # numpy 2.5 is unreachable for anything depending on pymc: pytensor 3.2.x
+      # numpy 2.5 is unreachable for anything depending on pymc: pytensor 3.3.0
       # pins numba <=0.66.0, and numba 0.66.0 still pins numpy <2.5. The ceiling
       # in pyproject.toml mirrors the shared conda core; raising it only declares
       # a range no resolver can use. Remove once numba supports numpy 2.5.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,14 +11,14 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.7.1` (see [Environment setup](#environment-setup)); a commented local-dev override in `environment.yml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.10.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `environment.yml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 
 Hybrid two-layer environment (shared across DSE research repos):
 
 - **Compiled core** — the scientific stack (`numpy`/`scipy`/`pandas`/`pymc`/`nutpie`/`jax`/`arviz`, …) comes from **conda-forge** and must match the canonical spec shipped in `dse-research-utils` (`data/environment-core.yml`) so it cannot drift across repos. Verify with `dse-check-env environment.yml`.
-- **Pip layer** — the pure-Python tail and the shared library. `dse-research-utils` installs from the public git tag `v0.7.1` (`dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.7.1#subdirectory=src/python`); the package itself installs editable (`-e ./`).
+- **Pip layer** — the pure-Python tail and the shared library. `dse-research-utils` installs from the public git tag `v0.10.0` (`dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.10.0#subdirectory=src/python`); the package itself installs editable (`-e ./`).
 
 - **Python environment**: Conda/mamba (environment name `dse-vocab-growth`), Python 3.14, channel `conda-forge`. Create with `mamba env create -f environment.yml`; update with `conda env update -f environment.yml`.
 - **Exact replication**: `conda-lock.yml` pins the compiled environment for `linux-64` and `osx-arm64`; `requirements-pip.lock` pins the pip layer. See `docs/runbooks/environment-locks.md`. Refresh both with `scripts/lock_environment.py` only after an intentional dependency change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,14 +11,14 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.7.1` (see [Environment setup](#environment-setup)); a commented local-dev override in `environment.yml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.10.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `environment.yml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 
 Hybrid two-layer environment (shared across DSE research repos):
 
 - **Compiled core** — the scientific stack (`numpy`/`scipy`/`pandas`/`pymc`/`nutpie`/`jax`/`arviz`, …) comes from **conda-forge** and must match the canonical spec shipped in `dse-research-utils` (`data/environment-core.yml`) so it cannot drift across repos. Verify with `dse-check-env environment.yml`.
-- **Pip layer** — the pure-Python tail and the shared library. `dse-research-utils` installs from the public git tag `v0.7.1` (`dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.7.1#subdirectory=src/python`); the package itself installs editable (`-e ./`).
+- **Pip layer** — the pure-Python tail and the shared library. `dse-research-utils` installs from the public git tag `v0.10.0` (`dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.10.0#subdirectory=src/python`); the package itself installs editable (`-e ./`).
 
 - **Python environment**: Conda/mamba (environment name `dse-vocab-growth`), Python 3.14, channel `conda-forge`. Create with `mamba env create -f environment.yml`; update with `conda env update -f environment.yml`.
 - **Exact replication**: `conda-lock.yml` pins the compiled environment for `linux-64` and `osx-arm64`; `requirements-pip.lock` pins the pip layer. See `docs/runbooks/environment-locks.md`. Refresh both with `scripts/lock_environment.py` only after an intentional dependency change.

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -13,8 +13,8 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: cdba92b6a107220a5e5a37124e9a21dcbf42ebe5cd7d128b82d7b4275ac49435
-    osx-arm64: 9fe2f7832bc5273a5d9231decbc808994c204598a47b17c622a40d270b4ba3d3
+    linux-64: f79865ddadd0f801e62fc4dcfac0e8f8ec298b1a168145348c93264790f95fc6
+    osx-arm64: 5cdf5f76a032bb3b48ec07a3e80c3fc22c7ed6b31d0407ef754ea10f828de74e
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -46,6 +46,32 @@ package:
   hash:
     md5: a44032f282e7d2acdeb1c240308052dd
     sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
+  category: main
+  optional: false
+- name: _python_abi3_support
+  version: '1.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cpython: ''
+    python-gil: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+  hash:
+    md5: 3845f3d75991bae0fb90884662f4327c
+    sha256: 2a7204314663eeda5dec482a956f0e2eaf289bd5b9953eaaaad0e81aa64638f2
+  category: main
+  optional: false
+- name: _python_abi3_support
+  version: '1.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cpython: ''
+    python-gil: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+  hash:
+    md5: 3845f3d75991bae0fb90884662f4327c
+    sha256: 2a7204314663eeda5dec482a956f0e2eaf289bd5b9953eaaaad0e81aa64638f2
   category: main
   optional: false
 - name: adwaita-icon-theme
@@ -119,39 +145,39 @@ package:
   category: main
   optional: false
 - name: arviz
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    arviz-base: '>=1.2.0,<1.3.0'
-    arviz-plots: '>=1.2.0,<1.3.0'
-    arviz-stats: '>=1.2.0,<1.3.0'
+    arviz-base: '>=1.3.0,<1.4.0'
+    arviz-plots: '>=1.3.0,<1.4.0'
+    arviz-stats: '>=1.3.0,<1.4.0'
     matplotlib-base: '>=3.9'
     python: '>=3.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-1.2.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-1.3.0-pyhc364b38_0.conda
   hash:
-    md5: b2b7e73023e0bb678b746ff41cb608df
-    sha256: 7e707ab2995cc884e16bd6658f8f9497007c643eea47a02572a449de7a88dee2
+    md5: 7edb3d33c0530bb373756886ffede096
+    sha256: c9839a1549e375e07396ab00729478a4b65ab9a5dce94a24b79955dce4622598
   category: main
   optional: false
 - name: arviz
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    arviz-base: '>=1.2.0,<1.3.0'
-    arviz-plots: '>=1.2.0,<1.3.0'
-    arviz-stats: '>=1.2.0,<1.3.0'
+    arviz-base: '>=1.3.0,<1.4.0'
+    arviz-plots: '>=1.3.0,<1.4.0'
+    arviz-stats: '>=1.3.0,<1.4.0'
     matplotlib-base: '>=3.9'
     python: '>=3.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-1.2.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-1.3.0-pyhc364b38_0.conda
   hash:
-    md5: b2b7e73023e0bb678b746ff41cb608df
-    sha256: 7e707ab2995cc884e16bd6658f8f9497007c643eea47a02572a449de7a88dee2
+    md5: 7edb3d33c0530bb373756886ffede096
+    sha256: c9839a1549e375e07396ab00729478a4b65ab9a5dce94a24b79955dce4622598
   category: main
   optional: false
 - name: arviz-base
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -160,14 +186,14 @@ package:
     python: '>=3.12'
     typing_extensions: '>=3.10'
     xarray: '>=2024.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d6e2ad796126fd7e603ac616675871aa
-    sha256: 48c05611eed5d16c7edfaed49d8f4670ddaeca98615aa8e69a0581d31cafae58
+    md5: 7d966cda07f98c63beff11d8888bf846
+    sha256: 051925d29d05bafee0fefa1cf2339da227a9e641539bc988d789c7acc7b75b5b
   category: main
   optional: false
 - name: arviz-base
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -176,98 +202,98 @@ package:
     python: '>=3.12'
     typing_extensions: '>=3.10'
     xarray: '>=2024.11.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-base-1.3.0-pyhd8ed1ab_0.conda
   hash:
-    md5: d6e2ad796126fd7e603ac616675871aa
-    sha256: 48c05611eed5d16c7edfaed49d8f4670ddaeca98615aa8e69a0581d31cafae58
+    md5: 7d966cda07f98c63beff11d8888bf846
+    sha256: 051925d29d05bafee0fefa1cf2339da227a9e641539bc988d789c7acc7b75b5b
   category: main
   optional: false
 - name: arviz-plots
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    arviz-base: '>=1.2,<1.3'
-    arviz-stats: '>=1.2,<1.3'
+    arviz-base: '>=1.3.0,<1.4.0'
+    arviz-stats: '>=1.3.0,<1.4.0'
     python: '>=3.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.2.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.3.0-pyhc364b38_0.conda
   hash:
-    md5: 2bd128a3d52f5848be9242c1bade8c59
-    sha256: 5a38487b3f6cf41b221ac9fe5f7997151b34d5b9d6a39360fc0448d4b448787e
+    md5: 9179ad19ce8ac8c950e68f2df119df05
+    sha256: 5bbe1e5d79f4dfa2129f6ddd1d51bfb5beb88c56147142c28dd58599bff2f863
   category: main
   optional: false
 - name: arviz-plots
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    arviz-base: '>=1.2,<1.3'
-    arviz-stats: '>=1.2,<1.3'
+    arviz-base: '>=1.3.0,<1.4.0'
+    arviz-stats: '>=1.3.0,<1.4.0'
     python: '>=3.12'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.2.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-plots-1.3.0-pyhc364b38_0.conda
   hash:
-    md5: 2bd128a3d52f5848be9242c1bade8c59
-    sha256: 5a38487b3f6cf41b221ac9fe5f7997151b34d5b9d6a39360fc0448d4b448787e
+    md5: 9179ad19ce8ac8c950e68f2df119df05
+    sha256: 5bbe1e5d79f4dfa2129f6ddd1d51bfb5beb88c56147142c28dd58599bff2f863
   category: main
   optional: false
 - name: arviz-stats
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    arviz-base: '>=1.2.0,<1.3.0'
-    arviz-stats-core: ==1.2.0
+    arviz-base: '>=1.3.0,<1.4.0'
+    arviz-stats-core: ==1.3.0
     python: '>=3.12'
     xarray: '>=2024.11.0'
     xarray-einstats: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.2.0-pyh8e99733_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.3.0-pyhfed9c42_0.conda
   hash:
-    md5: 20aeaee6493ba3121a6c86d0f959da67
-    sha256: 0a35c4bed081121a7d9f8a097e9f16c813858c64a1b736931ab54463cd0b328b
+    md5: 7b1c5471a69d8ad08ccc1efb98da2034
+    sha256: ce995271902a1e74493345330fe4f196a9dbd7fc437e580d54aeed1b3fcd4ddd
   category: main
   optional: false
 - name: arviz-stats
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    arviz-base: '>=1.2.0,<1.3.0'
-    arviz-stats-core: ==1.2.0
+    arviz-base: '>=1.3.0,<1.4.0'
+    arviz-stats-core: ==1.3.0
     python: '>=3.12'
     xarray: '>=2024.11.0'
     xarray-einstats: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.2.0-pyh8e99733_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-1.3.0-pyhfed9c42_0.conda
   hash:
-    md5: 20aeaee6493ba3121a6c86d0f959da67
-    sha256: 0a35c4bed081121a7d9f8a097e9f16c813858c64a1b736931ab54463cd0b328b
+    md5: 7b1c5471a69d8ad08ccc1efb98da2034
+    sha256: ce995271902a1e74493345330fe4f196a9dbd7fc437e580d54aeed1b3fcd4ddd
   category: main
   optional: false
 - name: arviz-stats-core
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: linux-64
   dependencies:
     numpy: '>=2'
     python: '>=3.12'
     scipy: '>=1.13'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.2.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.3.0-pyhc364b38_0.conda
   hash:
-    md5: 8ed1d87f4900b33ef4c54ef2d4239e78
-    sha256: 5a137409e86989d193eec40148dca11dfe1e4f58bae4c5e792219a19b0303a87
+    md5: 7dc911002966e30ccda5f5b87127ef9f
+    sha256: c554c69ff56839260f791272368762ec909112cbb96b4704eea47682dde6139a
   category: main
   optional: false
 - name: arviz-stats-core
-  version: 1.2.0
+  version: 1.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     numpy: '>=2'
     python: '>=3.12'
     scipy: '>=1.13'
-  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.2.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/arviz-stats-core-1.3.0-pyhc364b38_0.conda
   hash:
-    md5: 8ed1d87f4900b33ef4c54ef2d4239e78
-    sha256: 5a137409e86989d193eec40148dca11dfe1e4f58bae4c5e792219a19b0303a87
+    md5: 7dc911002966e30ccda5f5b87127ef9f
+    sha256: c554c69ff56839260f791272368762ec909112cbb96b4704eea47682dde6139a
   category: main
   optional: false
 - name: at-spi2-atk
@@ -925,27 +951,27 @@ package:
   category: main
   optional: false
 - name: blas
-  version: '2.308'
+  version: '2.309'
   manager: conda
   platform: linux-64
   dependencies:
     blas-devel: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-2.308-mkl.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-2.309-mkl.conda
   hash:
-    md5: cc70c78e098603488055d0f43608db6e
-    sha256: 93f67e76bfabe87c2e2aa9a0028d751aa6eaa9e2ff3a115e1a789e1fc945a612
+    md5: 9dd0f025349a526353ea91dd9cdf599b
+    sha256: 9c4602333f515e8f39e1807a81cc693a4fb87f2fccd9ca90b8d4441c58d886e5
   category: main
   optional: false
 - name: blas
-  version: '2.308'
+  version: '2.309'
   manager: conda
   platform: osx-arm64
   dependencies:
     blas-devel: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.308-accelerate.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-2.309-accelerate.conda
   hash:
-    md5: 5fabdb9d144b1b88186d79df0ff6a02d
-    sha256: d9604b809048c3d0abfe42da6258e458d01348d42281f67203272bb8485d3049
+    md5: 9871fe8f2c28448c83dff3b0f682b2f5
+    sha256: 5672e4772e459d6bd1a0138e2146ae5c52dfbdeb53ad7b881af2ca31b80f4250
   category: main
   optional: false
 - name: blas-devel
@@ -957,12 +983,12 @@ package:
     libcblas: 3.11.0
     liblapack: 3.11.0
     liblapacke: 3.11.0
-    mkl: '>=2026.0.0,<2027.0a0'
-    mkl-devel: 2026.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.11.0-8_hcf00494_mkl.conda
+    mkl: '>=2026.1.0,<2027.0a0'
+    mkl-devel: 2026.1.*
+  url: https://conda.anaconda.org/conda-forge/linux-64/blas-devel-3.11.0-9_hcf00494_mkl.conda
   hash:
-    md5: a459f3d651df194877b8563553e80409
-    sha256: b360a6028438f3cef9c50d7d9f8dd51b96e9d7dff46b5b67036912e3f8918a83
+    md5: 9163a094430cead29b0e1bf6149ce384
+    sha256: cf440e3dc59cf08d83116c4cd196beab485e08c8641703e93c0dccbc595f51cd
   category: main
   optional: false
 - name: blas-devel
@@ -974,10 +1000,10 @@ package:
     libcblas: 3.11.0
     liblapack: 3.11.0
     liblapacke: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.11.0-8_h55bc449_accelerate.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/blas-devel-3.11.0-9_h55bc449_accelerate.conda
   hash:
-    md5: 59223ab85a12ce4163b6cb1aa3357702
-    sha256: 8800834d25d4f9e3d2093b6f5d3672a9f6d9c65a1e8d79c9b110b672119564dd
+    md5: 0fe2c92600d1483811316c2090233161
+    sha256: cffd54200d9a33820d123b1f29c7b243ff29c47473833a59860ba2c984ecc1aa
   category: main
   optional: false
 - name: brotli
@@ -989,11 +1015,11 @@ package:
     brotli-bin: 1.2.0
     libbrotlidec: 1.2.0
     libbrotlienc: 1.2.0
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-h505cf86_3.conda
   hash:
-    md5: 8ccf913aaba749a5496c17629d859ed1
-    sha256: e511644d691f05eb12ebe1e971fd6dc3ae55a4df5c253b4e1788b789bdf2dfa6
+    md5: 6ff307b78fbfb7dcafb7e25ff8bc9c10
+    sha256: 1f2ccfebe6e0113bfc473b21906372c1ee4eb69bf6faef0ad7f3d4d79af63a98
   category: main
   optional: false
 - name: brotli
@@ -1005,10 +1031,10 @@ package:
     brotli-bin: 1.2.0
     libbrotlidec: 1.2.0
     libbrotlienc: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.2.0-h7d5ae5b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.2.0-hf00d406_3.conda
   hash:
-    md5: 48ece20aa479be6ac9a284772827d00c
-    sha256: 422ac5c91f8ef07017c594d9135b7ae068157393d2a119b1908c7e350938579d
+    md5: aa7df8174ee3b34a5ad8a3160429db68
+    sha256: 7050e1b11876219bd0df375ef3d83fd00f94fb4e13c1ffb21dede0c506893079
   category: main
   optional: false
 - name: brotli-bin
@@ -1019,11 +1045,11 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libbrotlidec: 1.2.0
     libbrotlienc: 1.2.0
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-h9908984_3.conda
   hash:
-    md5: af39b9a8711d4a8d437b52c1d78eb6a1
-    sha256: 64b137f30b83b1dd61db6c946ae7511657eead59fdf74e84ef0ded219605aa94
+    md5: 8929291d9efc59715df1cfa7daf5e3ed
+    sha256: 56b2e5e8a49f9887af74cc63e0d55a3654e60b667ad5558da089549a36ae6a0c
   category: main
   optional: false
 - name: brotli-bin
@@ -1034,10 +1060,10 @@ package:
     __osx: '>=11.0'
     libbrotlidec: 1.2.0
     libbrotlienc: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.2.0-hc919400_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.2.0-he4a93e4_3.conda
   hash:
-    md5: 377d015c103ad7f3371be1777f8b584c
-    sha256: e2d142052a83ff2e8eab3fe68b9079cad80d109696dc063a3f92275802341640
+    md5: d9de6c0ad7e008afdf62fb2ffd450b4a
+    sha256: 1e92cea587c2eaab169e45dae01c149b9889a8249eda296b8b6db39aee708531
   category: main
   optional: false
 - name: bzip2
@@ -1047,10 +1073,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
   hash:
-    md5: d2ffd7602c02f2b316fd921d39876885
-    sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+    md5: e675fabcf81499adc7edf58124fb1e01
+    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
   category: main
   optional: false
 - name: bzip2
@@ -1059,10 +1085,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
   hash:
-    md5: 620b85a3f45526a8bc4d23fd78fc22f0
-    sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
+    md5: b50612e7d190b8061ab4e7dc119cf4d5
+    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
   category: main
   optional: false
 - name: c-ares
@@ -1072,10 +1098,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-h280c20c_1.conda
   hash:
-    md5: 6130ad6705adc993b5d8482b7f66e01f
-    sha256: dee93a82d045f9aa8277829aa465224afa3c7a6ac18388de66099b2be7f705e7
+    md5: 2cef891b791040aab83e218c7d137679
+    sha256: 5139b6afbfaca91c47104ba9a6a40f81211e1c9200e96b73ce3a56f0ca1902f4
   category: main
   optional: false
 - name: c-ares
@@ -1084,10 +1110,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h84a0fba_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h1a92334_1.conda
   hash:
-    md5: 187f3b77e761a2f126f9e09f165cebba
-    sha256: 2bfa6ed107d2d8b5835228f8392050cc12e4b6dd732ee044c4ab503b94ff7f31
+    md5: 7d9390a4d4b43f91652823d870f68065
+    sha256: 104b41473845649101ba8ebf8221c7431256465d34ce380b10e9a90558ed33ac
   category: main
   optional: false
 - name: ca-certificates
@@ -1284,10 +1310,10 @@ package:
     ld64_osx-arm64: '*'
     llvm-openmp: '>=22.1.8'
     llvm-tools: 22.1.8
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-22.1.8-default_cfg_h4d70ba2_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-22.1.8-default_cfg_hbc7c751_6.conda
   hash:
-    md5: aee811a35b870553c0f6705f7d88d911
-    sha256: ecdc85b0cff23f9b707b08983b30e7b63c81e474ffff41baae9fb519a021847a
+    md5: 87a36460157785b995bf8d6e4a5025dd
+    sha256: e5e09704a7b39e001a7aae3cd13e8d6f0161c75cdc58e5a82d46328730792cf8
   category: main
   optional: false
 - name: clang-22
@@ -1300,10 +1326,14 @@ package:
     libclang-cpp22.1: ==22.1.8,>=22.1.8,<22.2.0a0
     libcxx: '>=22.1.8'
     libllvm22: '>=22.1.8,<22.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-22-22.1.8-default_h3bfd001_3.conda
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+    libzlib: '>=1.3.2,<2.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-22-22.1.8-default_hed75349_6.conda
   hash:
-    md5: 8d37f4369517317f62385cc0937b7c55
-    sha256: 0089918b32daaa4c1ae0762309f5d5cad6549624a0d1d32de7405ebfc616914a
+    md5: 8a1a3ac4f1f86f9ff5c63fa6e6c1ef57
+    sha256: 89c0d72eebd973a3c6bbccd83363968a6cbe0ba01eb79c55783bc7943fa87796
   category: main
   optional: false
 - name: clang-scan-deps
@@ -1316,10 +1346,14 @@ package:
     libclang13: '>=22.1.8'
     libcxx: '>=22.1.8'
     libllvm22: '>=22.1.8,<22.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-scan-deps-22.1.8-default_hdae4f07_3.conda
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+    libzlib: '>=1.3.2,<2.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-scan-deps-22.1.8-default_hc257da1_6.conda
   hash:
-    md5: 3d2d8c4fe5e1e8ce8b3986aa9e6152b7
-    sha256: fa518bf9bc7d17ced1a56b0b80b346cf7220e7ffd624a56aaf54d8e24ac7dd09
+    md5: da854da44e32397c0eedae9957259326
+    sha256: d5ab08fccabeb9b0e081b0303ed613fa91c0210878c50d4f05cd9d6e07f6e348
   category: main
   optional: false
 - name: clang_impl_osx-arm64
@@ -1330,17 +1364,17 @@ package:
     __osx: '>=11.0'
     cctools_impl_osx-arm64: ''
     clang-22: ==22.1.8
-    compiler-rt: 22.1.8.*
-    compiler-rt_osx-arm64: ''
+    compiler-rt: 22.1.8
+    compiler-rt_osx-arm64: 22.1.8
     ld64_osx-arm64: '*'
     libxml2: ''
     libxml2-16: '>=2.14.6'
     libzlib: '>=1.3.2,<2.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-22.1.8-default_hd222103_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-22.1.8-default_hc257da1_6.conda
   hash:
-    md5: 78fc1abfa6876f1844935ae3af3bae9d
-    sha256: 72dae57849bf56157dc371fbcb53a56496830e3d611703602973b96a4578a98b
+    md5: 3c3886653db4f1fd24ff9ce536e606b1
+    sha256: a31dd186791d4eed3ec8a40cb2aebdfefd07a66f47739790a3ab87c6d0336a50
   category: main
   optional: false
 - name: clangxx
@@ -1352,10 +1386,14 @@ package:
     clang: ==22.1.8
     clangxx_impl_osx-arm64: ==22.1.8
     libcxx-devel: 22.1.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-22.1.8-default_cfg_h43715c0_3.conda
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+    libzlib: '>=1.3.2,<2.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-22.1.8-default_cfg_h9c16036_6.conda
   hash:
-    md5: c954816249d3735947168e413b708cba
-    sha256: 4201a5b6fcbcdbc972d912a982e88a1258d253939853adb6f390c48a959cbc05
+    md5: d6cc31a5fa0fd68ea6ac33b1b58109e0
+    sha256: 10215770bde46dc19658d2aea82cb69413acaa4f9e7d517fef34c0bdfccc5d99
   category: main
   optional: false
 - name: clangxx_impl_osx-arm64
@@ -1372,10 +1410,10 @@ package:
     libxml2-16: '>=2.14.6'
     libzlib: '>=1.3.2,<2.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-22.1.8-default_hf42e7d6_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-22.1.8-default_h9cdd5ba_6.conda
   hash:
-    md5: 233d9a01138eecd253f6cfa05e525dfc
-    sha256: 80f75ad024b43c7b5564a1587328a31413586d2e1765be182ae74d6b1475b110
+    md5: 0b32fafa8c031ddaffcf16ccbfe51597
+    sha256: 4bdedff1b5090add04ac4f3d5e75da64785972eda6dddf4b084cd5d2a3518756
   category: main
   optional: false
 - name: cloudpickle
@@ -1494,6 +1532,32 @@ package:
   hash:
     md5: cddc851000ce131d757678c2f329eaad
     sha256: 754ab72f1c1ae99ef7c57995f59224dc9632cbd6731fe7e6277437fd01d43156
+  category: main
+  optional: false
+- name: cpython
+  version: 3.14.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.14,<3.15.0a0'
+    python_abi: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_102.conda
+  hash:
+    md5: 6b344ff499096c0b873d202fea1e2fcd
+    sha256: 4d97fdae803c1ed7c704289d1f856d60e5502f24e93e92f9d45fbea37fd9e9a7
+  category: main
+  optional: false
+- name: cpython
+  version: 3.14.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.14,<3.15.0a0'
+    python_abi: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_102.conda
+  hash:
+    md5: 6b344ff499096c0b873d202fea1e2fcd
+    sha256: 4d97fdae803c1ed7c704289d1f856d60e5502f24e93e92f9d45fbea37fd9e9a7
   category: main
   optional: false
 - name: cycler
@@ -1683,27 +1747,27 @@ package:
   category: main
   optional: false
 - name: filelock
-  version: 3.32.2
+  version: 3.32.3
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 977e2b00d5329b6d56ebe94ae1f4b67c
-    sha256: 5476fe77cc2f59389dd348135462892dc20f42114301221648df90a6e9650186
+    md5: 1ef717bcf73da3edcaaf7bf12a1e846c
+    sha256: 43832e6442c59af5d65c6a5afa5a4a5160f6a45c8cc25f5275a9454161c40bfd
   category: main
   optional: false
 - name: filelock
-  version: 3.32.2
+  version: 3.32.3
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 977e2b00d5329b6d56ebe94ae1f4b67c
-    sha256: 5476fe77cc2f59389dd348135462892dc20f42114301221648df90a6e9650186
+    md5: 1ef717bcf73da3edcaaf7bf12a1e846c
+    sha256: 43832e6442c59af5d65c6a5afa5a4a5160f6a45c8cc25f5275a9454161c40bfd
   category: main
   optional: false
 - name: flatbuffers
@@ -1822,7 +1886,7 @@ package:
   category: main
   optional: false
 - name: fontconfig
-  version: 2.18.2
+  version: 2.18.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -1830,17 +1894,17 @@ package:
     libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libgcc: '>=14'
+    libgcc: '>=15'
     libuuid: '>=2.42.2,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.2-h27c8c51_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
   hash:
-    md5: 3c702747058a5d0af93fe71e559327f3
-    sha256: d77a47bc2b340b997c680241751e581672d1d0377a680eaf0b19026f013f56b7
+    md5: 922776b528a470ab5afa81fd42abfa1d
+    sha256: 5a3eb10b18a97223ab06b3a7f0d7f56658db2f2800e2f2af95836fe3bf55ba63
   category: main
   optional: false
 - name: fontconfig
-  version: 2.18.2
+  version: 2.18.3
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -1850,10 +1914,10 @@ package:
     libfreetype6: '>=2.14.3'
     libintl: '>=0.25.1,<1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.2-h2b252f5_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.18.3-h81aa574_1.conda
   hash:
-    md5: 992ac5eb08a3a29b5f465cf90f326471
-    sha256: 9977c3f83d7f383de9bbd8a1ac6fd6eb4485cd9fda1679a9a63b697f4cb45a89
+    md5: 8ac8cc3fe744b484de4387703134d8b2
+    sha256: 004570d35fb0eff73ce3ae49b209a47622d0c2e580dd0dc4c61d59626b386a09
   category: main
   optional: false
 - name: fonts-conda-ecosystem
@@ -1947,10 +2011,10 @@ package:
   dependencies:
     libfreetype: 2.14.3
     libfreetype6: 2.14.3
-  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
   hash:
-    md5: 8462b5322567212beeb025f3519fb3e2
-    sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
+    md5: 2d0ea23b23603e07ca47f23f949f67b6
+    sha256: 612a8e0c1a6ecae23da54d81ef395f6ebb5c8e4468ec2611593ebce75876a4e0
   category: main
   optional: false
 - name: freetype
@@ -1960,10 +2024,10 @@ package:
   dependencies:
     libfreetype: 2.14.3
     libfreetype6: 2.14.3
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.3-hce30654_2.conda
   hash:
-    md5: 7bd06ab4ed807154c2d9031eb5ebf025
-    sha256: 96b33f1e2a32c602b167f43719e3acf89ec742b4a1e25e99ffd0e6f99b38d277
+    md5: 2f4cc7dc2e6622591735c49dda1b92aa
+    sha256: 90681f1d0658cb2fd49a074f644eb4774272499290487a4bebb1c4df01d6997b
   category: main
   optional: false
 - name: fribidi
@@ -1973,10 +2037,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_1.conda
   hash:
-    md5: f9f81ea472684d75b9dd8d0b328cf655
-    sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
+    md5: 1cd10eda5692519d01bb20e086e214c9
+    sha256: 4846a3ca0402f3fe33ad84ed50ab213c6aafde4a0faef3c5002f6bf753e21671
   category: main
   optional: false
 - name: fribidi
@@ -1985,10 +2049,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-h84a0fba_1.conda
   hash:
-    md5: 04bdce8d93a4ed181d1d726163c2d447
-    sha256: d856dc6744ecfba78c5f7df3378f03a75c911aadac803fa2b41a583667b4b600
+    md5: 2bb7d7dd91116b8c85e805b0e08cc67b
+    sha256: 6dd18694340b84290bb1906cc1359502b974aada6a8476cfe6dec3ce0e860af8
   category: main
   optional: false
 - name: gcc
@@ -2024,39 +2088,39 @@ package:
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.7
+  version: 2.44.8
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libglib: '>=2.88.2,<3.0a0'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    libgcc: '>=15'
+    libglib: '>=2.88.3,<3.0a0'
+    libjpeg-turbo: '>=3.2.0,<4.0a0'
     liblzma: '>=5.8.3,<6.0a0'
     libpng: '>=1.6.58,<1.7.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.7-h2b0a6b4_0.conda
+    libtiff: '>=4.7.2,<4.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.8-h68053f1_0.conda
   hash:
-    md5: 5d355db3e937086e22cf4cb5fe19787c
-    sha256: 1c22e37f9d7e06e9e0582ee5a55c2ddd19ea75f71f44eb13b56f504ef5c37aa5
+    md5: 10dab6a745f32ceeac6c9e00d9979797
+    sha256: 4345423572cb80f13acbe52987a880576046a0b42c4e22e3a85e0198ee02aab0
   category: main
   optional: false
 - name: gdk-pixbuf
-  version: 2.44.7
+  version: 2.44.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libglib: '>=2.88.2,<3.0a0'
+    libglib: '>=2.88.3,<3.0a0'
     libintl: '>=0.25.1,<1.0a0'
-    libjpeg-turbo: '>=3.1.4.1,<4.0a0'
+    libjpeg-turbo: '>=3.2.0,<4.0a0'
     liblzma: '>=5.8.3,<6.0a0'
     libpng: '>=1.6.58,<1.7.0a0'
-    libtiff: '>=4.7.1,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.7-h4e57454_0.conda
+    libtiff: '>=4.7.2,<4.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.8-h5867e2c_0.conda
   hash:
-    md5: f717a22e13a1499c9552ffff02d22d64
-    sha256: 69bb2e62a93f6407c9e9ccd4d21fe4d4e5373d64eecd6c5df318144ca4c80953
+    md5: aa0e0c67d3e89789959e0d77c8361b67
+    sha256: 0e91dc3531a3a7c4938abc115d7a49be61284a9a8650b404a37b2123fe5cf7dd
   category: main
   optional: false
 - name: gflags
@@ -2095,10 +2159,10 @@ package:
     libffi: ''
     libgcc: '>=14'
     libglib: ==2.88.3
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.3-h95f0039_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.88.3-h4916ab3_1.conda
   hash:
-    md5: 841fd9387fd3f24ea69a4f679242e32c
-    sha256: ccdad3d9149ca12353583818bdfde9f66753da7e8ea6dd35a6312062e2fe60d2
+    md5: 246c12ff18139b126586eb2d0e906c7e
+    sha256: ffa59cd7b517ed0a5905cc83643d08117f073502b0bdb1cab1835805ecc8da4e
   category: main
   optional: false
 - name: glib-tools
@@ -2110,10 +2174,10 @@ package:
     libffi: ''
     libglib: ==2.88.3
     libintl: '>=0.25.1,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.3-h5f197ff_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.88.3-hd03a632_1.conda
   hash:
-    md5: 607824e2f42f49049c999432385832e3
-    sha256: 672b06a290ae9bd4443f9315334f2dbb6d0ba239b3a1f2ea40fd66321e7a3ac6
+    md5: 842c53118ef3b15433627ee2c384c203
+    sha256: 200aec53216f3323b2072fb994b10fbee018ff3b894162a37222f1f316c3e476
   category: main
   optional: false
 - name: glog
@@ -2184,10 +2248,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
   hash:
-    md5: cf09e9fc938518e91d0706572cadf17a
-    sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
+    md5: f9fe2984587fa8235a6af6004760cd18
+    sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
   category: main
   optional: false
 - name: graphite2
@@ -2197,10 +2261,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-hf6b4638_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.15-h784d473_1.conda
   hash:
-    md5: 0d576cff278a2e60456d5b2c0a1ffda3
-    sha256: c0a060d7b7a05669043ef3f68c7a1025c8594e1ab73735afb64c35e8baa41da5
+    md5: 0c7b78d9ffff4f5a6ca28d346f734d8f
+    sha256: 471f34a187fdb4f2df33e26f2e471b16c239a5b277903f643d9c3a8c9a9f44ec
   category: main
   optional: false
 - name: graphviz
@@ -2420,15 +2484,15 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     cached-property: ''
-    hdf5: '>=2.1.0,<3.0a0'
-    libgcc: '>=14'
-    numpy: '>=1.23,<3'
+    hdf5: '>=1.14.6,<1.14.7.0a0'
+    libgcc: '>=15'
+    numpy: '>=1.25,<3'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_102.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py314he0d6181_103.conda
   hash:
-    md5: d93afa30018997705dd04513eeb5ac0f
-    sha256: 48e18f20bc1ff15433299dd77c20a4160eb29572eea799ae5a73632c6c3d7dfd
+    md5: d2b6a58e91c69c2620dbb2cfe1275321
+    sha256: d04064178601c4053130b41e893f6f2d217a810af923f589adae29316902f1e7
   category: main
   optional: false
 - name: h5py
@@ -2438,89 +2502,77 @@ package:
   dependencies:
     __osx: '>=11.0'
     cached-property: ''
-    hdf5: '>=2.1.0,<3.0a0'
-    numpy: '>=1.23,<3'
+    hdf5: '>=1.14.6,<1.14.7.0a0'
+    numpy: '>=1.25,<3'
     python: '>=3.14,<3.15.0a0,>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h658a3ac_102.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h0382f82_103.conda
   hash:
-    md5: ab9a6c652fd25407c9cf67b9b6b87496
-    sha256: 0762ed080bf45ca475da96796a8883a6c719603c44fa9b07a5883785649a4a0f
+    md5: fdaeaa67e3fdfab6b0030303333e50c2
+    sha256: 7bc6a7cb677420959b1202c7a41b81ef548c046f0a3acf9b424a4f30e1de011b
   category: main
   optional: false
 - name: harfbuzz
-  version: 14.2.1
+  version: 14.3.0
   manager: conda
   platform: linux-64
   dependencies:
-    libharfbuzz-devel: 14.2.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.2.1-ha770c72_1.conda
+    libharfbuzz-devel: 14.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.3.0-ha770c72_0.conda
   hash:
-    md5: 72e956a71241633d8c80aa198fd08784
-    sha256: 853beec89ff91cbbf630f1d305b69153eb28a3cb78af95ddc1fb4d30e524c6f4
+    md5: 7f42f814e1306f83e4cac267baa9acab
+    sha256: 511813aaad42ed2494efc77452738fed7734985e069efc08c279a701b1708ba0
   category: main
   optional: false
 - name: harfbuzz
-  version: 14.2.1
+  version: 14.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libharfbuzz-devel: 14.2.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.2.1-hce30654_1.conda
+    libharfbuzz-devel: 14.3.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-14.3.0-hce30654_0.conda
   hash:
-    md5: 95896299aa1012c7410629b2ee360f87
-    sha256: 8922ec1cd17f558ca38c513d4880b7fadbfa08b38a563880c8c2ceddfcc1fba2
+    md5: aab13bb027c8295f5b09ccb8cd084698
+    sha256: 67042b0e8896f707c60981947ae22fe0c13942283c8d7ac9b8286cc01cc1c2d2
   category: main
   optional: false
 - name: hdf5
-  version: 2.1.0
+  version: 1.14.6
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    aws-c-auth: '>=0.10.4,<0.10.5.0a0'
-    aws-c-common: '>=0.14.2,<0.14.3.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.27.3,<0.27.4.0a0'
-    aws-c-s3: '>=0.12.8,<0.12.9.0a0'
-    aws-c-sdkutils: '>=0.2.7,<0.2.8.0a0'
     libaec: '>=1.1.5,<2.0a0'
-    libcurl: '>=8.21.0,<9.0a0'
+    libcurl: '>=8.20.0,<9.0a0'
     libgcc: '>=14'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h654f344_110.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_110.conda
   hash:
-    md5: 58484580a0f626dbe7d5145f014dbfd4
-    sha256: 548411cb10baf1122c46cfef555936c385137d3637b75bd322e7574eda933842
+    md5: 9c6e11a83468e1d5decae516077a73fb
+    sha256: ac57ce3abbda2a82d6192bc36fbd7fe96e867d84c999ef81a3da034dfd01a995
   category: main
   optional: false
 - name: hdf5
-  version: 2.1.0
+  version: 1.14.6
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    aws-c-auth: '>=0.10.4,<0.10.5.0a0'
-    aws-c-common: '>=0.14.2,<0.14.3.0a0'
-    aws-c-http: '>=0.11.0,<0.11.1.0a0'
-    aws-c-io: '>=0.27.3,<0.27.4.0a0'
-    aws-c-s3: '>=0.12.8,<0.12.9.0a0'
-    aws-c-sdkutils: '>=0.2.7,<0.2.8.0a0'
     libaec: '>=1.1.5,<2.0a0'
-    libcurl: '>=8.21.0,<9.0a0'
+    libcurl: '>=8.20.0,<9.0a0'
     libcxx: '>=19'
     libgfortran: ''
     libgfortran5: '>=14.3.0'
     libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hebe1841_110.conda
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_110.conda
   hash:
-    md5: 0d84c4ec4af6aa69b8f40ab62b72e3bc
-    sha256: 7e66a888a88a92e3da6c5f3dd9a2ff658c1f2fb16f476b2200eb446f092bd5b1
+    md5: 65797138355b90a8e219afcf7e77b273
+    sha256: 6964fee3d3a4a59c85d2589eb5e8c8bff7dde9721854f493cc7b9aca5cd7d4be
   category: main
   optional: false
 - name: hicolor-icon-theme
@@ -2553,10 +2605,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
   hash:
-    md5: 4ef4b977bb216a3001a3334696a80850
-    sha256: d7c260b7e1cf22ce04d6ba8a86eabf4e6c50bc96a5c27fe2ecb32298af3e88eb
+    md5: 72a381cbad04f24b1c2a43ef707f45b4
+    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
   category: main
   optional: false
 - name: icu
@@ -2565,10 +2617,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hc7cc350_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
   hash:
-    md5: 6133ddbb17ba2b50700dd88e9303ce27
-    sha256: f0b22bc30e4cc29e29ba3234cb38497fe8def2c2aae4b775d42fe5b378a018c9
+    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
   category: main
   optional: false
 - name: importlib-metadata
@@ -2729,11 +2781,11 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
   hash:
-    md5: b38117a3c920364aff79f870c984b4a3
-    sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+    md5: ba55d1b89fd7775e67de8291029b4059
+    sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
   category: main
   optional: false
 - name: kiwisolver
@@ -2775,13 +2827,13 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     keyutils: '>=1.6.3,<2.0a0'
     libedit: '>=3.1.20250104,<3.2.0a0,>=3.1.20250104,<4.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
     openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
   hash:
-    md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
-    sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+    md5: 53318d715316929a574f83591308b1f8
+    sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
   category: main
   optional: false
 - name: krb5
@@ -2790,13 +2842,13 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=19'
+    libcxx: '>=21'
     libedit: '>=3.1.20250104,<3.2.0a0,>=3.1.20250104,<4.0a0'
     openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h34f8a20_2.conda
   hash:
-    md5: 8780f41b013d19219faef9c82260744b
-    sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
+    md5: 15235dd10450d67bc25ccafd5b46d2bc
+    sha256: aaea1d42b07769920db2af7471ece9399d2613448863da64ad8272998db5db34
   category: main
   optional: false
 - name: lazy-loader
@@ -3222,11 +3274,11 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    mkl: '>=2026.0.0,<2027.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h5875eb1_mkl.conda
+    mkl: '>=2026.1.0,<2027.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-9_h5875eb1_mkl.conda
   hash:
-    md5: 8ae84a87356b604a62f1aee136ef8efb
-    sha256: e30f7fa2a2fb6985f9ac6604575cb318b9ae44e263f6cacc282daee9dbd6127d
+    md5: 1c05815b5b3742a5f4398d94fec7aa11
+    sha256: a8c8b832fb56469221612e1f33c1c01868146c85721966b663a35d4248121e7e
   category: main
   optional: false
 - name: libblas
@@ -3236,11 +3288,11 @@ package:
   dependencies:
     __osx: '>=11.0'
     libgfortran: ''
-    libgfortran5: '>=14.3.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h3d1d584_accelerate.conda
+    libgfortran5: '>=14.4.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-9_h3d1d584_accelerate.conda
   hash:
-    md5: 38cc5133cd1a83fa70ea930999050f26
-    sha256: 0882a5c6eebdd0fbbb82ebd8b569f8c33e03b3f54acf7e77eafbe588b15e38a5
+    md5: 33f464f01650d5be2d9c2d05533e3d97
+    sha256: 700b9977c9204195efa3ee0913895e344f264fec7a9a5ec0e886e7b2cb4de9b2
   category: main
   optional: false
 - name: libbrotlicommon
@@ -3249,11 +3301,11 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_3.conda
   hash:
-    md5: 72c8fd1af66bd67bf580645b426513ed
-    sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
+    md5: 7a2499a177753582fb7ae7e9dc4a908a
+    sha256: e5864f257f839ffc27d681659bac95901f524f602b9121e5dcc5e2df18437f2d
   category: main
   optional: false
 - name: libbrotlicommon
@@ -3262,10 +3314,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_3.conda
   hash:
-    md5: 006e7ddd8a110771134fcc4e1e3a6ffa
-    sha256: a7cb9e660531cf6fbd4148cff608c85738d0b76f0975c5fc3e7d5e92840b7229
+    md5: b457450ba3f27c4749783c0204bd17b0
+    sha256: 5e62b856b2e77ce98db44133bacab1281b42c1040dcbd69dbacfb80890cff5b0
   category: main
   optional: false
 - name: libbrotlidec
@@ -3275,11 +3327,11 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libbrotlicommon: 1.2.0
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_3.conda
   hash:
-    md5: 366b40a69f0ad6072561c1d09301c886
-    sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
+    md5: 6ab3315dc56618d652c1da42a648a129
+    sha256: dad31b6d104973deb89710929a35651033aad692d4e7793cdb5b786a9bd54678
   category: main
   optional: false
 - name: libbrotlidec
@@ -3289,10 +3341,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_3.conda
   hash:
-    md5: 079e88933963f3f149054eec2c487bc2
-    sha256: 2eae444039826db0454b19b52a3390f63bfe24f6b3e63089778dd5a5bf48b6bf
+    md5: e07a99c6fdd984f4d588060f2f936bf4
+    sha256: 510c9fce0d9ffcf41741dd96fc05db381672109d5665ef002c2e58f0d4ca0118
   category: main
   optional: false
 - name: libbrotlienc
@@ -3302,11 +3354,11 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libbrotlicommon: 1.2.0
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_3.conda
   hash:
-    md5: 4ffbb341c8b616aa2494b6afb26a0c5f
-    sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
+    md5: 2ac965638d4c6b2b38383bb1aebaf543
+    sha256: d37124d0f51816e7d5e3a94bfc9ed3d6174d077f9b4f832d20c5a08b52bebf1f
   category: main
   optional: false
 - name: libbrotlienc
@@ -3316,10 +3368,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_3.conda
   hash:
-    md5: b2b7c8288ca1a2d71ff97a8e6a1e8883
-    sha256: 01436c32bb41f9cb4bcf07dda647ce4e5deb8307abfc3abdc8da5317db8189d1
+    md5: 954c78a9f591bfb12c79beaff7338ec8
+    sha256: eac412417eee2e93c62e9d53559f1f9c14f40b6c41e2c432af8b517596898dd1
   category: main
   optional: false
 - name: libcblas
@@ -3328,10 +3380,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_hfef963f_mkl.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-9_hfef963f_mkl.conda
   hash:
-    md5: 2101410a3915785b2c1595d1ae94e32c
-    sha256: a3ea22126a74321ddf754a0efaf998486ffb8b9ec69fc735b3f0eacb6ffc8a4e
+    md5: cbdd209a7b8cef670cc50830428a3b9d
+    sha256: 8ce1b4cdc6e0feb53c5f8e3cf69b1b2c034f5e2726a4027b2fa6feeb0e7fb93e
   category: main
   optional: false
 - name: libcblas
@@ -3340,10 +3392,10 @@ package:
   platform: osx-arm64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_h752f6bc_accelerate.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-9_h752f6bc_accelerate.conda
   hash:
-    md5: 169b3b3da92c0fed1454c4051dabaadd
-    sha256: 84a62507787e121b85998362816b2424d7f814cf6f8a22625fb636738788351e
+    md5: ca9ab16cae919037f520e8a0e3238857
+    sha256: b3afe0b26f1d67e1d74f7a93aca436814f8a508a7ff304c4226e6add45bb36b8
   category: main
   optional: false
 - name: libclang-cpp22.1
@@ -3355,10 +3407,14 @@ package:
     libgcc: '>=14'
     libllvm22: '>=22.1.8,<22.2.0a0'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h6c227bf_3.conda
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+    libzlib: '>=1.3.2,<2.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.8-default_h08c5240_6.conda
   hash:
-    md5: 864e6d29ec7378b89ff5b5c9c629099e
-    sha256: ccb8bd0a8f2d57675b6a60dabb0cc8becb35c2748ac4ec920d7f7625b93c16d8
+    md5: 4fd9026a57bb45cd15bd08ff8bd0578e
+    sha256: fc2981a8e45dd232ae88cf2580f7e75c258f4dccdc96f879b68ef0a9b45c9a2b
   category: main
   optional: false
 - name: libclang-cpp22.1
@@ -3369,10 +3425,14 @@ package:
     __osx: '>=11.0'
     libcxx: '>=22.1.8'
     libllvm22: '>=22.1.8,<22.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp22.1-22.1.8-default_hdca5a3d_3.conda
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+    libzlib: '>=1.3.2,<2.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp22.1-22.1.8-default_hc257da1_6.conda
   hash:
-    md5: 996a036eabb7a8594626fdc1cf758519
-    sha256: dcc960219fae62d99281e3767b6b3162b15aa53331ac0233c6d72ed99e5a1fbe
+    md5: 08920f1eb3b689caa8a7274d8ce81cb8
+    sha256: 5f16d1b4324284f2a360f56566867fd05c4a9dfbddff650887788f6285f956a9
   category: main
   optional: false
 - name: libclang13
@@ -3385,10 +3445,14 @@ package:
     libgcc: '>=14'
     libllvm22: '>=22.1.8,<22.2.0a0'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_h9692865_3.conda
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+    libzlib: '>=1.3.2,<2.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.8-default_hd70ba2e_6.conda
   hash:
-    md5: 2a913525f4201f1adab2711fcf6f89b3
-    sha256: b90ed8467a692788477c06bc0359fac52ed5651d801ddef189ba4b7ecf3ce38c
+    md5: a8e147873eca89dc1c5d319b027a6cd3
+    sha256: 8475136d3be6c2d16bdb801dcaf8769cb2ba372cad239c89ebd6a58912e14465
   category: main
   optional: false
 - name: libclang13
@@ -3400,10 +3464,14 @@ package:
     libclang-cpp22.1: ==22.1.8
     libcxx: '>=22.1.8'
     libllvm22: '>=22.1.8,<22.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-22.1.8-default_h3bfd001_3.conda
+    libxml2: ''
+    libxml2-16: '>=2.14.6'
+    libzlib: '>=1.3.2,<2.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-22.1.8-default_hed75349_6.conda
   hash:
-    md5: 2c49f55d9c150ce54e7c0f9d21664b47
-    sha256: 3a77e5fa9899d1c93d38799a487db905d5e3f2d8f842aba76b1ac8dc3d27e39c
+    md5: 15daddf398a7a982faf7e88f38ea60cc
+    sha256: 8d7d0ecabc11a7ed0b8cccff96815d8cc1cc712affc0dcdc540d9e18f6e7158f
   category: main
   optional: false
 - name: libcompiler-rt
@@ -3468,15 +3536,15 @@ package:
     krb5: '>=1.22.2,<1.23.0a0'
     libgcc: '>=14'
     libnghttp2: '>=1.68.1,<2.0a0'
-    libpsl: '>=0.22.0,<0.23.0a0'
+    libpsl: '>=0.23.0,<0.24.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hae6b9f4_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-heca4667_4.conda
   hash:
-    md5: f9f72caa23bf43e5d893f040dff262be
-    sha256: 4649ecf9d74893268fbaf748a170ea7bf6cf4493b7ce3c582654b9ffe78c93d3
+    md5: 3f2fd5617cfacac49c85f6dc63842ea1
+    sha256: aff8ef75636d0825ce34911e0bef2f26816e7afd090a9dcb4b9bacab75cbf584
   category: main
   optional: false
 - name: libcurl
@@ -3487,15 +3555,15 @@ package:
     __osx: '>=11.0'
     krb5: '>=1.22.2,<1.23.0a0'
     libnghttp2: '>=1.68.1,<2.0a0'
-    libpsl: '>=0.22.0,<0.23.0a0'
+    libpsl: '>=0.23.0,<0.24.0a0'
     libssh2: '>=1.11.1,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     openssl: '>=3.5.7,<4.0a0'
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-h1359186_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.21.0-hf618e03_4.conda
   hash:
-    md5: 063bec1720e5df7ff059b8f4e6e22e0b
-    sha256: 93d3997deb3a38052eb5a8c7b53f3eeeffe19d15d91243aa76f591c0e8b0ca97
+    md5: 66cf9c5003ee81ecdb0dc9f9df17bbe5
+    sha256: d25be36712d7f854a5f93513b9fbf1b0ee3219975b7fef4a3ee071b021b10167
   category: main
   optional: false
 - name: libcxx
@@ -3542,10 +3610,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
   hash:
-    md5: 6c77a605a7a689d17d4819c0f8ac9a00
-    sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
+    md5: 40f9b31aa9cf007789867df0decd0492
+    sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
   category: main
   optional: false
 - name: libdeflate
@@ -3554,24 +3622,24 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-he7e0567_1.conda
   hash:
-    md5: a6130c709305cd9828b4e1bd9ba0000c
-    sha256: 5e0b6961be3304a5f027a8c00bd0967fc46ae162cffb7553ff45c70f51b8314c
+    md5: 78650d671cb56909bb3e5c13bce310f9
+    sha256: d896f4aa4ce4c590c2838678cb1917356fdb461d2a189991c0280c818c362172
   category: main
   optional: false
 - name: libdrm
-  version: 2.4.127
+  version: 2.4.129
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
+    libgcc: '>=15'
     libpciaccess: '>=0.19,<0.20.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
   hash:
-    md5: d8d16b9b32a3c5df7e5b3350e2cbe058
-    sha256: 7d3187c11b7ae66c5595a8afd5a7ce352a490527fdf6614cab129bc7f2c16ba3
+    md5: 64cc91512b6278c315349dc13c53f680
+    sha256: ea46b0ca0fa16af1f8b329b740e6cd8b4577c5378fa8717b28a885f70668633d
   category: main
   optional: false
 - name: libedit
@@ -3580,12 +3648,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    ncurses: '>=6.5,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+    libgcc: '>=14'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
   hash:
-    md5: c277e0a4d549b03ac1e9d6cbbe3d017b
-    sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+    md5: 50708d3b951d0f8e2d7f2df5b5edc040
+    sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
   category: main
   optional: false
 - name: libedit
@@ -3594,11 +3662,11 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    ncurses: '>=6.5,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321h26f1114_1.conda
   hash:
-    md5: 44083d2d2c2025afca315c7a172eab2b
-    sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
+    md5: 843ef89082f368cb889305084d3b483c
+    sha256: 257c926f19e32bdb981fc674c76966049b6fc73f706bae58e9fed8757ad1da70
   category: main
   optional: false
 - name: libegl
@@ -3634,22 +3702,24 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
   hash:
-    md5: 172bf1cd1ff8629f2b1179945ed45055
-    sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+    md5: 7bc31538d6e3fb349e897353969237ec
+    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
   category: main
   optional: false
 - name: libev
   version: '4.33'
   manager: conda
   platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
   hash:
-    md5: 36d33e440c31857372a72137f78bacf5
-    sha256: 95cecb3902fbe0399c3a7e67a5bed1db813e5ab0e22f4023a5e0f722f2cc214f
+    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
   category: main
   optional: false
 - name: libevent
@@ -3703,28 +3773,28 @@ package:
   category: main
   optional: false
 - name: libffi
-  version: 3.5.2
+  version: 3.7.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
   hash:
-    md5: a360c33a5abe61c07959e449fa1453eb
-    sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+    md5: 0abe40a9880086ca4d2e5daf09dceff9
+    sha256: ac38603008bf1e99b8ed379b1a656a67a70e2841f2b6a069c630cdf6316012d2
   category: main
   optional: false
 - name: libffi
-  version: 3.5.2
+  version: 3.7.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
   hash:
-    md5: 43c04d9cb46ef176bb2a4c77e324d599
-    sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
+    md5: 92e8690d170d46d768c32553458c0105
+    sha256: 2c6ac9a6cd65af89b2bd448518bb1e13b44a2e48c0d469398e37bcfc0092e832
   category: main
   optional: false
 - name: libfreetype
@@ -3733,10 +3803,10 @@ package:
   platform: linux-64
   dependencies:
     libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
   hash:
-    md5: e289f3d17880e44b633ba911d57a321b
-    sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
+    md5: f8054e759d0ddddaf34a5c8fedc900a1
+    sha256: fb12ecb46c30d18d928c0e8fc346ab13b5f6fc8a9cacae4f2f4bb188782586f5
   category: main
   optional: false
 - name: libfreetype
@@ -3745,10 +3815,10 @@ package:
   platform: osx-arm64
   dependencies:
     libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_2.conda
   hash:
-    md5: 0582e67cd14cfed773be2f3b1aba08e0
-    sha256: d5637b01941c0fc8f5cbb1f170c238f4ee153b3c1708b9d50f4f1305438ff051
+    md5: ee1fc5bba400ff0cae27fbf141a1ae0c
+    sha256: 19ce8bd320414cb6b9889ecbf48a3ded848b0d1068b76ff6bea099bd7387d6f3
   category: main
   optional: false
 - name: libfreetype6
@@ -3757,13 +3827,13 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libpng: '>=1.6.55,<1.7.0a0'
+    libgcc: '>=15'
+    libpng: '>=1.6.58,<1.7.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
   hash:
-    md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
-    sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
+    md5: b72a266a9317036fd0464cb98b027cd0
+    sha256: ec607dd5445dd17ff6bf8b7fe6832e5504c226dd91d3aaea7ba83569808b0ce4
   category: main
   optional: false
 - name: libfreetype6
@@ -3774,10 +3844,10 @@ package:
     __osx: '>=11.0'
     libpng: '>=1.6.58,<1.7.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-h2ed5691_2.conda
   hash:
-    md5: a0bb0678f67c464938d3693fa96f6884
-    sha256: abbfffd8a8c776bb8b59a10c8247fc3aa6b17ba0051e9f6d199dca38479f214f
+    md5: 881cfb44ea02cc9849f612725a959660
+    sha256: d9b203d6484ad491b5b5f33d49a9d7a91189d776a9adae53d2b63af18ec11e6a
   category: main
   optional: false
 - name: libgcc
@@ -3960,15 +4030,15 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libffi: '>=3.5.2,<3.6.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
     libgcc: '>=14'
     libiconv: '>=1.18,<2.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h0d30a3d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-h45c3219_1.conda
   hash:
-    md5: 17c3b7b6bcbd35b688c933eb4834c0bc
-    sha256: 69ea4df61403531e5b3e5f3d52ba2837423df361b4eb8727f5b63aaf6de6768a
+    md5: 533cb021c1bfeba9f720e669cd863fdf
+    sha256: 4499458124bcf0bd45e8bd17576f9f007cb1373cb3b01659105443f522bab45c
   category: main
   optional: false
 - name: libglib
@@ -3977,15 +4047,15 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libffi: '>=3.5.2,<3.6.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
     libiconv: '>=1.18,<2.0a0'
     libintl: '>=0.25.1,<1.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.3-ha08bb59_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.88.3-ha531971_1.conda
   hash:
-    md5: 4a9309d9502a08a2d29b1743dcfb0e7f
-    sha256: a14417ae1f3f4a92c5766354eb280342fa6aae72a09af86bf7fcfc12a8c9225c
+    md5: 70a6bcf13dc0dd00fe3fe91190d38771
+    sha256: c9f7273bbe06d1693ff3a2b6f8b49b74e2ef6cbac2cead7aae767f2f5191b7aa
   category: main
   optional: false
 - name: libglvnd
@@ -4161,7 +4231,7 @@ package:
   category: main
   optional: false
 - name: libharfbuzz
-  version: 14.2.1
+  version: 14.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4172,18 +4242,18 @@ package:
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.88.2,<3.0a0'
+    libglib: '>=2.88.3,<3.0a0'
     libpng: '>=1.6.58,<1.7.0a0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.2.1-h17a8019_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.3.0-h17a8019_0.conda
   hash:
-    md5: fb4669c3990b94ea32fbb81f433e9aa6
-    sha256: 821c315f6b5171aa89e735be2ad84e74eb3f898fc7610ee36cfecd95dfa789e8
+    md5: f33637ebded146eafa6b2197c8f597a6
+    sha256: fb72d6f7e90d4927cb53a4e13592559ce74b65052323d5d6dd12499b026c680e
   category: main
   optional: false
 - name: libharfbuzz
-  version: 14.2.1
+  version: 14.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4194,17 +4264,17 @@ package:
     libcxx: '>=19'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libglib: '>=2.88.2,<3.0a0'
+    libglib: '>=2.88.3,<3.0a0'
     libpng: '>=1.6.58,<1.7.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.2.1-h5a65909_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-14.3.0-h5a65909_0.conda
   hash:
-    md5: e8d6e86663316dfbdec7dac532824516
-    sha256: 75860db66af9748572038d1e3a2260eca56ee4b38b9523e042fac8caf4277529
+    md5: 19248fa96b4c573e46bfec7fa3c875fa
+    sha256: 5803da482e914fc5d7ea82b31789471973b03ca58e9caffedd86e175c3aee447
   category: main
   optional: false
 - name: libharfbuzz-devel
-  version: 14.2.1
+  version: 14.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -4216,19 +4286,19 @@ package:
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.88.2,<3.0a0'
-    libharfbuzz: 14.2.1
+    libglib: '>=2.88.3,<3.0a0'
+    libharfbuzz: 14.3.0
     libpng: '>=1.6.58,<1.7.0a0'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.2.1-h17a8019_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.3.0-h17a8019_0.conda
   hash:
-    md5: 99cf21100441e51272f1cd6fe0632a20
-    sha256: 6d8e793042affd18ca1784b7794fab14d16f54f984777ce6ab86bacaa465ab0d
+    md5: 15634b3c7e5a68ca7c6e0bbf84cb2383
+    sha256: 7ce9326c2520ae758f523ae2d72a0762f7494d77fe8cc9a96065df541e1db8e2
   category: main
   optional: false
 - name: libharfbuzz-devel
-  version: 14.2.1
+  version: 14.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -4240,14 +4310,14 @@ package:
     libcxx: '>=19'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libglib: '>=2.88.2,<3.0a0'
-    libharfbuzz: 14.2.1
+    libglib: '>=2.88.3,<3.0a0'
+    libharfbuzz: 14.3.0
     libpng: '>=1.6.58,<1.7.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-devel-14.2.1-h5a65909_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libharfbuzz-devel-14.3.0-h5a65909_0.conda
   hash:
-    md5: e538f961a3042abf8307c5c5a6d6b09b
-    sha256: f3f74f090b6a31fed00d64cbe6bbeed6b2a9b820442714ecb66ada08dec913ea
+    md5: 9b9a765bb25ac591d79ced348d4dc340
+    sha256: ec6822ad0101e1d627aebb04792a0a642a706ba3c12e2691a90c7c3995b09fc1
   category: main
   optional: false
 - name: libhwloc
@@ -4311,10 +4381,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
   hash:
-    md5: 466badda5536d85ddc63ee9404f29735
-    sha256: 716332fd31b3808da7a4235a05212a9e9da05e854864c3def2dea0b5d2bf7610
+    md5: 898d1c9793eaa52efc4727bd84d2e39a
+    sha256: bba8538e6538ed58a8479b332337b96986561f975d06cfa2039a016c2d246ee4
   category: main
   optional: false
 - name: libjpeg-turbo
@@ -4323,10 +4393,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.2.0-h84a0fba_1.conda
   hash:
-    md5: 8f05a69b7e870574a2d366043f1515b1
-    sha256: e2b4fce7cf48705dc182a0aa6c478a47b16202aeb712242caf9c9ab6a19778fa
+    md5: b2f8c8e5a7651a1d7c05404c3a159517
+    sha256: 05006418f9392c9b723e8428808db106de0350a497832f95f921b85ff1072310
   category: main
   optional: false
 - name: liblapack
@@ -4335,10 +4405,10 @@ package:
   platform: linux-64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h5e43f62_mkl.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-9_h5e43f62_mkl.conda
   hash:
-    md5: 370e81464714060008e60ee53825bb3e
-    sha256: 0cb26d433dfa15a392eaeeb8a96ac468f4d007d7e7e37ef7bf46856aaf9a9785
+    md5: 255025c2d2df85b72c9ab3105f7611e4
+    sha256: 3060d9393e7013a192eb55354def1a522348baa57c3ce4dc9cb904bf392a9ac1
   category: main
   optional: false
 - name: liblapack
@@ -4347,10 +4417,10 @@ package:
   platform: osx-arm64
   dependencies:
     libblas: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hcb0d94e_accelerate.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-9_hcb0d94e_accelerate.conda
   hash:
-    md5: 98058173a1b07c96fd2f0bb35e3dea5c
-    sha256: 622f6c759beb2eee046d2e6749c90440186299e72f2a1b5da0fcafd98add4c1d
+    md5: 31673241e570e2a408576fa62f55215b
+    sha256: 181c3fc8ed3fa5728ad8e418aee37c94c556b169ab6fbc620b448f1b5cf0448e
   category: main
   optional: false
 - name: liblapacke
@@ -4361,10 +4431,10 @@ package:
     libblas: 3.11.0
     libcblas: 3.11.0
     liblapack: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-8_hdba1596_mkl.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-9_hdba1596_mkl.conda
   hash:
-    md5: 2709b62eee1b7e49a728e7766f4284b3
-    sha256: a3a3ec318b551073248e24b486879ffd9b85b84ed56ccbb2d6e0d6f24c08a273
+    md5: 8a4e244b80d9239f7ab7a2d1d5786d55
+    sha256: 68f7318c0859627e58708d8eb6e297a945f9c04bff29672ea9e6351791be4c88
   category: main
   optional: false
 - name: liblapacke
@@ -4375,10 +4445,10 @@ package:
     libblas: 3.11.0
     libcblas: 3.11.0
     liblapack: 3.11.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.11.0-8_hbdd07e9_accelerate.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.11.0-9_hbdd07e9_accelerate.conda
   hash:
-    md5: 9e30190e30d9f81efe430b521cfb6202
-    sha256: cc5396c03800d35e531a3269a0f27cd27cf5333971ebf1b2f9df2de294b77f30
+    md5: d2dbdc0cbf29754e1575c0a78f9e66dd
+    sha256: 8cb75e86c882585437003b2be6a5bac9418678cb934e5f154babb9a4b711ead8
   category: main
   optional: false
 - name: libllvm22
@@ -4423,10 +4493,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
   hash:
-    md5: b88d90cad08e6bc8ad540cb310a761fb
-    sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
   category: main
   optional: false
 - name: liblzma
@@ -4435,10 +4505,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
   hash:
-    md5: b1fd823b5ae54fbec272cea0811bd8a9
-    sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
+    md5: 8ab10323068b107661a4b9a4af84f3b5
+    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
   category: main
   optional: false
 - name: libmpdec
@@ -4448,10 +4518,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
   hash:
-    md5: 2c21e66f50753a083cbe6b80f38268fa
-    sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
+    md5: fcfed1dc5053eb1901b66e7b1fc32588
+    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
   category: main
   optional: false
 - name: libmpdec
@@ -4460,10 +4530,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
   hash:
-    md5: 57c4be259f5e0b99a5983799a228ae55
-    sha256: 1089c7f15d5b62c622625ec6700732ece83be8b705da8c6607f4dabb0c4bd6d2
+    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
   category: main
   optional: false
 - name: libnghttp2
@@ -4630,10 +4700,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
   hash:
-    md5: 33082e13b4769b48cfeb648e15bfe3fc
-    sha256: f41721636a7c2e51bc2c642e1127955ab9c81145470714fdaac44d4d09e4af41
+    md5: 35fa2b34bbced424e6976d30f5fde576
+    sha256: addc80c69d362a9e6c40305c493139a8e9ee504b2f45a6687dbdaa9da3c6183c
   category: main
   optional: false
 - name: libpng
@@ -4642,12 +4712,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
+    libgcc: '>=15'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
   hash:
-    md5: eba48a68a1a2b9d3c0d9511548db85db
-    sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
+    md5: fcf71c8d979148873f6f8ad4cfc73d86
+    sha256: c19eefb87d70d9b4b0629fa48414a155a47a1be4f04583ae71ed8c5a9a32fdcb
   category: main
   optional: false
 - name: libpng
@@ -4657,27 +4727,27 @@ package:
   dependencies:
     __osx: '>=11.0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-hf5e6511_1.conda
   hash:
-    md5: 2259ae0949dbe20c0665850365109b27
-    sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
+    md5: e0466c58fd07db190b9a81b5e58539f2
+    sha256: f88da60b348ee1f3e1a9c20fe02142fdafe889f08da0b1cc33c1f3f14460239d
   category: main
   optional: false
 - name: libpq
-  version: '18.4'
+  version: '18.6'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     icu: '>=78.3,<79.0a0'
     krb5: '>=1.22.2,<1.23.0a0'
-    libgcc: '>=14'
+    libgcc: '>=15'
     openldap: '>=2.6.13,<2.7.0a0'
     openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.4-hd5a49e9_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
   hash:
-    md5: 6c9103e7ea739a3bb3505da49a4708c1
-    sha256: f7232cb79a31f5a5bcd499aea930b469cde8b96d26db9541022493fd274d2a6e
+    md5: 72e019c04ed02a179da38c56965802d1
+    sha256: b1eb210c180fda9c445b11cba1286ec250ce2c2a85ccb0551a4ed5423df51e68
   category: main
   optional: false
 - name: libprotobuf
@@ -4712,7 +4782,7 @@ package:
   category: main
   optional: false
 - name: libpsl
-  version: 0.22.0
+  version: 0.23.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -4720,24 +4790,24 @@ package:
     icu: '>=78.3,<79.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.22.0-hf670292_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hf670292_0.conda
   hash:
-    md5: 28fe63e41909020150cca96ec8f73f15
-    sha256: 25bac8c350015dd686b61e2ef50fa6aa3fc7393fd5db14046d03a1f571bdf728
+    md5: c8217f5bdd5b018087bdea081912cda5
+    sha256: 2e6405feb59e3f40a5a4641dfa73afda158046893aa73d478e23415e18997ece
   category: main
   optional: false
 - name: libpsl
-  version: 0.22.0
+  version: 0.23.1
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     icu: '>=78.3,<79.0a0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.22.0-h7a62e17_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpsl-0.23.1-h7a62e17_0.conda
   hash:
-    md5: 4886d347a69b14dd9f2e79146984c522
-    sha256: b907c4288d113df898dccee15fa603630d5ce226e023ca207bd4e047b96a3d2f
+    md5: 75a4cdf128d016141db61732ea462276
+    sha256: 0140cb0d059ac531e476b85a543668b69b7dffec16f0d26269ab6c9b70546921
   category: main
   optional: false
 - name: libraqm
@@ -4863,11 +4933,11 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_1.conda
   hash:
-    md5: c08557d00807785decafb932b5be7ef5
-    sha256: 421f7bd7caaa945d9cd5d374cc3f01e75637ca7372a32d5e7695c825a48a30d1
+    md5: c70eb797aa92a294b09ef8f41f6bd578
+    sha256: fcfa03afe31f40dfabf011629d99836adbebbc3ed1b38c7e9eee9ffc7581975b
   category: main
   optional: false
 - name: libsqlite
@@ -4905,13 +4975,13 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+    libgcc: '>=14'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
   hash:
-    md5: eecce068c7e4eddeb169591baac20ac4
-    sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
+    md5: 5c526561e1d2a2e071941174eae84557
+    sha256: 7e463000fa1cba3f3a6597b776f6ab301d425a96e3bc20d0d9d76a3b9f237aa3
   category: main
   optional: false
 - name: libssh2
@@ -4919,12 +4989,12 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libzlib: '>=1.3.1,<2.0a0'
-    openssl: '>=3.5.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-hbf2880b_1.conda
   hash:
-    md5: b68e8f66b94b44aaa8de4583d3d4cc40
-    sha256: 8bfe837221390ffc6f111ecca24fa12d4a6325da0c8d131333d63d6c37f27e0a
+    md5: d957a8eda98c49b073e8dcfd677c127a
+    sha256: a056e518c3d2d09fbb1778cea80c0c95338fb24adf1a817bbf90fb484850a304
   category: main
   optional: false
 - name: libstdcxx
@@ -5099,10 +5169,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
   hash:
-    md5: aea31d2e5b1091feca96fcfe945c3cf9
-    sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+    md5: 9332b53d0ea93c5d39e33be03a0c611a
+    sha256: 8415001414f488c85b72b9d8cc2071dfb3981a47bc3c8eb56ef91a57d12eae7f
   category: main
   optional: false
 - name: libwebp-base
@@ -5111,10 +5181,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h202fb40_1.conda
   hash:
-    md5: e5e7d467f80da752be17796b87fe6385
-    sha256: a4de3f371bb7ada325e1f27a4ef7bcc81b2b6a330e46fac9c2f78ac0755ea3dd
+    md5: 168a13e329259710b28277abc1395b8e
+    sha256: 0ff54650d470c7e54cbeffdd53a8c063e055a7bcf784388c0385ce5c4741b0f4
   category: main
   optional: false
 - name: libxcb
@@ -5149,15 +5219,16 @@ package:
   category: main
   optional: false
 - name: libxcrypt
-  version: 4.4.36
+  version: 4.4.38
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
   hash:
-    md5: 5aa797f8787fe7a17d1b0821485b5adc
-    sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+    md5: f7a7ff5a6ab331e037abd34f379a631d
+    sha256: f7e9292dd219a6435bbb1223da9586c3e70d66d169c5a92f08db3f2127df04e9
   category: main
   optional: false
 - name: libxkbcommon
@@ -5341,7 +5412,7 @@ package:
   category: main
   optional: false
 - name: llvmlite
-  version: 0.47.0
+  version: 0.48.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5349,30 +5420,30 @@ package:
     libgcc: '>=14'
     libstdcxx: '>=14'
     libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.14,<3.15.0a0'
+    python: ''
     python_abi: 3.14.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.47.0-py314h946fb2a_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.48.0-py314h8f0570d_1.conda
   hash:
-    md5: 22feb934c64b2d62b3b2b278eb40629e
-    sha256: e77292afb920e8b46f75c98a370d79aa4a922ff1ebed38c54381ad5d613c834e
+    md5: 869536d88f55c6235d75805533e30868
+    sha256: f6ef7e67ad5fa82ab6697caa69b6b76df90264b43a6ac5e23b695156d514e7a8
   category: main
   optional: false
 - name: llvmlite
-  version: 0.47.0
+  version: 0.48.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
     libzlib: '>=1.3.2,<2.0a0'
-    python: '>=3.14,<3.15.0a0,>=3.14,<3.15.0a0'
+    python: ''
     python_abi: 3.14.*
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.47.0-py314hc7e35b3_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.48.0-py314h582f951_1.conda
   hash:
-    md5: c555bb3e65064bf7807d0419eb0ae120
-    sha256: 54dbf3a5acc8eb4d0902345145bdf0a658a3ac118ab3d10424c899fb899cda46
+    md5: 6441a7f3066baffbfe9952d1cf1ee8ad
+    sha256: 2e4b585c7612892ea2f6328a32c8c8a7b231cada67a7b62124043827f849718f
   category: main
   optional: false
 - name: lz4-c
@@ -5381,12 +5452,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libstdcxx: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-hee9eb32_2.conda
   hash:
-    md5: 9de5350a85c4a20c685259b889aa6393
-    sha256: 47326f811392a5fd3055f0f773036c392d26fdb32e4d8e7a8197eed951489346
+    md5: e38a3253d72ab07d471483f24947e2a2
+    sha256: b8c0e930183e6b7f83cd35ace102f2b8c2f0faae41dc05255dc72f247dfc556a
   category: main
   optional: false
 - name: lz4-c
@@ -5395,11 +5466,11 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=18'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-hdca3b7d_2.conda
   hash:
-    md5: 01511afc6cc1909c5303cf31be17b44f
-    sha256: 94d3e2a485dab8bdfdd4837880bde3dd0d701e2b97d6134b8806b7c8e69c8652
+    md5: d47f7f3481c6f2fcc4ed22802f61c6dd
+    sha256: 1887867b393eb3c2b336deaffcf228574821ea1e0dcb9ef7bf6c9f59cec40f03
   category: main
   optional: false
 - name: markdown-it-py
@@ -5544,7 +5615,7 @@ package:
   category: main
   optional: false
 - name: mkl
-  version: 2026.0.0
+  version: 2026.1.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5552,54 +5623,52 @@ package:
     _openmp_mutex: '*,>=4.5'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    llvm-openmp: '>=22.1.5'
-    onemkl-license: 2026.0.0
+    llvm-openmp: '>=22.1.8'
     tbb: '>=2023.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.0.0-h0e700b2_915.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hecca717_244.conda
   hash:
-    md5: 44208bd851118db1e20923441f1bb3bb
-    sha256: b23dc574c681cfa9708378b781d206fa790f1944cfb7b4c20177824b96938544
+    md5: 3575c034d908c0567c53ed6a33e9dfd9
+    sha256: 0b903cfa21b1a3396b3468d41b8112d49a5bd7ff6642305791caca3af33fbaf2
   category: main
   optional: false
 - name: mkl-devel
-  version: 2026.0.0
+  version: 2026.1.0
   manager: conda
   platform: linux-64
   dependencies:
-    mkl: 2026.0.0
-    mkl-include: 2026.0.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2026.0.0-ha770c72_915.conda
+    mkl: 2026.1.0
+    mkl-include: 2026.1.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-devel-2026.1.0-ha770c72_244.conda
   hash:
-    md5: 3db2fde9583b30a96f69cfed4c1aad32
-    sha256: 28c05308907195dccd0a62b6a940ca98ae71be0c254a895d0bfbd901f62e996c
+    md5: b87e47f06086656b84565cb1d72ea244
+    sha256: 89b3d2e21c0ac6bb4a0b0495473a8fdda939bf9a50871091cd64e52d640a67ec
   category: main
   optional: false
 - name: mkl-include
-  version: 2026.0.0
+  version: 2026.1.0
   manager: conda
   platform: linux-64
-  dependencies:
-    onemkl-license: 2026.0.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2026.0.0-hf2ce2f3_915.conda
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-include-2026.1.0-ha770c72_244.conda
   hash:
-    md5: 8235451efc38020f8a94b2791fab3cc3
-    sha256: 3f99061261358eb73e1d7d93a368e3c29ff43aaa7cbfe0ac6e89d45e4995a7c8
+    md5: 653b438353669616adf6e78ef62ef6fe
+    sha256: 71cd5db20b5f75183614b814473af582db9dcc4e6651144bbce5517ccfbd9e42
   category: main
   optional: false
 - name: mkl-service
-  version: 2.7.2
+  version: 2.8.0
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-    mkl: '>=2026.0.0,<2027.0a0'
+    mkl: '>=2026.1.0,<2027.0a0'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-service-2.7.2-py314h3e0429d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/mkl-service-2.8.0-py314h3e0429d_0.conda
   hash:
-    md5: c59455f88a2e38505cc7d05a5b904ccf
-    sha256: c70b7a0e68d4f9888b896cba2d9af36aec2e2233d5acbc2cf26135c8758c4a78
+    md5: 3ad114ea01ade2d7a4f16ee7bcf9b15f
+    sha256: b3e279d095f9a244cb468fd90d9a9e53a3d6a29655dac746e4f08cfe146097e0
   category: main
   optional: false
 - name: ml_dtypes
@@ -5658,12 +5727,12 @@ package:
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-    python: 3.14.*
+    python: ''
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.1-py314hf8a3a22_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.2.1-py314hdf3942c_1.conda
   hash:
-    md5: 437187ee6b84e1cb787b8b8194478174
-    sha256: a6f59e73e012318028ebe905eb7843f4a43c5c11205078b932cbb2d55b98f27a
+    md5: 709964d5659d3a2192395a7ac8768b15
+    sha256: 81391bab68e075ddbcf2bfe035c069734ba12832a813b39897155008f431899b
   category: main
   optional: false
 - name: multipledispatch
@@ -5747,10 +5816,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
   hash:
-    md5: fc21868a1a5aacc937e7a18747acb8a5
-    sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+    md5: ee6c0cd80a60961a1f48aa3e0b91f986
+    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
   category: main
   optional: false
 - name: ncurses
@@ -5759,10 +5828,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
   hash:
-    md5: 343d10ed5b44030a2f67193905aea159
-    sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
+    md5: 3dfa0d0316dc246cd44937a557de4501
+    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
   category: main
   optional: false
 - name: nlohmann_json
@@ -5770,10 +5839,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_2.conda
   hash:
-    md5: 16c2a0e9c4a166e53632cfca4f68d020
-    sha256: fd2cbd8dfc006c72f45843672664a8e4b99b2f8137654eaae8c3d46dca776f63
+    md5: fe93be7dd9209e6ae673962e3031ff51
+    sha256: 8f8b554c74b032b3e63a8828fb0ecc7ae4f5c5a6bd0afcf75423d5ff79290cb0
   category: main
   optional: false
 - name: nlohmann_json
@@ -5781,14 +5850,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_2.conda
   hash:
-    md5: 755cfa6c08ed7b7acbee20ccbf15a47c
-    sha256: 1945fd5b64b74ef3d57926156fb0bfe88ee637c49f3273067f7231b224f1d26d
+    md5: 0debf38c50bb3ea6f712c87310a00289
+    sha256: 3c7235b1574907737d09b46b3a0f7f0f5fcafc2380f2c8d02fc55aa23ce47c3c
   category: main
   optional: false
 - name: numba
-  version: 0.65.1
+  version: 0.66.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -5796,32 +5865,32 @@ package:
     _openmp_mutex: '>=4.5'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    llvmlite: '>=0.47.0,<0.48.0a0'
+    llvmlite: '>=0.48.0,<0.49.0a0'
     numpy: '>=1.22.3,<2.5,>=1.23,<3'
-    python: '>=3.14,<3.15.0a0'
+    python: ''
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.65.1-py314h8169c2f_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/numba-0.66.0-py314h42812f9_1.conda
   hash:
-    md5: d74691e038386bb543a574122c72d834
-    sha256: 750f8893a16721394969c030e7778212b99c54aab137a9744cafdb70a6fd513d
+    md5: b2356f05812a7e3a724baa21617035f1
+    sha256: d8ca2096544bcff0aabc44468e3ad8c160222814704af77510bb97d00556c845
   category: main
   optional: false
 - name: numba
-  version: 0.65.1
+  version: 0.66.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
     llvm-openmp: '>=19.1.7'
-    llvmlite: '>=0.47.0,<0.48.0a0'
+    llvmlite: '>=0.48.0,<0.49.0a0'
     numpy: '>=1.22.3,<2.5,>=1.23,<3'
-    python: '>=3.14,<3.15.0a0,>=3.14,<3.15.0a0'
+    python: ''
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.65.1-py314hb38061f_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.66.0-py314h705d3de_1.conda
   hash:
-    md5: 606140802769e37d32f5e83a485e5a4b
-    sha256: 86ab4c3273761dec812c198fcb658c3b8f86b39bb0a3b409a62baff9f19db927
+    md5: 36963987dbd28a0522a99625f54012f8
+    sha256: 891dc017080e256abf5d71ff3b2a76d1440c41ef857303437cbee4d163be842a
   category: main
   optional: false
 - name: numcodecs
@@ -6038,17 +6107,6 @@ package:
     sha256: 3fd55525a5449553618eab86703be7156b1cb4993756aee38ae323ff0b57d253
   category: main
   optional: false
-- name: onemkl-license
-  version: 2026.0.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/onemkl-license-2026.0.0-hf2ce2f3_915.conda
-  hash:
-    md5: f9a902d29c0980c672f77eff7be1794c
-    sha256: fd53c7f3e874b6fd2add63103028ed707b728cc275597d12951886cfcda46e7d
-  category: main
-  optional: false
 - name: openjpeg
   version: 2.5.4
   manager: conda
@@ -6107,10 +6165,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     ca-certificates: ''
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
   hash:
-    md5: 79dd2074b5cd5c5c6b2930514a11e22d
-    sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
+    md5: c5955c27917ff2234def47f075e71e02
+    sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
   category: main
   optional: false
 - name: openssl
@@ -6120,10 +6178,10 @@ package:
   dependencies:
     __osx: '>=11.0'
     ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_1.conda
   hash:
-    md5: 8187a86242741725bfa74785fe812979
-    sha256: b3e3ca895c336d4eb91c5d2f244a312bdb59a0de8cfa0cc4c179225ab2f6bbfb
+    md5: 65d1906712b85d1679263c518d011b5b
+    sha256: 66be2283b5b37dcda1332b5e74c1782a8cb14fd2e62e0d38017c2d35bf73c119
   category: main
   optional: false
 - name: opt_einsum
@@ -6192,27 +6250,27 @@ package:
   category: main
   optional: false
 - name: packaging
-  version: '26.2'
+  version: '26.3'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
   hash:
-    md5: 4c06a92e74452cfa53623a81592e8934
-    sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
+    md5: 936687ed80f295a1f5dbcf8bd34c252c
+    sha256: c432626b16768b8dab228bfb706f7060c2d462a21c516d240f68f2f902b5a044
   category: main
   optional: false
 - name: packaging
-  version: '26.2'
+  version: '26.3'
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+    python: '>=3.9'
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
   hash:
-    md5: 4c06a92e74452cfa53623a81592e8934
-    sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
+    md5: 936687ed80f295a1f5dbcf8bd34c252c
+    sha256: c432626b16768b8dab228bfb706f7060c2d462a21c516d240f68f2f902b5a044
   category: main
   optional: false
 - name: pandas
@@ -6251,7 +6309,7 @@ package:
   category: main
   optional: false
 - name: pango
-  version: 1.58.0
+  version: 1.58.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -6264,18 +6322,18 @@ package:
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
     libgcc: '>=14'
-    libglib: '>=2.88.2,<3.0a0'
-    libharfbuzz: '>=14.2.1'
+    libglib: '>=2.88.3,<3.0a0'
+    libharfbuzz: '>=14.3.0'
     libpng: '>=1.6.58,<1.7.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.58.0-hda50119_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pango-1.58.2-hda50119_0.conda
   hash:
-    md5: ef685e254006246695cbc36cf3fda159
-    sha256: ec020fd570ba116c06592af8d8ce05f41c20b6d673d1a8a7a5a98fecad0f4b14
+    md5: 6a2822aaf9a34ac3708904a47ff3dd7e
+    sha256: 48f27a6c3e4062bc09dafe9c7f6b288c5de5655e81095ab7f1aad920b2163b7b
   category: main
   optional: false
 - name: pango
-  version: 1.58.0
+  version: 1.58.2
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6287,14 +6345,14 @@ package:
     libexpat: '>=2.8.1,<3.0a0'
     libfreetype: '>=2.14.3'
     libfreetype6: '>=2.14.3'
-    libglib: '>=2.88.2,<3.0a0'
-    libharfbuzz: '>=14.2.1'
+    libglib: '>=2.88.3,<3.0a0'
+    libharfbuzz: '>=14.3.0'
     libpng: '>=1.6.58,<1.7.0a0'
     libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.58.0-hf80efc4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.58.2-hf80efc4_0.conda
   hash:
-    md5: 81bffd56a1dee786e084ca8d7bafb86d
-    sha256: dbe0796fba7ccdc4a6934010e92a78c6c06a35fe3975e08c617e99a2151b926a
+    md5: 83c3d3d895dd96f87b0a1916e2c41f70
+    sha256: c300fba11c4cd7cdd7609b6f165981af24d2181d40280ca6af420710c4c7d42e
   category: main
   optional: false
 - name: patsy
@@ -6402,27 +6460,27 @@ package:
   category: main
   optional: false
 - name: pip
-  version: '26.2'
+  version: 26.2.1
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.2-pyh145f28c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda
   hash:
-    md5: 94a03888aec9fd6270bcbdf6592d3196
-    sha256: eb1066222db9d4c4fcf36c4a3c4cc1d122baecc052807061b931ab2ac672d386
+    md5: 573cb3ed111004230ed3de650653cd4d
+    sha256: 0f7021cfb3ff454c91a5e28e1f5060906a52c6d1cde3f879a7d03ac33c28b1c3
   category: main
   optional: false
 - name: pip
-  version: '26.2'
+  version: 26.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.2-pyh145f28c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-26.2.1-pyh145f28c_0.conda
   hash:
-    md5: 94a03888aec9fd6270bcbdf6592d3196
-    sha256: eb1066222db9d4c4fcf36c4a3c4cc1d122baecc052807061b931ab2ac672d386
+    md5: 573cb3ed111004230ed3de650653cd4d
+    sha256: 0f7021cfb3ff454c91a5e28e1f5060906a52c6d1cde3f879a7d03ac33c28b1c3
   category: main
   optional: false
 - name: pixman
@@ -6433,10 +6491,10 @@ package:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
   hash:
-    md5: 7cd77fef4da3e1ca9484394616cb71f1
-    sha256: 9e5b5be056820ade8b09ef73cf9f4bea037eb9887145d0297ac99e0add88878d
+    md5: 0ee5bb30034b081a1386c1e2c98ab0a7
+    sha256: 829d8288764282de5a9f7b9169acb75cc7dc0b6c3fe2535cfe87dea3436bbc5d
   category: main
   optional: false
 - name: pixman
@@ -6446,34 +6504,93 @@ package:
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h784d473_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h784d473_3.conda
   hash:
-    md5: 63b5e8afb859517d0073b295f1aa9589
-    sha256: b7d0a814a3f8f30bba28c83ccfd896e89f90ffd8a763c4cb5fa55abe7ba3cf0c
+    md5: 9a99c0b60efe41c194d01c182d000733
+    sha256: 4779cd57231ce2e96fac643fcbdd4a6f51a57986264545445574e9c4acf526d3
   category: main
   optional: false
 - name: platformdirs
-  version: 4.11.0
+  version: 4.11.3
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.3-pyhcf101f3_0.conda
   hash:
-    md5: 1fadaa6dd1d03d062075f84157ac2cc7
-    sha256: a4b8c7d3b3703d10f93187986d59aec09b22033978945845899beb7f849a7be6
+    md5: 31474b00d0ca5accac14eda09ba11216
+    sha256: 810511c90649ca59fa0174958a210fd5051c0a7848cfbd42c87054a6836726b5
   category: main
   optional: false
 - name: platformdirs
-  version: 4.11.0
+  version: 4.11.3
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.3-pyhcf101f3_0.conda
   hash:
-    md5: 1fadaa6dd1d03d062075f84157ac2cc7
-    sha256: a4b8c7d3b3703d10f93187986d59aec09b22033978945845899beb7f849a7be6
+    md5: 31474b00d0ca5accac14eda09ba11216
+    sha256: 810511c90649ca59fa0174958a210fd5051c0a7848cfbd42c87054a6836726b5
+  category: main
+  optional: false
+- name: polars
+  version: 1.43.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    polars-runtime-32: 1.43.2
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.2-pyh8da0edf_0.conda
+  hash:
+    md5: fbca53c3325e69df796fcef948ec9aaa
+    sha256: 00cdfd4dbf90c68058885e888fb9b1e92d597611206568705214b786229224d5
+  category: main
+  optional: false
+- name: polars
+  version: 1.43.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    polars-runtime-32: 1.43.2
+    python: '>=3.10'
+  url: https://conda.anaconda.org/conda-forge/noarch/polars-1.43.2-pyh8da0edf_0.conda
+  hash:
+    md5: fbca53c3325e69df796fcef948ec9aaa
+    sha256: 00cdfd4dbf90c68058885e888fb9b1e92d597611206568705214b786229224d5
+  category: main
+  optional: false
+- name: polars-runtime-32
+  version: 1.43.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _python_abi3_support: 1.*
+    cpython: '>=3.10'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/polars-runtime-32-1.43.2-py310h9585f58_0.conda
+  hash:
+    md5: 912d8eb6fdbea640f27c5e97859be85b
+    sha256: ba6c79dd4c74a41d866b6716e2d22e1d656f099cbd17b2039c7933181d571793
+  category: main
+  optional: false
+- name: polars-runtime-32
+  version: 1.43.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    _python_abi3_support: 1.*
+    cpython: '>=3.10'
+    libcxx: '>=19'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/polars-runtime-32-1.43.2-py310hcbcba24_0.conda
+  hash:
+    md5: f9c536a3a5d4117e1d5c6b61d8f791ea
+    sha256: 2c7e90b2614257da2cb220b19c4dd420444c7ae8d2692caaedcd43c1184fa01a
   category: main
   optional: false
 - name: preliz
@@ -6551,11 +6668,11 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb03c661_1003.conda
   hash:
-    md5: b3c17d95b5a10c6e64a21fa17573e70e
-    sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+    md5: df2c27f36bdb0dde779f55b5df76a352
+    sha256: afc3b27b2cbb0487c1d0e963f96e71181ecfb623a24fb393bb19ff974a6382a1
   category: main
   optional: false
 - name: pthread-stubs
@@ -6564,10 +6681,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h84a0fba_1003.conda
   hash:
-    md5: 415816daf82e0b23a736a069a75e9da7
-    sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
+    md5: d4852e6054b74645cf49ca10f6349191
+    sha256: 1c2338b9b0486af86883b9593d2f3e2845bbf216ea453dfe5d9a228e8dbe4057
   category: main
   optional: false
 - name: pyarrow
@@ -6668,35 +6785,35 @@ package:
   category: main
   optional: false
 - name: pymc
-  version: 6.2.0
+  version: 6.3.1
   manager: conda
   platform: linux-64
   dependencies:
-    pymc-base: ==6.2.0
+    pymc-base: ==6.3.1
     pytensor: ''
     python-graphviz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pymc-6.2.0-hfd44b2b_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pymc-6.3.1-h13dcb8a_0.conda
   hash:
-    md5: bcd8e84edd6e84598f7cb7858a1891af
-    sha256: b9b52b1799aa1f59a29dc1355d1f5ca62f602223becec7cb316d21f2dc807e5a
+    md5: 308492dc43b0d4d142783f1d1d6a3a48
+    sha256: 8926342c041abe24d8584ca3fb6bd2059b5b07c16a15a4b0a009f391282b8e8b
   category: main
   optional: false
 - name: pymc
-  version: 6.2.0
+  version: 6.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    pymc-base: ==6.2.0
+    pymc-base: ==6.3.1
     pytensor: ''
     python-graphviz: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pymc-6.2.0-hfd44b2b_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pymc-6.3.1-h13dcb8a_0.conda
   hash:
-    md5: bcd8e84edd6e84598f7cb7858a1891af
-    sha256: b9b52b1799aa1f59a29dc1355d1f5ca62f602223becec7cb316d21f2dc807e5a
+    md5: 308492dc43b0d4d142783f1d1d6a3a48
+    sha256: 8926342c041abe24d8584ca3fb6bd2059b5b07c16a15a4b0a009f391282b8e8b
   category: main
   optional: false
 - name: pymc-base
-  version: 6.2.0
+  version: 6.3.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -6705,20 +6822,20 @@ package:
     cloudpickle: ''
     numpy: '>=1.25.0'
     pandas: '>=0.24.0'
-    pytensor-base: '>=3.2.2,<3.3'
+    pytensor-base: '>=3.2.2,<3.4'
     python: '>=3.12'
     rich: '>=13.7.1'
     scipy: '>=1.4.1'
     threadpoolctl: '>=3.1.0,<4.0.0'
     typing_extensions: '>=3.7.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.2.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.3.1-pyhc364b38_0.conda
   hash:
-    md5: 0474966b3d83c45e9401625c996621f7
-    sha256: ef8c872cfa4b6d055cbeea46c3808592a87bb5167d261304916c3e2af5bcdbd5
+    md5: efd3cb76ffcdb10c76a9acada47d2159
+    sha256: 1164bc1e9d5bc098d9a2850d34c30e7e90f3f340058fc8d019e4b6aeac6e0574
   category: main
   optional: false
 - name: pymc-base
-  version: 6.2.0
+  version: 6.3.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -6727,16 +6844,16 @@ package:
     cloudpickle: ''
     numpy: '>=1.25.0'
     pandas: '>=0.24.0'
-    pytensor-base: '>=3.2.2,<3.3'
+    pytensor-base: '>=3.2.2,<3.4'
     python: '>=3.12'
     rich: '>=13.7.1'
     scipy: '>=1.4.1'
     threadpoolctl: '>=3.1.0,<4.0.0'
     typing_extensions: '>=3.7.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.2.0-pyhc364b38_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pymc-base-6.3.1-pyhc364b38_0.conda
   hash:
-    md5: 0474966b3d83c45e9401625c996621f7
-    sha256: ef8c872cfa4b6d055cbeea46c3808592a87bb5167d261304916c3e2af5bcdbd5
+    md5: efd3cb76ffcdb10c76a9acada47d2159
+    sha256: 1164bc1e9d5bc098d9a2850d34c30e7e90f3f340058fc8d019e4b6aeac6e0574
   category: main
   optional: false
 - name: pyparsing
@@ -6789,40 +6906,40 @@ package:
   category: main
   optional: false
 - name: pytensor
-  version: 3.2.3
+  version: 3.3.0
   manager: conda
   platform: linux-64
   dependencies:
     blas: '*'
     gxx: ''
     mkl-service: ''
-    pytensor-base: ==3.2.3
+    pytensor-base: ==3.3.0
     python: ''
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytensor-3.2.3-py314h53f1e19_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytensor-3.3.0-py314ha04e0d8_0.conda
   hash:
-    md5: 3e8fb4fef046e456b62efa9ab763d9b9
-    sha256: de67a15d27aa90d67845c7bda14717aae4a2d5bf858b2fd9e199b59032eac759
+    md5: 9ad1bfa1210ab7383edb3e88dfcc30a8
+    sha256: 422882556b0136fd6939ae8be095e33b187712e642a485e0377a8332f33b23b5
   category: main
   optional: false
 - name: pytensor
-  version: 3.2.3
+  version: 3.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     blas: '*'
     clangxx: ''
-    pytensor-base: ==3.2.3
+    pytensor-base: ==3.3.0
     python: ''
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-3.2.3-py314h7fe1151_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-3.3.0-py314h0ac4119_0.conda
   hash:
-    md5: b700e31ce4599fff19392acd345c200e
-    sha256: 6116d3ade011887d07b7c177db835b8d8e26122de364bfe1f6c5d9959e43c9ee
+    md5: c0d7e06ae86b1159bdb14a5776dba730
+    sha256: 884da424d2d24f2f814422fb6da3904d8496772c77252f3e28ee05f0bfd02684
   category: main
   optional: false
 - name: pytensor-base
-  version: 3.2.3
+  version: 3.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -6830,36 +6947,36 @@ package:
     filelock: '>=3.15'
     libgcc: '>=14'
     libstdcxx: '>=14'
-    numba: '>=0.58,<=0.65.1'
+    numba: '>=0.58,<=0.66.0'
     numpy: '>=1.25,<3,>=2.0'
     python: ''
     python_abi: 3.14.*
     scipy: '>=1,<2'
     setuptools: '>=59.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-3.2.3-np2py314h6477eea_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pytensor-base-3.3.0-np2py314h6477eea_0.conda
   hash:
-    md5: 77330bf2436a086f12b3154d573bd09e
-    sha256: a8341561a97c51200c864737fd7df9afb493271ec7d611fb22d496ddb704a902
+    md5: 139602b6549d6c1df664ca38324826f2
+    sha256: d8bb7357a11263c6a8e7c89bafbb428ce7ba2e00703252553962a1985f5e7fda
   category: main
   optional: false
 - name: pytensor-base
-  version: 3.2.3
+  version: 3.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     filelock: '>=3.15'
     libcxx: '>=19'
-    numba: '>=0.58,<=0.65.1'
+    numba: '>=0.58,<=0.66.0'
     numpy: '>=1.25,<3,>=2.0'
     python: 3.14.*
     python_abi: 3.14.*
     scipy: '>=1,<2'
     setuptools: '>=59.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-3.2.3-np2py314hdd732f0_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pytensor-base-3.3.0-np2py314hdd732f0_0.conda
   hash:
-    md5: 671cf391779c03f232062726bafbbc25
-    sha256: 4999e6a36408033616bba6504514e988b5ed69d011b0027ef3f1de0512f4b7b1
+    md5: 409c5aebeacd76f31045c11dc4fd0e00
+    sha256: 3e1785ef7de319bde45ef29206ea416de87b958677ad45d919a70d5feecbed48
   category: main
   optional: false
 - name: pytensor-distributions
@@ -6899,11 +7016,11 @@ package:
     bzip2: '>=1.0.8,<2.0a0'
     ld_impl_linux-64: '>=2.36.1'
     libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.5.2,<3.6.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
     libgcc: '>=14'
     liblzma: '>=5.8.3,<6.0a0'
     libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.53.3,<4.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
     libuuid: '>=2.42.2,<3.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
@@ -6913,10 +7030,10 @@ package:
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_101_cp314.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
   hash:
-    md5: 78975a41cf3c525da654f17e35bfca9e
-    sha256: ee8f2006e1724b1f2e9e0ccc5a7cfdcab973460faa2f63ac1f6e44fdad4c0344
+    md5: 9b6c336ef7195fbee1c10c09bfcf901b
+    sha256: f5ff5c1fac471dfed4fc4288856a63eb9d771e6042d9f70420d75b9f488400d8
   category: main
   optional: false
 - name: python
@@ -6927,10 +7044,10 @@ package:
     __osx: '>=11.0'
     bzip2: '>=1.0.8,<2.0a0'
     libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.5.2,<3.6.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
     liblzma: '>=5.8.3,<6.0a0'
     libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.53.3,<4.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
     libzlib: '>=1.3.2,<2.0a0'
     ncurses: '>=6.6,<7.0a0'
     openssl: '>=3.5.7,<4.0a0'
@@ -6939,10 +7056,10 @@ package:
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_101_cp314.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-hf4d206d_102_cp314.conda
   hash:
-    md5: 6e9670f5238dfb27ef4f6364ed536cc0
-    sha256: fc70ae73df7798bce7cac7adef7fdfb874208b2623a0e8ccb4354194b8508769
+    md5: 8da4ea285021110e2617f7538c386afc
+    sha256: 9767b5eee5cef50716708787bb3b4225d2a974bcd50653e856f9db5910a4b17e
   category: main
   optional: false
 - name: python-dateutil
@@ -7000,6 +7117,32 @@ package:
   hash:
     md5: d152b7fb7864d920162742b7eb81235b
     sha256: 22903d53c15dfe0f89760e7c39f65f581db91cf0ca40c96c5f3e2e829946dbb3
+  category: main
+  optional: false
+- name: python-gil
+  version: 3.14.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    cpython: 3.14.6.*
+    python_abi: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_102.conda
+  hash:
+    md5: 364ec4bb854ab4ca9ca4e626a55ea8da
+    sha256: b15fb3e5daae788ca78844ee4ee9f1a1b07911cd4e83c484d8c1ce2794c6c93b
+  category: main
+  optional: false
+- name: python-gil
+  version: 3.14.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    cpython: 3.14.6.*
+    python_abi: '*'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.6-h4df99d1_102.conda
+  hash:
+    md5: 364ec4bb854ab4ca9ca4e626a55ea8da
+    sha256: b15fb3e5daae788ca78844ee4ee9f1a1b07911cd4e83c484d8c1ce2794c6c93b
   category: main
   optional: false
 - name: python-graphviz
@@ -7369,27 +7512,27 @@ package:
   category: main
   optional: false
 - name: setuptools
-  version: 83.0.0
+  version: 84.0.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-83.0.0-pyh332efcf_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
   hash:
-    md5: 6bf6acbab2499830180ec88c3aff2fa4
-    sha256: 48a9f96016505debadfc67f06de7ac548decbc38d327409b24b0432ef6f16335
+    md5: 62ac906f1cd582c6c264c95625cb9d6f
+    sha256: 9e200ee5f9ff19a4d94e4b51c4856d53dec849f91032f345cf0c6bc3d51a7183
   category: main
   optional: false
 - name: setuptools
-  version: 83.0.0
+  version: 84.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-83.0.0-pyh332efcf_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
   hash:
-    md5: 6bf6acbab2499830180ec88c3aff2fa4
-    sha256: 48a9f96016505debadfc67f06de7ac548decbc38d327409b24b0432ef6f16335
+    md5: 62ac906f1cd582c6c264c95625cb9d6f
+    sha256: 9e200ee5f9ff19a4d94e4b51c4856d53dec849f91032f345cf0c6bc3d51a7183
   category: main
   optional: false
 - name: sigtool-codesign
@@ -7399,11 +7542,11 @@ package:
   dependencies:
     __osx: '>=11.0'
     libsigtool: 0.1.3
-    openssl: '>=3.5.4,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_1.conda
   hash:
-    md5: ade77ad7513177297b1d75e351e136ce
-    sha256: f3d006e2441f110160a684744d90921bbedbffa247d7599d7e76b5cd048116dc
+    md5: a322c0a0d3b5be99ee11f9ccec99b60e
+    sha256: 7efd6d7d18bf9cc5788bfe1c1e1620d9dbbe00a81c646814929a82ff31944cf3
   category: main
   optional: false
 - name: six
@@ -7517,11 +7660,11 @@ package:
   dependencies:
     __osx: '>=11.0'
     libcxx: '>=19.0.0.a0'
-    ncurses: '>=6.5,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_2.conda
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-hb561403_3.conda
   hash:
-    md5: 555070ad1e18b72de36e9ee7ed3236b3
-    sha256: de6893e53664e769c1b1c4103a666d436e3d307c0eb6a09a164e749d116e80f7
+    md5: 0676b8719dd1e9bb1003e59a481c6c3e
+    sha256: 9f1cc109e6e57861110e9de6e03beca7fd2b7fbdb46124cccc07990b0844d88a
   category: main
   optional: false
 - name: tbb
@@ -7591,7 +7734,7 @@ package:
   category: main
   optional: false
 - name: tornado
-  version: 6.5.7
+  version: 6.5.8
   manager: conda
   platform: linux-64
   dependencies:
@@ -7599,24 +7742,24 @@ package:
     libgcc: '>=14'
     python: '>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py314h5bd0f2a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py314h5bd0f2a_0.conda
   hash:
-    md5: 4a8e5889712641aabdf6695e292857fe
-    sha256: bbb7056f7c5fd606df16ed73ee68687050de2c02fd69a3f69a1cb533a7ed2ae8
+    md5: faea84d2f2ccadf70cf9e55381d75b3e
+    sha256: ebec0d90f99fa7bbe91eabab41ee77d3f36dbd58ec2f08aa4220fdd713610b6d
   category: main
   optional: false
 - name: tornado
-  version: 6.5.7
+  version: 6.5.8
   manager: conda
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
     python: '>=3.14,<3.15.0a0,>=3.14,<3.15.0a0'
     python_abi: 3.14.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py314h6c2aa35_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.8-py314h6c2aa35_0.conda
   hash:
-    md5: cc1d84777343f00f01c08a2d9550f639
-    sha256: 1a4f3d940cf239acde2fc61674b7cf80219a7f22a369e92b95b245be2d47caf1
+    md5: ab1bd70ec9c95d199f8ce456823004ab
+    sha256: 4af8e4394d249619b4f1641c82fd6c0a8b97d51991ca2986095bed400c2e5eb9
   category: main
   optional: false
 - name: tqdm
@@ -7727,13 +7870,13 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.5.2,<3.6.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
     libgcc: '>=14'
     libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-hd6090a7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-h1964d1d_1.conda
   hash:
-    md5: b34c5559f45d8996e3bc0b6250a6cc84
-    sha256: 6b9e182021ef3a64ab3bf788ebdab6de6775035612237c639ccafc941639eb13
+    md5: 47e3c5d0b1e968ee49efc7c3fa8ebc0c
+    sha256: a8f1333274382d23721d6f72483ece364631231f8ac3f74389951b1ff2820148
   category: main
   optional: false
 - name: wrapt
@@ -7928,11 +8071,11 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
   hash:
-    md5: fb901ff28063514abb6046c9ec2c4a45
-    sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+    md5: 85c9442aec283b4e464fa9ecc484a2f3
+    sha256: 49b532d1df875c6749d9078b56a76f3f5db49a5abe0ca620b593ed474ef0ebf1
   category: main
   optional: false
 - name: xorg-libsm
@@ -7941,13 +8084,13 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=13'
-    libuuid: '>=2.38.1,<3.0a0'
+    libgcc: '>=14'
+    libuuid: '>=2.42.2,<3.0a0'
     xorg-libice: '>=1.1.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
   hash:
-    md5: 1c74ff8c35dcadf952a16f752ca5aa49
-    sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+    md5: aa7459ed9ad086ba11dda843d764b33d
+    sha256: ef907caee0665cf3b0f775602cc50e388e3bade8ce22ecade0873ff26604b2fd
   category: main
   optional: false
 - name: xorg-libx11
@@ -7971,10 +8114,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
   hash:
-    md5: b2895afaf55bf96a8c8282a2e47a5de0
-    sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+    md5: f06ef439c280a5f90b8bf62355008dbc
+    sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
   category: main
   optional: false
 - name: xorg-libxau
@@ -7983,10 +8126,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h84a0fba_2.conda
   hash:
-    md5: 78b548eed8227a689f93775d5d23ae09
-    sha256: adae11db0f66f86156569415ed79cda75b2dbf4bea48d1577831db701438164f
+    md5: 31d71ce1b056f69b6ec67ee0712bdf97
+    sha256: 5c5ea38ceec008e4ff40111fc166b04086fca310b0aa9e5bd46f65e6b0dcb71d
   category: main
   optional: false
 - name: xorg-libxcomposite
@@ -8043,10 +8186,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
   hash:
-    md5: 1dafce8548e38671bea82e3f5c6ce22f
-    sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+    md5: 2e66c929f3d879708335b6ea4557c838
+    sha256: c50a16c05ccd7fe7dd6d6cfb539f4e9a491d50f9ed7a5c902fec638f7d0d27be
   category: main
   optional: false
 - name: xorg-libxdmcp
@@ -8055,10 +8198,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-h84a0fba_2.conda
   hash:
-    md5: 9d1299ace1924aa8f4e0bc8e71dd0cf7
-    sha256: f7fa0de519d8da589995a1fe78ef74556bb8bc4172079ae3a8d20c3c81354906
+    md5: f51e9414bf1b7bb556aac1a0b74a75fe
+    sha256: 2f6915f0897ace4a1b5d66d0463079f7bc9819b0048c03677e47764f0a743499
   category: main
   optional: false
 - name: xorg-libxext
@@ -8189,10 +8332,10 @@ package:
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-h280c20c_1.conda
   hash:
-    md5: aa8d21be4b461ce612d8f5fb791decae
-    sha256: 7a8c64938428c2bfd016359f9cb3c44f94acc256c6167dbdade9f2a1f5ca7a36
+    md5: 3b51576511038b50fdbd05245e22e4b1
+    sha256: 051c6088bf2381840fcf8764737b829cc6c5f793718d2417d097d6e3b153eba9
   category: main
   optional: false
 - name: yaml
@@ -8221,7 +8364,7 @@ package:
   category: main
   optional: false
 - name: zarr
-  version: 3.2.1
+  version: 3.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -8231,15 +8374,15 @@ package:
     numpy: '>=2'
     packaging: '>=22.0'
     python: '>=3.12'
-    typing_extensions: '>=4.13'
-  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
+    typing_extensions: '>=4.14'
+  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.3.0-pyhc364b38_0.conda
   hash:
-    md5: b787cd1f01e24b161261438a5589df51
-    sha256: 88716d633ac7fdc896ce7aa00efdfc91df6363d51bebabfb60d34399c023a3d0
+    md5: 9ea26dd8ab46e83b7b7faaa891037471
+    sha256: 9563025fbe0aab05a099651d087747dda6eea21605e13fbc920c555dc14936b2
   category: main
   optional: false
 - name: zarr
-  version: 3.2.1
+  version: 3.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -8249,11 +8392,11 @@ package:
     numpy: '>=2'
     packaging: '>=22.0'
     python: '>=3.12'
-    typing_extensions: '>=4.13'
-  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
+    typing_extensions: '>=4.14'
+  url: https://conda.anaconda.org/conda-forge/noarch/zarr-3.3.0-pyhc364b38_0.conda
   hash:
-    md5: b787cd1f01e24b161261438a5589df51
-    sha256: 88716d633ac7fdc896ce7aa00efdfc91df6363d51bebabfb60d34399c023a3d0
+    md5: 9ea26dd8ab46e83b7b7faaa891037471
+    sha256: 9563025fbe0aab05a099651d087747dda6eea21605e13fbc920c555dc14936b2
   category: main
   optional: false
 - name: zipp
@@ -8312,12 +8455,12 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
   hash:
-    md5: 2aadb0d17215603a82a2a6b0afd9a4cb
-    sha256: ea4e50c465d70236408cb0bfe0115609fd14db1adcd8bd30d8918e0291f8a75f
+    md5: 1726acec19beeed1c764385cd8622405
+    sha256: 8b786bb4380fa69a718b08a400040b865bc9207eda337e0a1955717c3c3a9403
   category: main
   optional: false
 - name: zlib-ng
@@ -8326,11 +8469,11 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-h31dac16_1.conda
   hash:
-    md5: d99c2a23a31b0172e90f456f580b695e
-    sha256: a339606a6b224bb230ff3d711e801934f3b3844271df9720165e0353716580d4
+    md5: 4621ded2fd5b36f51454d5f81bff4ec1
+    sha256: 489a29915a3e1b425cff4df10a448f55bbaaf29d777a0f8a9e381444e6a284f1
   category: main
   optional: false
 - name: zstd
@@ -8339,11 +8482,11 @@ package:
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
   hash:
-    md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
-    sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+    md5: aa459086047c0e5e27023ab19f8cb86a
+    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
   category: main
   optional: false
 - name: zstd
@@ -8352,10 +8495,10 @@ package:
   platform: osx-arm64
   dependencies:
     __osx: '>=11.0'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
   hash:
-    md5: ab136e4c34e97f34fb621d2592a393d8
-    sha256: 9485ba49e8f47d2b597dd399e88f4802e100851b27c21d7525625b0b4025a5d9
+    md5: 4ec2684c73812cc2c3d78379384a39cc
+    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
   category: main
   optional: false

--- a/environment.yml
+++ b/environment.yml
@@ -6,23 +6,23 @@ dependencies:
   # Must match dse-research-utils' data/environment-core.yml exactly. Verify:
   #   dse-check-env environment.yml
   - python=3.14.6
-  - numpy>=2.4.6,<2.5 # pymc -> pytensor 3.x -> numba -> numpy<2.5; numba 0.66.0 still pins <2.5, so lifting this needs a numba release that supports 2.5
+  - numpy>=2.4.6,<2.5 # pymc 6.3.1 -> pytensor 3.3.0 -> numba <=0.66.0 -> numpy <2.5; numpy 2.5.2 remains unreachable
   - scipy>=1.18.0
   - pandas>=3.0.5
   - pyarrow>=24.0.0 # pandas 3.x's default `str` dtype is Arrow-backed; floor held at 24 by jaxlib's libabseil pin
-  - numba>=0.58,<=0.66.0 # cap tracks the admitted pytensor: 3.2.4 raised its own cap from <=0.65.1 to <=0.66.0, and pymc>=6.2.0 admits 3.2.4. Does not lift the numpy cap — numba 0.66.0 still pins numpy <2.5
+  - numba>=0.58,<=0.66.0 # pymc 6.3.1 admits pytensor 3.3.0, which caps numba at 0.66.0; numba still pins numpy <2.5
   - matplotlib>=3.11.1
   - scikit-learn>=1.9.0
   - statsmodels>=0.14.6
   - polars>=1.43.2 # canonical core (not used by this repo, but the core is a single lockstep spec)
-  - pymc>=6.2.0 # pulls pytensor + a C toolchain from conda-forge; requires pytensor >=3.2.2,<3.3 -> numba <=0.66.0 -> numpy <2.5
+  - pymc>=6.3.1 # pulls current pytensor 3.3.0 + a C toolchain; pytensor caps numba <=0.66.0 -> numpy <2.5
   - nutpie>=0.16.11
   - numpyro>=0.21.0
   - jax>=0.10.2 # CPU build; GPU acceleration via an environment-gpu.yml overlay
-  - arviz>=1.2.0
-  - arviz-base>=1.2.0
-  - arviz-stats>=1.2.0
-  - arviz-plots>=1.2.0
+  - arviz>=1.3.0
+  - arviz-base>=1.3.0
+  - arviz-stats>=1.3.0
+  - arviz-plots>=1.3.0
   - preliz>=0.27.1
   - h5py>=3.16.0
   - h5netcdf>=1.8.1
@@ -42,7 +42,7 @@ dependencies:
       # notebook (ipython/ipywidgets/notebook/jupytext), io (orjson/tabulate).
       # This also pulls dse-research-utils' own runtime deps (azure-identity/
       # -storage-blob, rich, psutil, pyyaml, …) — no need to list them here.
-      - dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.9.2#subdirectory=src/python
+      - dse-research-utils[viz,notebook,io] @ git+https://github.com/dseinternational/research.git@v0.10.0#subdirectory=src/python
       - -e ./
       # Local-dev override — to develop against a sibling checkout of research,
       # comment the git line above and uncomment this instead:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,11 @@ license = { text = "AGPL-3.0-or-later" }
 authors = [{ name = "Frank Buckley" }]
 
 dependencies = [
-  "arviz-plots>=1.2.0",
-  "arviz-stats>=1.2.0",
-  "arviz>=1.2.0",
+  "arviz-plots>=1.3.0",
+  "arviz-stats>=1.3.0",
+  "arviz>=1.3.0",
   "duckdb>=1.5.5",
-  "dse-research-utils>=0.9.2",
+  "dse-research-utils>=0.10.0",
   # jaxlib is conda-owned but only arrives transitively via jax; environment.yml
   # does not declare it (nothing here imports it directly — it is numpyro's
   # backend). Keep this floor at or below what the conda layer may solve to —
@@ -30,7 +30,7 @@ dependencies = [
   "nutpie>=0.16.11",
   "pandas>=3.0.5",
   "preliz>=0.27.1",
-  "pymc>=6.2.0",
+  "pymc>=6.3.1",
   "scipy>=1.18.0",
   "rich>=15.0.0",
   "xarray>=2026.7.0"
@@ -49,7 +49,7 @@ dev = [
 # dse-research-utils isn't published to PyPI — resolve it from the public git
 # tag. (The conda env in environment.yml installs it from the same tag in its
 # pip layer; this entry is only consumed by uv.)
-dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.9.2" }
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.10.0" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"


### PR DESCRIPTION
> [!NOTE]
> Drafted by a LLM-based AI tool (Codex/GPT-5).

## Summary

- Adopt dse-research-utils 0.10.0 and its shared PyMC 6.3.1, PyTensor 3.3.0, and ArviZ 1.3.0 environment.
- Regenerate the conda lock for linux-64 and osx-arm64 from the updated environment.
- Keep repository guidance and Dependabot configuration synchronized with the new shared-library version.

## Validation

- 596 tests passed.
- Ruff lint passed.
- Spellcheck and Markdown format checks passed.
- Fresh conda solves and the shared environment check passed for both supported platforms.

## Release dependency

This draft depends on [dseinternational/research#85](https://github.com/dseinternational/research/pull/85). After the dse-research-utils v0.10.0 tag is published, refresh requirements-pip.lock from that immutable release commit before this PR is merged.