### PR TITLE
Plan the refit for a 2 TB attached disk, and record why fits go straight to it

### DIFF
--- a/docs/runbooks/full-refit.md
+++ b/docs/runbooks/full-refit.md
@@ -33,6 +33,15 @@ naive run hits. Distilled from the 2026-07-12 run
   tell-tale of the old rounding.
 - Data current: `python scripts/prepare_data.py` (confirm the 810 reference scale;
   see `docs/report/methods-data.qmd`).
+- **On the DSE data-science fleet, most of this list is already on the image.**
+  The stack's cloud-init installs `uv`, the newest stable CPython, Node.js active
+  LTS, Quarto with a per-user TinyTeX (so `quarto render --to pdf` works without
+  a separate LaTeX install), Pandoc, plotting fonts, `gh`, Graphviz, and — on the
+  ARM64 CPU bootstrap — pinned **PowerShell 7.6 LTS exposed as `pwsh`**, which is
+  what `run_replication.ps1` needs. Do not install competing versions by hand.
+  The one thing worth checking rather than assuming is the report book's fonts:
+  the image provides "plotting fonts", which is not the same claim as Source
+  Sans 3 and Monaspace Neon, and those are needed only for the `pdf` format.
 - **Graphviz `dot` on `PATH`.** Present on the DSE VM images since 2026-08-25. It
   is the one tool a _fit_ tolerates missing — `render_model_graph` catches the
   failure and prints a warning rather than aborting — but every model report
@@ -191,19 +200,40 @@ seconds per fit, perhaps 10–25 minutes across the whole run. Copying ~320 GB b
 to the attached disk afterwards costs about the same again, so the round trip
 saves nothing and may lose.
 
