### PR TITLE
Adopt the shared helpers from dse-research-utils v0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ environments = [
 # dse-research-utils isn't published to PyPI — resolve it from the public git
 # tag. To develop against a sibling checkout instead, comment this out and use:
 #   dse-research-utils = { path = "../research/src/python", editable = true }
-dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.11.2" }
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.12.0" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"

--- a/scripts/crosswalk_dse_oxford.py
+++ b/scripts/crosswalk_dse_oxford.py
@@ -18,6 +18,7 @@ Usage:
 import argparse
 
 import arviz as az
+import dse_research_utils.statistics.intervals as stats_intervals
 import duckdb
 import numpy as np
 import pandas as pd
@@ -101,8 +102,10 @@ def count_ratio(idata, age, age_varying: bool):
     return (LEN_DSE * p_dse) / (LEN_OXF * p_oxf)
 
 
-def _hdi(x):
-    return np.percentile(x, [5, 50, 95])
+def _eti_90(x):
+    # A 90% equal-tailed interval; this was previously (mis)printed as an HDI.
+    lo, hi = stats_intervals.eti_1d(x, eti_prob=0.90)
+    return lo, float(np.median(np.asarray(x)[np.isfinite(x)])), hi
 
 
 def report(df: pd.DataFrame, outcome: str, seed: int, draws: int, tune: int) -> None:
@@ -114,22 +117,22 @@ def report(df: pd.DataFrame, outcome: str, seed: int, draws: int, tune: int) -> 
     print(f"  max r-hat {float(summ['r_hat'].max()):.3f}   "
           f"min ess {float(summ['ess_bulk'].min()):.0f}")
 
-    lo, md, hi = _hdi(idata.posterior["delta"].values.ravel())
-    print(f"  delta (logit offset): median {md:.3f}  90% HDI [{lo:.3f}, {hi:.3f}]  "
+    lo, md, hi = _eti_90(idata.posterior["delta"].values.ravel())
+    print(f"  delta (logit offset): median {md:.3f}  90% ETI [{lo:.3f}, {hi:.3f}]  "
           f"(0 = per-form; {np.log(LEN_DSE / LEN_OXF):.3f} = length-only)")
 
     print("  R = DSE/Oxford count ratio by age (population level):")
     for age in REPORT_AGES:
-        lo, md, hi = _hdi(count_ratio(idata, age, age_varying=False))
-        print(f"    age {age:2d}: median {md:.3f}  90% HDI [{lo:.3f}, {hi:.3f}]")
+        lo, md, hi = _eti_90(count_ratio(idata, age, age_varying=False))
+        print(f"    age {age:2d}: median {md:.3f}  90% ETI [{lo:.3f}, {hi:.3f}]")
     r_mid = count_ratio(idata, float(np.median(d.age)), age_varying=False)
     print(f"  P(R > 1) = {np.mean(r_mid > 1):.3f}   P(R < 1.95) = {np.mean(r_mid < 1.95):.3f}  "
           f"(at median age {np.median(d.age):.0f})")
 
     idata_av, _ = fit(df, outcome, age_varying=True, seed=seed, draws=draws, tune=tune)
-    lo, md, hi = _hdi(idata_av.posterior["delta1"].values.ravel())
+    lo, md, hi = _eti_90(idata_av.posterior["delta1"].values.ravel())
     excludes = "yes" if (lo > 0 or hi < 0) else "no"
-    print(f"  age-varying delta1: median {md:+.3f}  90% HDI [{lo:+.3f}, {hi:+.3f}]  "
+    print(f"  age-varying delta1: median {md:+.3f}  90% ETI [{lo:+.3f}, {hi:+.3f}]  "
           f"(CI excludes 0? {excludes})")
 
 

--- a/scripts/experiments/vg16_crosslag_quantification.py
+++ b/scripts/experiments/vg16_crosslag_quantification.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import argparse
 import os
 
+import dse_research_utils.statistics.intervals as stats_intervals
 import numpy as np
 import xarray as xr
 
@@ -65,7 +66,8 @@ def sig(x):
 
 
 def eti(v, label, fmt="{: .4f}"):
-    lo, med, hi = np.percentile(v, [5.5, 50, 94.5])
+    lo, hi = stats_intervals.eti_1d(v, eti_prob=stats_intervals.DEFAULT_CI_PROB)
+    med = float(np.median(v))
     print(f"  {label:58s} {fmt.format(med)}  [{fmt.format(lo).strip()}, {fmt.format(hi).strip()}]")
     return med, lo, hi
 

--- a/scripts/experiments/vg19_individual_trajectories.py
+++ b/scripts/experiments/vg19_individual_trajectories.py
@@ -27,6 +27,7 @@ Hard-coded to the output root of the machine the 2026-08-22 run happened on.
 Cited by ``notes/202608220748-vg19-individual-trajectories.md``.
 """
 
+import dse_research_utils.statistics.intervals as stats_intervals
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -59,7 +60,8 @@ def sd(t0, t1, r, a):
 
 
 def eti89(x):
-    return np.mean(x), np.quantile(x, 0.055), np.quantile(x, 0.945)
+    lo, hi = stats_intervals.eti_1d(x, eti_prob=stats_intervals.DEFAULT_CI_PROB)
+    return np.mean(x), lo, hi
 
 
 def main():

--- a/scripts/loo_compare.py
+++ b/scripts/loo_compare.py
@@ -36,6 +36,7 @@ import os
 from dataclasses import dataclass
 
 import arviz as az
+import dse_research_utils.statistics.loo as shared_loo
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -85,6 +86,12 @@ class LooEntry:
 #: reaches so the notice fires before a table looks authoritative.
 HIGH_PARETO_K_UNUSABLE_SHARE = 0.20
 
+#: Pareto-k above which an observation counts as "high k" in the summary tables.
+#: Fixed at 0.7 rather than the fit's own ``good_k`` because the published column
+#: name (``pareto_k_gt_0.7``) states the threshold and ``aggregate_summary.py``
+#: reads it.
+HIGH_PARETO_K_THRESHOLD = 0.7
+
 
 def _warn_if_unusable(label: str, row: dict) -> None:
     """Print a notice when a row's PSIS-LOO has degenerated past use."""
@@ -107,23 +114,35 @@ def _warn_if_unusable(label: str, row: dict) -> None:
 
 
 def _loo_summary_row(label: str, loo, reff=None) -> dict:
-    if hasattr(loo, "pareto_k"):
-        k = loo.pareto_k.values
-    else:
-        k = loo.diagnostics.values
+    """One row of the LOO comparison table.
+
+    Built from the shared :func:`dse_research_utils.statistics.loo.loo_summary_row`.
+    ``reff`` is the relative efficiency this LOO used: pinned to the sampled
+    parameters where the trace records them (``loo_reff``), else ArviZ's
+    posterior-wide default, so a mixed-convention table shows it. The
+    ``pareto_k_gt_0.7`` column keeps its fixed 0.7 threshold (rather than the
+    shared default of the fit's own ``good_k``) because that threshold is part
+    of the published column name and ``aggregate_summary.py`` reads it.
+    """
+    shared = shared_loo.loo_summary_row(
+        loo,
+        label=label,
+        reff=reff,
+        k_threshold=HIGH_PARETO_K_THRESHOLD,
+        include_looic=True,
+    )
+    # Re-emitted in the published column order; the shared builder names the
+    # count column generically and also carries the threshold it used.
     return {
-        "label": label,
-        "elpd_loo": float(loo.elpd),
-        "se": float(loo.se),
-        "p_loo": float(loo.p),
-        # The relative efficiency this LOO used: pinned to the sampled
-        # parameters where the trace records them (loo_reff), else ArviZ's
-        # posterior-wide default, so a mixed-convention table shows it.
-        "reff": None if reff is None else float(reff),
-        "looic": float(-2.0 * loo.elpd),
-        "looic_se": float(2.0 * loo.se),
-        "pareto_k_gt_0.7": int((k > 0.7).sum()),
-        "n_observations": int(k.size),
+        "label": shared["label"],
+        "elpd_loo": shared["elpd_loo"],
+        "se": shared["se"],
+        "p_loo": shared["p_loo"],
+        "reff": shared["reff"],
+        "looic": shared["looic"],
+        "looic_se": shared["looic_se"],
+        "pareto_k_gt_0.7": shared["pareto_k_above"],
+        "n_observations": shared["n_observations"],
     }
 
 

--- a/scripts/loso_compare.py
+++ b/scripts/loso_compare.py
@@ -34,6 +34,7 @@ import tempfile
 from dataclasses import dataclass
 
 import arviz as az
+import dse_research_utils.statistics.loo as shared_loo
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -363,17 +364,30 @@ def to_marginal_idata(
 
 
 def _summary_row(label: str, loo, reff: float) -> dict:
-    k = loo.pareto_k.values if hasattr(loo, "pareto_k") else loo.diagnostics.values
+    """One row of the subject-level LOO table.
+
+    Built from the shared :func:`dse_research_utils.statistics.loo.loo_summary_row`,
+    with the observation count named ``n_subjects`` because the predictive unit
+    here is a child. ``reff`` is the relative efficiency over the sampled
+    parameters (``loo_reff``), recorded because the Pareto-k column depends on
+    it; the 0.7 threshold is fixed to match the column name.
+    """
+    shared = shared_loo.loo_summary_row(
+        loo,
+        label=label,
+        reff=reff,
+        unit_name="n_subjects",
+        k_threshold=0.7,
+    )
+    # Re-emitted in the published column order (see loo_compare._loo_summary_row).
     return {
-        "label": label,
-        "elpd_loo": float(loo.elpd),
-        "se": float(loo.se),
-        "p_loo": float(loo.p),
-        "pareto_k_gt_0.7": int((k > 0.7).sum()),
-        "n_subjects": int(k.size),
-        # Relative efficiency over the sampled parameters (loo_reff): recorded
-        # because the Pareto-k column depends on it.
-        "reff": float(reff),
+        "label": shared["label"],
+        "elpd_loo": shared["elpd_loo"],
+        "se": shared["se"],
+        "p_loo": shared["p_loo"],
+        "pareto_k_gt_0.7": shared["pareto_k_above"],
+        "n_subjects": shared["n_subjects"],
+        "reff": shared["reff"],
     }
 
 

--- a/src/vocab_growth/comparison.py
+++ b/src/vocab_growth/comparison.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import os
 
 import arviz as az
+import dse_research_utils.plot.io as plot_io
 import dse_research_utils.statistics.intervals as shared_intervals
 import numpy as np
 import pandas as pd
@@ -444,9 +445,9 @@ def overlay_age_curves(title, series, out_base, *, ylabel="Expected words"):
     ax.set_title(title)
     ax.set_ylim(bottom=0)
     ax.legend(loc="upper left", frameon=True)
-    fig.savefig(out_base + ".png")
-    fig.savefig(out_base + ".svg")
-    plt.close(fig)
+    plot_io.save_styled_figure(
+        os.path.dirname(out_base), os.path.basename(out_base), fig=fig, bbox_inches=None
+    )
 
 
 def plot_summary_band(
@@ -499,10 +500,7 @@ def save_panel(out_dir, filename, ax_setup, draw, *, figsize=(8.0, 5.0)) -> None
     ax.legend(loc="best", frameon=True, fontsize=9)
     ax.grid(True, alpha=0.3)
     fig.tight_layout()
-    os.makedirs(out_dir, exist_ok=True)
-    fig.savefig(os.path.join(out_dir, f"{filename}.png"), dpi=200)
-    fig.savefig(os.path.join(out_dir, f"{filename}.svg"))
-    plt.close(fig)
+    plot_io.save_styled_figure(out_dir, filename, fig=fig, bbox_inches=None)
 
 
 # ----------------------------------------------------------------------------

--- a/src/vocab_growth/comparison.py
+++ b/src/vocab_growth/comparison.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import os
 
 import arviz as az
+import dse_research_utils.statistics.intervals as shared_intervals
 import numpy as np
 import pandas as pd
 
@@ -301,18 +302,13 @@ def evaluate_at_ages(
 
 
 def hdi_from_samples(x: np.ndarray, prob: float) -> tuple[float, float]:
-    """Narrowest-interval HDI of a 1-D sample array, ignoring NaN."""
-    x = x[~np.isnan(x)]
-    if x.size == 0:
-        return np.nan, np.nan
-    xs = np.sort(x)
-    n = xs.size
-    k = int(np.floor(prob * n))
-    if k >= n:
-        return float(xs[0]), float(xs[-1])
-    widths = xs[k:] - xs[: n - k]
-    i = int(np.argmin(widths))
-    return float(xs[i]), float(xs[i + k])
+    """Narrowest-interval HDI of a 1-D sample array, ignoring NaN.
+
+    Delegates to the shared :func:`dse_research_utils.statistics.intervals.hdi_1d`
+    (an identical ``floor(prob * n)`` construction); kept as a local name for the
+    existing call sites.
+    """
+    return shared_intervals.hdi_1d(x, hdi_prob=prob)
 
 
 def summarise_per_N(samples: np.ndarray, grid: np.ndarray) -> pd.DataFrame:

--- a/src/vocab_growth/descriptive.py
+++ b/src/vocab_growth/descriptive.py
@@ -9,10 +9,12 @@ measure) and scatter plots with each study drawn in a distinct colour. They are
 used by ``scripts/generate_descriptive_report.py`` to populate the report's
 "Data and measures" chapter.
 
-Note: ``summarise_by_group``, ``scatter_by_group`` and ``categorical_palette``
-are deliberately generic (no vocabulary-growth specifics) and are candidates for
-promotion to ``dse_research_utils`` (``statistics.descriptive`` / ``plot``) so
-other DSE projects can reuse them; kept local here until that shared release.
+Note: ``categorical_palette`` moved to
+``dse_research_utils.plot.styles`` in v0.12.0 (merged with the other repo's
+variant, which also samples continuous colormaps evenly) and is re-exported
+below. ``summarise_by_group`` and ``scatter_by_group`` are also generic (no
+vocabulary-growth specifics apart from the ``MEASURES`` default and the
+save-side-effect convention) and remain candidates for promotion.
 """
 
 from __future__ import annotations
@@ -22,14 +24,9 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from dse_research_utils.plot.styles import categorical_palette
 
 MEASURES = ("understood", "spoken", "signed")
-
-
-def categorical_palette(n: int) -> list:
-    """Return ``n`` distinct colours from a qualitative matplotlib colormap."""
-    cmap = plt.get_cmap("tab20" if n > 10 else "tab10")
-    return [cmap(i % cmap.N) for i in range(n)]
 
 
 def summarise_by_group(

--- a/src/vocab_growth/environment.py
+++ b/src/vocab_growth/environment.py
@@ -9,10 +9,20 @@ the ``DSE_VOCAB_GROWTH_OUTPUT_DIR`` environment variable > the repository-local
 its ``models`` / ``comparisons`` subdirectories. ``docs/report/figures/``
 (``REPORT_FIGS_DIR``) is the report-facing cache and deliberately stays in the
 checkout, never under this root.
+
+The resolution *policy* and the disk preflight live in
+:mod:`dse_research_utils.environment` (v0.12.0), shared with the other research
+repositories. What stays here is this repository's configuration — the
+environment-variable name, the repo-local default, and the ``models`` /
+``comparisons`` layout — plus ``str``-returning wrappers, since this package's
+call sites feed ``os.path.join``.
 """
 
 import os
-import shutil
+
+from dse_research_utils.environment.disk import free_space_gb as _shared_free_space_gb
+from dse_research_utils.environment.disk import preflight_disk as _shared_preflight_disk
+from dse_research_utils.environment.paths import OutputRoot
 
 _MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 _SRC_DIR = os.path.dirname(_MODULE_DIR)
@@ -46,11 +56,13 @@ OUTPUT_DIR_ENV_VAR = "DSE_VOCAB_GROWTH_OUTPUT_DIR"
 
 _DEFAULT_OUTPUT_DIR = os.path.join(ROOT_DIR, "output")
 
-_output_root_override: str | None = None
-
-
-def _normalise(path: str) -> str:
-    return os.path.abspath(os.path.expanduser(path))
+# ``resolve_symlinks=False``: ``<repo>/output`` is a symlink to a scratch volume
+# on the fitting VM, and the link path is the stable name recorded in fit
+# manifests and blob-upload prefixes, so a configured root is normalised with
+# ``expanduser`` + ``abspath`` rather than resolved through the link.
+_OUTPUT_ROOT = OutputRoot(
+    OUTPUT_DIR_ENV_VAR, _DEFAULT_OUTPUT_DIR, resolve_symlinks=False
+)
 
 
 def set_output_root(path: str | None) -> None:
@@ -60,18 +72,17 @@ def set_output_root(path: str | None) -> None:
     the override and fall back to the environment variable / default. Call this
     once, early in a script's entry point, before any output path is resolved.
     """
-    global _output_root_override
-    _output_root_override = _normalise(path) if path else None
+    _OUTPUT_ROOT.set(path)
 
 
 def output_root() -> str:
     """Resolve the output root at call time (see module docstring for precedence)."""
-    if _output_root_override is not None:
-        return _output_root_override
-    env_value = os.environ.get(OUTPUT_DIR_ENV_VAR)
-    if env_value:
-        return _normalise(env_value)
-    return _DEFAULT_OUTPUT_DIR
+    return str(_OUTPUT_ROOT.resolve())
+
+
+def describe_output_root() -> str:
+    """One-line description of the resolved root and its source, for run logs."""
+    return _OUTPUT_ROOT.describe()
 
 
 def models_output_dir() -> str:
@@ -99,18 +110,8 @@ def __getattr__(name: str) -> str:
 
 
 def free_space_gb(path: str | None = None) -> float:
-    """Free space (GiB) on the volume backing ``path`` (default: the output root).
-
-    Walks up to the nearest existing parent if ``path`` does not exist yet, so it
-    works for an output directory that is about to be created.
-    """
-    target = _normalise(path or output_root())
-    while not os.path.exists(target):
-        parent = os.path.dirname(target)
-        if parent == target:
-            break
-        target = parent
-    return shutil.disk_usage(target).free / (1024 ** 3)
+    """Free space (GiB) on the volume backing ``path`` (default: the output root)."""
+    return _shared_free_space_gb(path or output_root())
 
 
 def preflight_disk(
@@ -123,18 +124,6 @@ def preflight_disk(
     multi-hour sample. Prints the resolved output location so redirected runs are
     obvious in job logs. Returns the free space in GiB when the check passes.
     """
-    target = _normalise(path or output_root())
-    free = free_space_gb(target)
-    drive = os.path.splitdrive(target)[0] or target
-    # Surface the resolved root only when that is what we are actually checking, so
-    # this line can't disagree with the [disk] target when a caller passes a subdir.
-    if target == _normalise(output_root()):
-        print(f"[output] resolved output root: {output_root()}", flush=True)
-    print(f"[disk] {free:.1f} GiB free on {drive} "
-          f"(need >= {min_gb:.0f} GiB for {label})", flush=True)
-    if free < min_gb:
-        raise RuntimeError(
-            f"Insufficient disk space for {label}: {free:.1f} GiB free on {drive}, "
-            f"need >= {min_gb:.0f} GiB. Free space and retry."
-        )
-    return free
+    return _shared_preflight_disk(
+        min_gb, path or output_root(), label=label, output_root=output_root()
+    )

--- a/src/vocab_growth/intervals.py
+++ b/src/vocab_growth/intervals.py
@@ -25,29 +25,29 @@ Rethinking* (2020) and Kruschke, *Bayesian Analysis Reporting Guidelines*
 (Nat. Hum. Behav. 2021), and ``docs/models/README.md`` (Interval reporting
 convention).
 
-The outer mass is carried by the shared
-:class:`dse_research_utils.statistics.models.reporting.ReportingConfiguration`
-``ci_prob`` (0.89) and its ``interval_kind`` (``"eti"``); the inner mass is
-:data:`INNER_CI_PROB` (0.50), which the shared config does not yet model.
+The interval *mechanics* — the kind dispatcher, the per-grid bands, and the
+tidy two-band summary — live in :mod:`dse_research_utils.statistics.intervals`
+(v0.12.0) together with the shared masses (:data:`DEFAULT_CI_PROB` 0.89,
+:data:`INNER_CI_PROB` 0.50), re-exported here. What stays local is the
+*policy*: which named estimands report with HDI (:data:`HDI_ESTIMANDS` /
+:func:`interval_kind_for`) and the ``age_months`` grid naming. This project
+passes ``interval_kind="eti"`` explicitly on its
+:class:`~dse_research_utils.statistics.models.reporting.ReportingConfiguration`
+(the shared default is ``"hdi"``).
 """
 
-from typing import Literal
-
-import dse_research_utils.statistics.intervals as stats_intervals
 import numpy as np
 import pandas as pd
-
-IntervalKind = Literal["eti", "hdi"]
-
-# Outer interval mass. Kept in sync with ReportingConfiguration.ci_prob and the
-# shared library default; used as the fallback for free functions that do not
-# carry a reporting context.
-DEFAULT_CI_PROB: float = 0.89
-
-# Inner interval mass. The shared ReportingConfiguration carries only a single
-# ``ci_prob``, so the inner band lives here until a second mass is first-class
-# upstream.
-INNER_CI_PROB: float = 0.50
+from dse_research_utils.statistics.intervals import (
+    DEFAULT_CI_PROB,  # noqa: F401 — re-exported: the outer 89% house mass
+    INNER_CI_PROB,  # noqa: F401 — re-exported: the inner 50% house mass
+    IntervalKind,
+)
+from dse_research_utils.statistics.intervals import bands as _shared_bands
+from dse_research_utils.statistics.intervals import interval_1d as _shared_interval_1d
+from dse_research_utils.statistics.intervals import (
+    summarise_bands as _shared_summarise_bands,
+)
 
 # Estimands reported with HDI rather than the ETI default, because their
 # posteriors are strongly skewed or boundary-censored so an equal-tailed
@@ -78,17 +78,9 @@ def interval_1d(
 ) -> tuple[float, float]:
     """Credible interval of a 1-D sample array, NaN-aware.
 
-    ``kind="eti"`` returns the equal-tailed (percentile) interval; ``"hdi"``
-    the highest-density interval. Both delegate to the shared
-    :mod:`dse_research_utils.statistics.intervals` primitives.
+    Delegates to :func:`dse_research_utils.statistics.intervals.interval_1d`.
     """
-    x = np.asarray(x, dtype=float)
-    x = x[~np.isnan(x)]
-    if x.size == 0:
-        return float("nan"), float("nan")
-    if kind == "hdi":
-        return stats_intervals.hdi_1d(x, hdi_prob=prob)
-    return stats_intervals.eti_1d(x, eti_prob=prob)
+    return _shared_interval_1d(x, prob, kind)
 
 
 def bands(
@@ -98,23 +90,11 @@ def bands(
     *,
     sample_axis: int = 1,
 ) -> np.ndarray:
-    """Per-grid credible interval of a 2-D sample array.
+    """Per-grid credible interval of a 2-D sample array, ``(n_grid, 2)``.
 
-    ``samples`` has one axis of draws (``sample_axis``) and one grid axis; the
-    return is ``(n_grid, 2)`` of ``(lo, hi)`` along the grid, NaN-aware. Use for
-    trajectory / query-age bands where the interval is computed independently at
-    each grid point.
+    Delegates to :func:`dse_research_utils.statistics.intervals.bands`.
     """
-    arr = np.asarray(samples, dtype=float)
-    if arr.ndim != 2:
-        raise ValueError(f"bands expects a 2-D array, got shape {arr.shape}")
-    grid_axis = 1 - sample_axis
-    n_grid = arr.shape[grid_axis]
-    out = np.empty((n_grid, 2), dtype=float)
-    for i in range(n_grid):
-        draws = arr[:, i] if sample_axis == 0 else arr[i, :]
-        out[i, 0], out[i, 1] = interval_1d(draws, prob, kind)
-    return out
+    return _shared_bands(samples, prob, kind, sample_axis=sample_axis)
 
 
 def summarise(
@@ -134,23 +114,16 @@ def summarise(
     ``ci_lo``/``ci_hi`` (outer), ``interval_kind``. The kind defaults to
     :func:`interval_kind_for` applied to ``name`` (so callers can just pass the
     estimand name and get ETI, or HDI for the skewed short-list); pass ``kind``
-    to override.
+    to override. Delegates to
+    :func:`dse_research_utils.statistics.intervals.summarise_bands`.
     """
     resolved_kind = kind if kind is not None else interval_kind_for(name)
-    arr = np.asarray(samples, dtype=float)
-    if arr.ndim == 1:
-        arr = arr[:, None] if sample_axis == 0 else arr[None, :]
-    inner_band = bands(arr, inner, resolved_kind, sample_axis=sample_axis)
-    outer_band = bands(arr, outer, resolved_kind, sample_axis=sample_axis)
-    median = np.nanmedian(arr, axis=sample_axis)
-    return pd.DataFrame(
-        {
-            grid_name: np.asarray(grid, dtype=float),
-            "median": median,
-            "ci50_lo": inner_band[:, 0],
-            "ci50_hi": inner_band[:, 1],
-            "ci_lo": outer_band[:, 0],
-            "ci_hi": outer_band[:, 1],
-            "interval_kind": resolved_kind,
-        }
+    return _shared_summarise_bands(
+        samples,
+        grid,
+        kind=resolved_kind,
+        outer=outer,
+        inner=inner,
+        sample_axis=sample_axis,
+        grid_name=grid_name,
     )

--- a/src/vocab_growth/loo_reff.py
+++ b/src/vocab_growth/loo_reff.py
@@ -24,6 +24,11 @@ way without the model. A trace written before the attribute existed can still be
 pinned when the caller can name the parameters (a rebuilt model); otherwise
 :func:`reff_or_default` falls back to ArviZ's convention and says so.
 
+The computation lives in :mod:`dse_research_utils.statistics.loo` (v0.12.0);
+this module binds it to this repository's trace-attribute reader and keeps the
+project-specific ``LookupError`` message, which names the date the attribute
+was introduced.
+
 See ``notes/202608231530-observation-deterministics-not-sampled.md`` §3 and §7.
 """
 
@@ -32,15 +37,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any
 
-import numpy as np
-import xarray as xr
+import dse_research_utils.statistics.loo as shared_loo
 
 from vocab_growth.fit_artifacts import read_sampled_parameters_attr
-
-
-def _posterior(trace: Any) -> xr.Dataset:
-    node = trace["posterior"] if not isinstance(trace, xr.Dataset) else trace
-    return node.to_dataset() if hasattr(node, "to_dataset") else node
 
 
 def sampled_parameter_names(trace: Any, *, names: Sequence[str] | None = None) -> list[str]:
@@ -70,19 +69,9 @@ def sampled_parameter_reff(trace: Any, *, names: Sequence[str] | None = None) ->
     Every named variable must be in the posterior; a compacted trace keeps the
     free random variables, so this holds for every tier.
     """
-    import arviz_stats  # noqa: F401  (registers the ``azstats`` accessor)
-
-    posterior = _posterior(trace)
-    wanted = sampled_parameter_names(trace, names=names)
-    missing = [name for name in wanted if name not in posterior.data_vars]
-    if missing:
-        raise KeyError(f"Sampled parameters absent from the posterior: {missing}")
-    if posterior.sizes.get("chain", 1) == 1:
-        return 1.0
-    n_samples = int(posterior.sizes["chain"] * posterior.sizes["draw"])
-    ess = posterior[wanted].azstats.ess(method="mean")
-    values = np.hstack([ess[name].values.ravel() for name in ess.data_vars])
-    return float(values.mean() / n_samples)
+    return shared_loo.sampled_parameter_reff(
+        trace, names=sampled_parameter_names(trace, names=names)
+    )
 
 
 def reff_or_default(

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -1727,10 +1727,6 @@ def _plot_and_print_dist(context, dist, name):
     console.print(f"  [yellow]{name}[/yellow]: {summary}")
 
 
-_RHAT_WARN = 1.01
-_ESS_WARN = 400
-
-
 class ConvergenceGateError(RuntimeError):
     """Raised when a reporting-quality fit fails convergence checks."""
 
@@ -1759,6 +1755,7 @@ def enforce_convergence_gate(
     )
     rhat_failing = gate_summary.get("rhat_failing") or []
     ess_failing = gate_summary.get("ess_failing") or []
+    unassessable = gate_summary.get("unassessable_parameters") or []
 
     # A registered, narrowly-scoped exception can accept an R-hat-only failure
     # where the reported quantities converge and the failing parameter is a
@@ -1776,18 +1773,21 @@ def enforce_convergence_gate(
             "reason": accepted.reason,
             "decided": accepted.decided,
         }
-        summary_path = os.path.join(output_dir, DIAGNOSTICS_SUMMARY_FILENAME)
-        if os.path.isfile(summary_path):
-            with open(summary_path, encoding="utf-8") as handle:
-                payload = json.load(handle)
-            payload[ACCEPTED_EXCEPTION_KEY] = gate_summary[ACCEPTED_EXCEPTION_KEY]
-            write_json_atomic(summary_path, payload)
+        if os.path.isfile(os.path.join(output_dir, DIAGNOSTICS_SUMMARY_FILENAME)):
+            shared_diagnostics.amend_diagnostics_summary(
+                output_dir, {ACCEPTED_EXCEPTION_KEY: gate_summary[ACCEPTED_EXCEPTION_KEY]}
+            )
         rhat_failing = []
         scan_failed = False
 
-    if scan_failed or rhat_failing or ess_failing:
+    if scan_failed or rhat_failing or ess_failing or unassessable:
         if scan_failed:
             reason = "The R-hat/ESS convergence scan did not complete."
+        elif unassessable and not (rhat_failing or ess_failing):
+            reason = (
+                f"The convergence gate could not assess R-hat/ESS for "
+                f"{len(unassessable)} parameter(s): {', '.join(unassessable[:6])}."
+            )
         else:
             reason = (
                 f"The convergence gate found {len(rhat_failing)} R-hat failure(s) "
@@ -1846,8 +1846,8 @@ def _report_diagnostic_warnings(gate_summary: dict) -> None:
     table.
     """
     thresholds = gate_summary.get("thresholds") or {}
-    rhat_max = thresholds.get("rhat_max", _RHAT_WARN)
-    ess_threshold = thresholds.get("ess_threshold", _ESS_WARN)
+    rhat_max = thresholds.get("rhat_max", shared_diagnostics.RHAT_MAX)
+    ess_threshold = thresholds.get("ess_threshold", shared_diagnostics.ESS_THRESHOLD)
     max_rhat = gate_summary.get("max_rhat")
     min_ess = gate_summary.get("min_ess")
 

--- a/src/vocab_growth/models/diagnostics_utils.py
+++ b/src/vocab_growth/models/diagnostics_utils.py
@@ -3,8 +3,7 @@
 
 """Helpers for model diagnostics."""
 
-import arviz as az
-import numpy as np
+import dse_research_utils.plot.diagnostics_mcmc as shared_plot_diagnostics
 
 from vocab_growth.fit_artifacts import ACCEPTED_EXCEPTION_KEY, read_convergence_caveats
 
@@ -81,54 +80,9 @@ def render_convergence_caveats(directory: str = ".") -> None:
     print(":::")
 
 
-def capped_plot_var_names(
-    trace,
-    var_names: list[str],
-    *,
-    squared: bool = False,
-) -> list[str]:
-    """Return the first variables that fit within ArviZ's subplot limit."""
-    max_subplots = az.rcParams.get("plot.max_subplots")
-    if not isinstance(max_subplots, int):
-        return list(var_names)
-
-    max_plot_items = max_subplots
-    if squared:
-        max_plot_items = int(np.floor(np.sqrt(max_subplots)))
-
-    selected_var_names: list[str] = []
-    selected_plot_items = 0
-    for var_name in var_names:
-        plot_items = plot_variable_count(trace, var_name)
-        if selected_plot_items + plot_items <= max_plot_items:
-            selected_var_names.append(var_name)
-            selected_plot_items += plot_items
-
-    return selected_var_names
-
-
-def plot_required_subplots(
-    trace,
-    var_names: list[str],
-    *,
-    squared: bool = False,
-) -> int:
-    n_plot_items = sum(plot_variable_count(trace, var_name) for var_name in var_names)
-    if squared:
-        return n_plot_items**2
-    return n_plot_items
-
-
-def plot_variable_count(trace, var_name: str) -> int:
-    posterior = trace.posterior
-    if hasattr(posterior, "dataset"):
-        posterior = posterior.dataset
-
-    sample_dims = posterior.attrs.get("sample_dims", az.rcParams["data.sample_dims"])
-    if isinstance(sample_dims, str):
-        sample_dims = [sample_dims]
-
-    sample_dims = set(sample_dims)
-    variable = posterior[var_name]
-    plot_dims = [dim for dim in variable.dims if dim not in sample_dims]
-    return int(np.prod([variable.sizes[dim] for dim in plot_dims]))
+# The subplot-budget helpers now live in the shared library
+# (dse_research_utils.plot.diagnostics_mcmc, v0.12.0); re-exported here so the
+# existing import paths in models/common.py and the tests keep working.
+capped_plot_var_names = shared_plot_diagnostics.capped_plot_var_names
+plot_required_subplots = shared_plot_diagnostics.plot_required_subplots
+plot_variable_count = shared_plot_diagnostics.plot_variable_count

--- a/src/vocab_growth/plotting.py
+++ b/src/vocab_growth/plotting.py
@@ -4,6 +4,7 @@
 import os
 from typing import Protocol
 
+import dse_research_utils.plot.io as plot_io
 import dse_research_utils.plot.predictive as plot_predictive
 import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
@@ -17,8 +18,12 @@ import vocab_growth.intervals as intervals
 
 
 def _save_csv(df: pd.DataFrame, output_dir: str, filename: str) -> None:
-    """Save a DataFrame as CSV alongside the corresponding plot."""
-    df.to_csv(os.path.join(output_dir, f"{filename}.csv"), index=False)
+    """Save a DataFrame as CSV alongside the corresponding plot.
+
+    Delegates to the shared writer; kept as a local name (and argument order)
+    for this module's call sites.
+    """
+    plot_io.save_plot_data(output_dir, filename, df)
 
 
 # ISO 216 A-series landscape aspect ratio (width : height = √2 : 1), used to size
@@ -32,12 +37,24 @@ def _iso_a_landscape_figsize(width: float = 7.5) -> tuple[float, float]:
 
 
 def _save_png_svg(
-    fig: Figure, output_dir: str, filename: str, *, dpi: int = 300, svg: bool = True
+    fig: Figure, output_dir: str, filename: str, *, dpi: float = plot_styles.DPI_FILE, svg: bool = True
 ) -> None:
-    """Save a figure as PNG (and, unless ``svg=False``, SVG) under one filename stem."""
-    fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=dpi)
-    if svg:
-        fig.savefig(os.path.join(output_dir, f"{filename}.svg"))
+    """Save a figure as PNG (and, unless ``svg=False``, SVG) under one filename stem.
+
+    Delegates to :func:`dse_research_utils.plot.io.save_styled_figure`.
+    ``bbox_inches=None`` and ``close=False`` preserve this project's cropping
+    and its figure-returning plot functions; the shared helper additionally
+    creates ``output_dir`` if it is absent.
+    """
+    plot_io.save_styled_figure(
+        output_dir,
+        filename,
+        fig=fig,
+        dpi=dpi,
+        bbox_inches=None,
+        close=False,
+        svg=svg,
+    )
 
 
 #: A child needs at least this many administrations before their observations are
@@ -212,14 +229,22 @@ def plot_prior_samples(
     x_obs: np.ndarray | pd.Series,
     y_obs: np.ndarray | pd.Series,
     n_trials: int = 810,
-    n_curves = 1000,
+    n_curves: int = 1000,
     x_label: str = "x",
     y_label: str = "y",
     filename: str | None = None,
     output_dir: str | None = None,
+    random_seed: int | None = None,
 ) -> Figure:
+    """Prior-predictive spaghetti plot at this project's checklist size.
 
-    fig = plot_predictive.plot_prior_samples_binomial(
+    A thin wrapper over the shared
+    :func:`dse_research_utils.plot.predictive.plot_prior_samples_binomial` that
+    carries the vocabulary-checklist defaults (``n_trials=810``,
+    ``n_curves=1000``). ``random_seed`` selects which prior draws are drawn;
+    left ``None`` the curve selection is unseeded, as before.
+    """
+    return plot_predictive.plot_prior_samples_binomial(
         x,
         y_samples,
         x_obs,
@@ -229,9 +254,9 @@ def plot_prior_samples(
         x_label,
         y_label,
         filename,
-        output_dir)
-
-    return fig
+        output_dir,
+        random_seed=random_seed,
+    )
 
 
 def plot_prior_samples_ratio(

--- a/src/vocab_growth/sensitivity/compare.py
+++ b/src/vocab_growth/sensitivity/compare.py
@@ -39,9 +39,7 @@ import os
 
 import numpy as np
 import pandas as pd
-
-RHAT_MAX = 1.01
-ESS_THRESHOLD = 400
+from dse_research_utils.statistics.diagnostics import ESS_THRESHOLD, RHAT_MAX
 
 #: Definition fields that always differ between a baseline and its variant, and
 #: whose difference carries no information: the variant's directory name and the

--- a/tests/test_diagnostics_gate.py
+++ b/tests/test_diagnostics_gate.py
@@ -79,12 +79,19 @@ def test_gate_covers_hsgp_basis_coefficients():
         assert name in gate_names
 
 
-def _payload(rhat_failing=(), ess_failing=(), max_rhat=1.005, min_ess=1200.0):
+def _payload(
+    rhat_failing=(),
+    ess_failing=(),
+    max_rhat=1.005,
+    min_ess=1200.0,
+    unassessable=(),
+):
     return {
         "max_rhat": max_rhat,
         "min_ess": min_ess,
         "rhat_failing": list(rhat_failing),
         "ess_failing": list(ess_failing),
+        "unassessable_parameters": list(unassessable),
         "thresholds": {"rhat_max": 1.01, "ess_threshold": 400},
     }
 
@@ -142,6 +149,41 @@ def test_development_fit_reports_but_does_not_raise(tmp_path):
     )
 
     assert not (tmp_path / "CONVERGENCE_FAILED.txt").exists()
+
+
+def test_unassessable_parameter_fails_the_hard_tier(tmp_path):
+    """A gated parameter whose R-hat/ESS could not be measured must not publish.
+
+    The shared writer's NaN-skipping reductions leave a constant or unsampled
+    parameter out of the extrema and the failing lists, so before
+    dse-research-utils 0.12.0 such a fit reached publication reporting finite
+    diagnostics and an empty failing list. The shared gate now names those
+    parameters; the hard tier fails closed on them.
+    """
+    with pytest.raises(ConvergenceGateError):
+        enforce_convergence_gate(
+            _payload(unassessable=["frozen_term"]),
+            sampling_config_name="rep",
+            output_dir=str(tmp_path),
+        )
+
+    marker = tmp_path / "CONVERGENCE_FAILED.txt"
+    assert marker.exists()
+    assert "could not assess" in marker.read_text()
+    assert "frozen_term" in marker.read_text()
+
+
+def test_measured_failures_take_precedence_in_the_reason(tmp_path):
+    """A measured failure is reported as such even alongside an unassessable one."""
+    with pytest.raises(ConvergenceGateError):
+        enforce_convergence_gate(
+            _payload(rhat_failing=["theta[0]"], max_rhat=1.03, unassessable=["frozen_term"]),
+            sampling_config_name="rep",
+            output_dir=str(tmp_path),
+        )
+
+    text = (tmp_path / "CONVERGENCE_FAILED.txt").read_text()
+    assert "R-hat failure(s)" in text
 
 
 def test_sampling_config_classification_is_explicit():

--- a/uv.lock
+++ b/uv.lock
@@ -517,8 +517,8 @@ wheels = [
 
 [[package]]
 name = "dse-research-utils"
-version = "0.11.2"
-source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.11.2#2d19c5ef2d2f3a66c64a92a232760f36ee580a37" }
+version = "0.12.0"
+source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.0#cd5cc18f113d1ca7e78be1e9c23f43078ce1bc01" }
 dependencies = [
     { name = "arviz" },
     { name = "arviz-base" },
@@ -592,7 +592,7 @@ lint = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.11.2" }]
+requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
> [!NOTE]
> Drafted by a LLM-based AI tool (Claude Code/Fable 5).

Adopts the shared helpers released in [dse-research-utils v0.12.0](https://github.com/dseinternational/research/pull/93), which took several pieces of this repository's plumbing upstream so `language-reading-predictors` shares them rather than carrying its own variants. This repo keeps its *policy* throughout — which estimands report with HDI, the hard/soft convergence tiering, the reporting-age caps — and shares only the mechanics.

## The one behaviour change worth reviewing first

The hard convergence tier now fails closed on `unassessable_parameters`. The shared gate reduced R-hat and ESS with NaN-skipping operations, and a NaN also compares `False` against the thresholds, so it never reached `rhat_failing` / `ess_failing` either: a fit holding one healthy parameter and one constant or unsampled one passed with finite extrema and empty failing lists. `language-reading-predictors` found this in its 2026-08-22 ITT audit and patched it locally; this repo was still exposed. A measured failure still takes precedence in the reported reason, and `tests/test_diagnostics_gate.py` gains two regression tests.

## A reporting bug fixed in passing

`scripts/crosswalk_dse_oxford.py`'s `_hdi` returned `np.percentile(x, [5, 50, 95])` — a 90% *equal-tailed* interval — and all three of its consumers printed it as a "90% HDI". Renamed to `_eti_90` and the three labels corrected. The numbers are unchanged; only the claim about what they are.

## What changed

**Intervals.** `intervals.py` keeps `HDI_ESTIMANDS` / `interval_kind_for` and the `age_months` grid naming, and re-exports the mechanics (the kind dispatcher, per-grid `bands`, the tidy two-band summary, and the 0.89 / 0.50 masses). Three hand-rolled re-implementations go with it: `comparison.hdi_from_samples` (an identical `floor(prob * n)` construction), and the vg16 / vg19 experiment harnesses, which spelled 89% ETIs as raw percentile and quantile literals.

**Diagnostics.** `sensitivity/compare.py` and `models/common.py` stop re-declaring `RHAT_MAX` / `ESS_THRESHOLD` — there were three copies of 1.01 / 400 in the repo — and `enforce_convergence_gate` records an accepted R-hat exception through the shared `amend_diagnostics_summary` rather than its own read-modify-rewrite.

**Figure saving.** `_save_png_svg` and `_save_csv` become thin delegations, so this repo's ~23 save sites and the other repo's stop being separate implementations of one policy. `bbox_inches=None` and `close=False` preserve the existing cropping and the figure-returning plot functions. Two `comparison.py` sites had drifted from the house resolution and are normalised: `overlay_age_curves` passed no `dpi` at all (so the PNG was 300 or matplotlib's default 100 depending on whether the house style had been applied) and `save_panel` passed `dpi=200`, the only non-`DPI_FILE` resolution in either repository. Output figures are gitignored, regenerated artefacts.

**Environment.** `environment.py` keeps this repo's configuration — env-var name, repo-local default, `models`/`comparisons` layout, and `str`-returning wrappers for the `os.path.join` call sites — and delegates the resolution policy. It passes `resolve_symlinks=False`, preserving the `abspath` normalisation this repo needs because `<repo>/output` is a symlink to a scratch volume on the fitting VM, where the link path is the stable name recorded in fit manifests and blob-upload prefixes. All twelve existing environment tests pass unchanged. It also gains `describe_output_root()`, the source-attributed run-log line the other repo already had.

**LOO.** `loo_reff.py` delegates the reff computation and keeps the repo-specific trace-attribute reader and its dated `LookupError`. `loo_compare._loo_summary_row` and `loso_compare._summary_row` were near-clones; both now build from the shared row and re-emit it in their published column order, so the CSV schemas are byte-identical. The fixed 0.7 Pareto-k threshold is named once as `HIGH_PARETO_K_THRESHOLD`, recording *why* it is fixed rather than the fit's own `good_k`: the column name states it and `aggregate_summary.py` reads it.

**Also.** The subplot-budget helpers and `categorical_palette` moved upstream and are re-exported, as `descriptive.py`'s own docstring had anticipated. `plot_prior_samples` now forwards `random_seed` (default `None`, so curve selection is unseeded exactly as before); without it a caller could not reproduce a figure's draw selection, which the neighbouring `plot_prior_predictions` comment already assumed.

## Verification

`uv run pytest` on the real pinned dependency — **946 passed, 11 skipped**. `uv run ruff check src scripts tests` clean, `npm run spellcheck` and `npm run format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
