### PR TITLE
docs(scripts): fix stale _ceiling_by_form docstring about survey_vocab_max

### DIFF
--- a/scripts/data_coverage.py
+++ b/scripts/data_coverage.py
@@ -47,11 +47,14 @@ NEAR_CEILING_FRACTION = 0.90
 def _ceiling_by_form() -> pd.DataFrame:
     """Quantify at-ceiling and near-ceiling observations by (study, ceiling).
 
-    Reads ``survey_vocab_max`` straight from the ``vocab_combined`` view — it is
-    the native checklist ceiling of each row's source form and is dropped by
-    :func:`load_combined_data`, so this audit queries the view directly. For
-    each (study, ceiling, outcome) it reports how many modelled counts sit at
-    the ceiling or within ``NEAR_CEILING_FRACTION`` of it, i.e. how much of the
+    Reads ``survey_vocab_max`` — the native checklist ceiling of each row's
+    source form — straight from the raw ``vocab_combined`` view rather than
+    through :func:`load_combined_data`. The loader's frame carries the ceiling
+    too, but its default masking rules (ceiling-only children, implausible
+    production) remove or mask exactly the near-ceiling counts this audit
+    exists to count, so querying the pre-mask view is deliberate. For each
+    (study, ceiling, outcome) it reports how many source counts sit at the
+    ceiling or within ``NEAR_CEILING_FRACTION`` of it, i.e. how much of the
     data is exposed to the fixed-810-denominator harmonisation.
     """
     with duckdb.connect(VOCABULARY_DATA_PATH, read_only=True) as con:


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Fable 5).

## What changed

The docstring of `_ceiling_by_form()` in `scripts/data_coverage.py` claimed that `survey_vocab_max` "is dropped by `load_combined_data`, so this audit queries the view directly". That premise is stale: `load_combined_data` in `src/vocab_growth/data_utils.py` now selects `survey_vocab_max` and only drops `produced` by default, so the masked frame does carry the ceiling.

The docstring now states the actual (and still valid) rationale for querying the raw `vocab_combined` view: the loader's default masking rules (ceiling-only children, implausible production) remove or mask exactly the near-ceiling counts this audit exists to count, so auditing pre-mask data straight from the view is a deliberate choice, not a workaround for a missing column.

## Why

The stale claim invited a "cleanup" that would route the audit through the loader and silently understate near-ceiling exposure to the fixed-810-denominator harmonisation (issue #128), because the masking rules fire on precisely the near-ceiling signature being counted.

## Notes for reviewers

- Docstring-only change; no behaviour is affected. An optional masked-frame mode was considered and deliberately not added — it would mostly count what the masks left behind, which is a different question nothing currently asks.
- `uv run ruff check scripts/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)