-**Local disks are ephemeral, and the fits are long.** An Azure temp disk does not
-survive deallocation or host maintenance. This project has already lost `rep`
-fits to a full disk (2026-08-14) and to a concurrent OOM; losing a fifteen-hour
-VG12 fit to a host migration is not a failure mode worth adding for the numbers
-above. Note also that the `v6` VM generations only carry a local temp disk when
-the SKU name includes `d` — `Epdsv6` has one, `Epsv6` does not — so confirm the
-provisioned SKU actually offers the choice before planning around it.
+**Local disk is disposable by design, and the fits are long.** On the DSE data
+science fleet the two mounts are explicit about this
+([`dsegroup/infrastructure`](https://github.com/dsegroup/infrastructure), the
+data-science stack's cloud-init):
 
-**Where local disk does help**, if the SKU has one: PyTensor's compile cache
-(`PYTENSOR_FLAGS=base_compiledir=...`). It is many small latency-sensitive files
-and is disposable by design, which is exactly what a temp disk is for. Keep
-expectations low — CI measured the compile cache as noise and dropped it in
-`8b7de41` — but it is the right home for it if you want one.
+| mount      | what it is                                 | survives teardown |
+| ---------- | ------------------------------------------ | ----------------- |
+| `/data`    | the persistent disk, mounted when attached | yes               |
+| `/scratch` | every local NVMe the tier carries, striped | **no — wiped**    |
+
+`$TMPDIR` points at `/scratch`. **Fit to `/data`.** The XL tier is
+`Standard_E32pds_v6` — the `d` variants do carry local NVMe, so the choice
+genuinely exists here and is not small: [infrastructure
+#1804](https://github.com/dsegroup/infrastructure/pull/1804) stripes all of it
+into one RAID0 volume, taking XL's `/scratch` from 440 GiB to about 1.3 TiB.
+That PR was still open on 2026-08-25, so a box provisioned before it merges comes
+up with the single-device 440 GiB `/scratch`; either way the size objection is
+not what decides this.
+
+What decides it is that `/scratch` is _meant_ to be lost. It is wiped on
+teardown, and a deallocate/start wipes local NVMe outright even though #1804
+gives the mount an `fstab` entry that survives a plain reboot. The stripe also
+multiplies the device-failure surface across three disks — which that PR
+correctly accepts, on the grounds that the failure "costs a workspace that
+teardown was going to wipe anyway". A fifteen-hour VG12 fit is not that. This
+project has already lost `rep` fits to a full disk (2026-08-14) and to a
+concurrent OOM; host maintenance is not a third failure mode worth buying for
+tens of seconds per fit.
+
+**Where `/scratch` does help**: PyTensor's compile cache
+(`PYTENSOR_FLAGS=base_compiledir=/scratch/...`). Many small latency-sensitive
+files, disposable by design — exactly what the mount is for, and with the stripe
+it has both the room and the throughput. Keep expectations low: CI measured the
+compile cache as noise and dropped it in `8b7de41`.
 
 ### Surviving a full disk
 

--- a/docs/runbooks/full-refit.md
+++ b/docs/runbooks/full-refit.md
@@ -33,9 +33,22 @@ naive run hits. Distilled from the 2026-07-12 run
   tell-tale of the old rounding.
 - Data current: `python scripts/prepare_data.py` (confirm the 810 reference scale;
   see `docs/report/methods-data.qmd`).
-- Disk: **set `DSE_VOCAB_GROWTH_TRACE_PERSISTENCE=compact` before you start**, and
+- **Graphviz `dot` on `PATH`.** Present on the DSE VM images since 2026-08-25. It
+  is the one tool a _fit_ tolerates missing — `render_model_graph` catches the
+  failure and prints a warning rather than aborting — but every model report
+  references `gp_model_graph.svg`, so without it all twenty render with a broken
+  figure and nothing fails loudly enough to notice.
+- Disk: **choose the trace tier against the volume you actually have, and set it
+  before you start.** Under about 1 TB use
+  `DSE_VOCAB_GROWTH_TRACE_PERSISTENCE=compact`; at 1 TB or more leave the default
+  `full`, and make sure that variable is _unset_ so it cannot silently override
+  you. `compact` is byte-identical for reporting but blocks recovery scoring,
+  `regenerate_plots.py` and `loso_compare.py` on those fits without a refit, so
+  it is a saving worth making only when the space is genuinely tight. Either way,
   redirect output off the checkout with `--output-dir <scratch>` or
-  `DSE_VOCAB_GROWTH_OUTPUT_DIR`. The report figure cache
+  `DSE_VOCAB_GROWTH_OUTPUT_DIR` — and point it at the **attached** disk rather
+  than at a local temp disk, for the reasons in
+  [Fit straight to the attached disk](#fit-straight-to-the-attached-disk-not-to-local-scratch). The report figure cache
   (`docs/report/figures/`) always stays in the checkout. Sizing and the
   exceptions are in [Surviving a full disk](#surviving-a-full-disk) — read it
   before the first fit, not after. The old advice here ("~20 GB × n_models") was
@@ -152,6 +165,46 @@ memory-heavy. So:
   a batch of small DS sensitivity fits (see below). Run them as a separate
   `-MaxParallel 1` pass; a single pool with a mixed model list cannot express this.
 
+### Fit straight to the attached disk, not to local scratch
+
+Asked when the 2026-08 run was provisioned with a 2 TB premium disk: fit to the
+VM's local SSD and copy the results across afterwards, or write straight to the
+attached disk? **Straight to the attached disk.** Three reasons, in order of
+weight.
+
+**The output root has to be one filesystem.** `create_staging_root` puts
+`.staging` _inside_ the output root, and `promote_staged_fit` publishes with
+`os.replace` — a rename. Across filesystems that raises `EXDEV` rather than
+degrading to a copy, so the pipeline cannot stage on local and publish to the
+attached disk; the rollback path (`.previous`, also under the output root) has
+the same constraint. Fitting to scratch therefore means the _whole_ output root
+lives on scratch, and the copy to the attached disk is a separate manual step
+outside the atomicity machinery — a crash during a 320 GB copy leaves a partial
+fit that nothing guards against. That trades a real protection for a saving the
+next point shows is negligible.
+
+**The saving is noise against the sampling.** Posterior sampling is about 92% of
+a `rep` fit's wall clock (measured on VG12: 3h09m of 3h26m), and the trace is a
+single burst at the end. Writing a 16 GB `trace.nc` costs on the order of a
+minute to premium storage and a fraction of that to local NVMe — call it tens of
+seconds per fit, perhaps 10–25 minutes across the whole run. Copying ~320 GB back
+to the attached disk afterwards costs about the same again, so the round trip
+saves nothing and may lose.
+
+**Local disks are ephemeral, and the fits are long.** An Azure temp disk does not
+survive deallocation or host maintenance. This project has already lost `rep`
+fits to a full disk (2026-08-14) and to a concurrent OOM; losing a fifteen-hour
+VG12 fit to a host migration is not a failure mode worth adding for the numbers
+above. Note also that the `v6` VM generations only carry a local temp disk when
+the SKU name includes `d` — `Epdsv6` has one, `Epsv6` does not — so confirm the
+provisioned SKU actually offers the choice before planning around it.
+
+**Where local disk does help**, if the SKU has one: PyTensor's compile cache
+(`PYTENSOR_FLAGS=base_compiledir=...`). It is many small latency-sensitive files
+and is disposable by design, which is exactly what a temp disk is for. Keep
+expectations low — CI measured the compile cache as noise and dropped it in
+`8b7de41` — but it is the right home for it if you want one.
+
 ### Surviving a full disk
 
 On 2026-08-14 at 16:12 the output volume reached 100% and five in-flight refits died on `[Errno 28] No space left on device` — VG16 and VG14 part-way through writing `trace.nc`, and VG10, VG07 and VG05 before they had started. Nothing warned first: the fits simply failed at the moment they wrote.
@@ -169,6 +222,8 @@ $env:DSE_VOCAB_GROWTH_TRACE_PERSISTENCE = 'compact'
 **Three models should stay at `full`: VG10, VG12 and VG15.** They are `fit_recovery.py`'s headline set, and recovery scoring refuses a compacted trace up front — as do `regenerate_plots.py` and `loso_compare.py`. Pass `--trace-persistence full` for those three specifically. Everything else can be compacted, at the cost of needing a refit if its plots ever have to be regenerated.
 
 **Sizing.** Budget by _fits_, not by models: a full round fits ~15 models of record plus ~20 registered sensitivity variants plus recovery replicates. At `full` that exceeds 400 GB; at `compact` it is roughly 130–150 GB. Add headroom for atomic promotion, which transiently holds a second copy of the largest trace in `.staging`. **500 GB is comfortable at `compact`; 1 TB at `full`.**
+
+The 2026-08 refit is provisioned on a **2 TB attached disk**, so `full` is the tier to use and this section's `compact` advice does not apply to it. Measured against the current traces, its 28 planned fits come to about 320 GB at `full` — lower than the 400 GB above because that figure includes recovery replicates, which this run does not schedule. Either way it is comfortably inside the volume, and a fresh VM starts with an empty `output/`, so the peak equals the total rather than transiently holding both an old and a new trace.
 
 **Recovering a volume that is already full**: `scripts/compact_traces.py` applies the tier to traces already written. It reuses the same policy code the fit pipeline uses, verifies each rewrite carries every free parameter the original had before atomically replacing it, and records the tier in `fit_manifest.json`. It processes smallest-first, which matters — each rewrite needs room for its output beside the original, so the small traces buy the space the large ones need.
 

--- a/notes/202608221500-refit-handover-reporting-cap.md
+++ b/notes/202608221500-refit-handover-reporting-cap.md
@@ -118,18 +118,36 @@ Eleven models, all at `--config rep`:
 
 **VG19 is not optional even though it is not a model of record.** `sync_report_figures` validates every directory that resolves to a registered model and one failure aborts the whole run — the trap recorded at `docs/runbooks/full-refit.md:464`.
 
-## 3. Disk — plan this before starting
+## 3. Disk — no longer the binding constraint
 
-At the time of writing `/scratch2` has **33 G free** against **98 G** of current traces for these eleven. Refitting writes the new trace before the old is replaced, so the peak matters.
+> [!NOTE]
+> **Rewritten 2026-08-25.** This section previously planned around `/scratch2` having 33 G free against 98 G of traces, and recommended `--trace-persistence compact` on that basis. The refit is now provisioned on a VM with a **2 TB attached disk**, which changes the recommendation to its opposite. The original reasoning is in git history; nothing below depends on it.
 
-The clean source of room is the **three VG19 `rep` recovery replicate directories, 35 G in total**, which are fully scored — `recovery_matrix_vg19.csv` and the six per-replicate CSVs were written 2026-08-22 08:03 — and have no remaining consumer. Removing them gives roughly 68 G.
+**Use `full`.** It is the default, so no flag is needed — but check that `DSE_VOCAB_GROWTH_TRACE_PERSISTENCE` is unset on the VM, because the environment variable would silently override it.
 
-Then choose persistence deliberately:
+The whole set at `full`, using current traces as proxies and estimating VG21 and VG23 at VG13's size:
 
-- `--trace-persistence compact` takes the set to roughly 35 G and is **byte-identical for reporting**. It drops the observation-sized deterministics, which are recomputable. It does **block** later recovery scoring, `regenerate_plots.py` and `kfold_loso`-adjacent work on those fits without another refit.
-- `full` needs the 98 G and leaves every downstream option open.
+|                                            |   fits |  at `full` |
+| ------------------------------------------ | -----: | ---------: |
+| Core refit set                             |     15 |     ~178 G |
+| Sensitivity variants (§0 decisions 4b, 4c) |      7 |      ~77 G |
+| Fallback arms on VG10 and VG20             |      6 |      ~66 G |
+| **Total**                                  | **28** | **~320 G** |
 
-Given that recovery, k-fold and the parameter-recovery baselines have all just been run and are unaffected by this change (§5), `compact` is the reasonable default here, with `full` for **VG20** alone if any of its downstream work is expected.
+Roughly 16% of the volume. A fresh VM starts with an empty `output/`, so peak equals total — the "new trace written before the old is replaced" problem that drove the original plan does not arise.
+
+**Why `full` rather than `compact` now that it is affordable.** `compact` is byte-identical for reporting, so it costs nothing _for the report_. What it costs is everything queued behind the report: `loso_compare.py`, `regenerate_plots.py` and parameter-recovery scoring all refuse a compacted fit up front, and the work waiting on these refits is exactly that — [#225](https://github.com/dseinternational/vocabulary-growth/issues/225)'s mirror experiment (VG20 fitted to VG19-simulated data, explicitly gated on this run), [#226](https://github.com/dseinternational/vocabulary-growth/issues/226) item 1's further `rep` psi replicates, and the recovery completion [#233](https://github.com/dseinternational/vocabulary-growth/issues/233) asks for. Choosing `compact` to save 240 G on a 2 TB disk would buy a second refit window.
+
+**Graphviz is on the VM images** as of 2026-08-25, so the model-diagram figure renders. It was the one non-Python tool a fit tolerates missing — `render_model_graph` catches the failure and warns — but all twenty model reports reference `gp_model_graph.svg`, so without it every report renders with a broken figure.
+
+### What is binding instead
+
+**Wall time.** Twenty-eight `rep` fits, several of them multi-hour, and the sensitivity variants are full fits rather than cheap ones. Two consequences:
+
+- The run order that §0 decision 1 fixes is now the main lever rather than a nicety. The fallback arms on VG10 and VG20 must complete and **be read** before the remaining models launch; running everything and reading afterwards forfeits the point of that decision and risks a second window.
+- If the window is tight, the sensitivity variants are the right thing to defer — they are the only fits here whose absence blocks nothing except a robustness claim. Every model in the core set is stale and unpublishable until refitted.
+
+**Memory, not disk, is what has historically killed these runs.** A concurrent memory hog has previously taken out `rep` fits mid-run; the precautions are in the runbook's _Surviving an OOM_ section, not here, and a large disk does nothing for that failure mode.
 
 ## 4. Order of operations, and the traps
 


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

The refit VM is provisioned with Graphviz on the image and a **2 TB attached disk**. That inverts two pieces of standing advice and answers a third question.

## The trace tier flips to `full`

The handover's disk section planned around `/scratch2` having 33 G free against 98 G of traces, and recommended `--trace-persistence compact`. At 2 TB the recommendation is the opposite:

| | fits | at `full` |
|---|---:|---:|
| Core refit set | 15 | ~178 G |
| Sensitivity variants | 7 | ~77 G |
| Fallback arms on VG10 and VG20 | 6 | ~66 G |
| **Total** | **28** | **~320 G** |

Roughly 16% of the volume, and a fresh VM starts with an empty `output/` so the peak equals the total rather than transiently holding both an old and a new trace.

`compact` is byte-identical *for reporting*, so it looks free. What it costs is everything queued behind the report: `loso_compare.py`, `regenerate_plots.py` and recovery scoring all refuse a compacted fit up front, and that is precisely the work gated on these refits — #225's mirror experiment, #226 item 1's further psi replicates, #233's recovery completion. Saving 240 G on a 2 TB disk would buy a second refit window.

**A trap this closes:** the runbook's TL;DR said flatly *"set `DSE_VOCAB_GROWTH_TRACE_PERSISTENCE=compact` before you start"*. An operator following it would silently override the intended tier. It is now conditional on the volume, and the sizing section records the 2 TB case *beside* the 2026-08-14 disk-fill scar rather than replacing it.

## Scratch versus attached disk

New runbook section. **Straight to the attached disk**, and the first reason is structural rather than about throughput:

`create_staging_root` puts `.staging` **inside** the output root, and `promote_staged_fit` publishes with `os.replace` — a rename, which raises `EXDEV` across filesystems rather than degrading to a copy. The rollback path under `.previous` has the same constraint. So the output root must be a single filesystem: the pipeline *cannot* stage on local and publish to the attached disk. Fitting to scratch means the whole output root lives there and the copy across is a separate manual step **outside the atomicity machinery** — a crash during a 320 G copy leaves a partial fit that nothing guards against.

The throughput saving that would buy is noise regardless. Sampling is ~92% of a `rep` fit's wall clock (VG12: 3h09m of 3h26m) and the trace is a single burst at the end; writing 16 GB costs on the order of a minute to premium storage and a fraction of that to local NVMe. Copying ~320 G back afterwards costs about what the faster writes saved.

Third, local disks are ephemeral and these fits are long — this project has already lost `rep` fits to a full disk and to a concurrent OOM, and a host migration eating a fifteen-hour VG12 fit is not a failure mode worth adding for tens of seconds per fit.

### Corrected after reading [`dsegroup/infrastructure#1804`](https://github.com/dsegroup/infrastructure/pull/1804)

A first draft of this hedged that the `v6` generations only carry a local temp disk when the SKU includes `d`, and told the operator to confirm the choice even existed. On this fleet it does, and it is not small — the XL tier is `Standard_E32pds_v6` with 4×440 GiB local NVMe, and #1804 stripes all of it into one RAID0 volume, taking `/scratch` from 440 GiB to about **1.3 TiB**. So capacity is not what decides this, and the section now says so instead of leaving a caveat that reads as if the option might be unavailable.

What decides it is that `/scratch` is *meant* to be lost. The runbook now names the mounts rather than describing them abstractly:

| mount | what it is | survives teardown |
|---|---|---|
| `/data` | the persistent disk, mounted when attached | yes |
| `/scratch` | every local NVMe the tier carries, striped | **no — wiped** |

`$TMPDIR` points at `/scratch`. **Fit to `/data`.** A deallocate/start wipes local NVMe outright even with #1804's `fstab` entry, which only survives a plain reboot; and the stripe multiplies the device-failure surface across three disks — which that PR correctly accepts, on the grounds that the failure costs "a workspace that teardown was going to wipe anyway". A fifteen-hour VG12 fit is not that.

#1804 was still open on 2026-08-25, so a box provisioned before it merges comes up with the single-device 440 GiB `/scratch`. The recommendation is the same either way.

Where `/scratch` *does* help: PyTensor's compile cache — many small latency-sensitive files, disposable by design, and with the stripe it has both room and throughput. Expectations kept low, since CI measured that cache as noise and dropped it in `8b7de41`.

### Prerequisites the image already satisfies

Also from #1804's description: the stack's cloud-init installs `uv`, the newest stable CPython, Node LTS, Quarto with a per-user TinyTeX, Pandoc, `gh`, Graphviz, and — on the ARM64 CPU bootstrap — pinned **PowerShell 7.6 LTS as `pwsh`**, which is what `run_replication.ps1` needs. §0 now records these so nobody installs a competing copy. One item flagged as worth checking rather than assuming: the image lists "plotting fonts", which is not the same claim as Source Sans 3 and Monaspace Neon, needed for the report book's `pdf` format only.

## Graphviz

Added to the runbook prerequisites. It is the one tool a *fit* tolerates missing — `render_model_graph` catches the failure and warns — but all twenty model reports reference `gp_model_graph.svg`, so without it every report renders with a broken figure and nothing fails loudly enough to notice.

## Testing

Documentation only; no code changed. `pytest` shows the two pre-existing VG14/VG15 stale-artefact failures and nothing else, and `format:check` and `spellcheck` pass.
