### PR TITLE
Descriptive report figures, summary tables, and 12pt figure fonts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.11.2` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.12.1` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@ docs/comparison/*.svg
 docs/comparison/index.html
 docs/comparison/index_files/
 
+# The standalone descriptive report renders in place the same way: index.html
+# and index_files/ land beside docs/descriptive/index.qmd and are regenerated
+# on every render — never committed.
+docs/descriptive/index.html
+docs/descriptive/index_files/
+
 # Quarto/LaTeX render byproducts staged next to docs/report/index.qmd. The book
 # renders to the output root (see _quarto.yml's output-dir), so an index.html
 # here is a leftover from an older render, not a deliverable -- but it is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.11.2` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.12.1` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.11.2` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.12.1` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 

--- a/docs/descriptive/index.qmd
+++ b/docs/descriptive/index.qmd
@@ -23,7 +23,7 @@ format:
 ---
 
 ::: {.callout-note}
-Drafted by an LLM-based AI tool (Claude Code/Opus 4.8).
+Drafted by an LLM-based AI tool (Claude Code/Opus 4.8; repeated-measures trajectory sections Claude Code/Fable 5).
 :::
 
 ::: {.callout-warning title="Warning: Describes the observed data, not model output"}
@@ -32,7 +32,7 @@ This report summarises the **raw observed data only** — no fitted model output
 
 This report inventories the pooled Down syndrome vocabulary data before any modelling: how much data each contributing study provides, over what ages, and how words understood, spoken and signed are distributed. It is deliberately separate from the [modelling report](../report/) and the [model pages](../models/) — a plain description of what we are fitting to.
 
-Each row of the source data is one **parent-report checklist administration** for one child at one age: counts of words *understood* and *spoken* (and, for the signing sub-set, words *signed*), harmonised onto the common 810-item reference inventory. Children measured repeatedly contribute several rows, so observations exceed children. The current pooled sample comprises **1,078 observations of 576 children across eleven international studies, spanning ages 8–115 months** — 818 observations record words understood, 1,063 words spoken, and 528 words signed. Per-study detail is in @tbl-inventory; the figures then plot the raw observations, one colour per study.
+Each row of the source data is one **parent-report checklist administration** for one child at one age: counts of words *understood* and *spoken* (and, for the signing sub-set, words *signed*), harmonised onto the common 810-item reference inventory. Children measured repeatedly contribute several rows, so observations exceed children. The current pooled sample comprises **1,516 observations of 777 children across fourteen international studies, spanning ages 8–115 months** — 976 observations record words understood, 1,421 words spoken, and 899 words signed. Per-study detail is in @tbl-inventory; the figures then plot the raw observations, one colour per study.
 
 ## Study inventory
 
@@ -88,11 +88,37 @@ The studies vary widely in size (from a dozen to a couple of hundred observation
 
 ## Vocabulary by age
 
-Both receptive and expressive vocabulary rise with age, but with very wide between-child spread at every age — the raw scatter makes the case for a flexible (nonparametric) mean function and for modelling the between-child variability explicitly rather than assuming a tight growth curve.
+Both receptive and expressive vocabulary rise with age, but with very wide between-child spread at every age — the raw scatter makes the case for a flexible (nonparametric) mean function and for modelling the between-child variability explicitly rather than assuming a tight growth curve. Every observation is drawn (single-visit children included) over the pool's full age range, so it is also visible where the data thins: beyond about 72 months, coverage rests on a couple of studies, which is why the modelling report's figures stop there. The red band is the pooled interquartile range (25th–75th percentile) per 6-month age bin, drawn only where a bin holds at least five observations; the pooled median and mean appear on the repeated-measures figures below.
 
-![Words understood by age, coloured by study](figures/scatter_age_understood_ds.png){#fig-understood-age .lightbox fig-align="left"}
+![Words understood by age, coloured by study, against the pooled interquartile band](figures/observations_age_understood_ds.png){#fig-understood-age .lightbox fig-align="left"}
 
-![Words spoken by age, coloured by study](figures/scatter_age_spoken_ds.png){#fig-spoken-age .lightbox fig-align="left"}
+![Words spoken by age, coloured by study, against the pooled interquartile band](figures/observations_age_spoken_ds.png){#fig-spoken-age .lightbox fig-align="left"}
+
+### The typically-developing reference pool by age
+
+The Wordbank typically-developing pool the models compare against is too dense for a scatter — hundreds of administrations at each integer age saturate into stripes — so its by-age view is the monthly distribution: one violin per month (density clipped to that month's observed range), with the pooled monthly median and interquartile band. The shapes carry the story a scatter hides: production mass sitting on zero into the second year, the long right tail as the spurt begins, and accumulation at the form ceilings. Comprehension is measured only on the bivariate forms, so the understood panel ends where those forms do.
+
+![Words understood by age (typically developing), monthly distributions](figures/violins_age_understood_td.png){#fig-understood-age-td .lightbox fig-align="left"}
+
+![Words spoken by age (typically developing), monthly distributions](figures/violins_age_spoken_td.png){#fig-spoken-age-td .lightbox fig-align="left"}
+
+## Individual trajectories (repeated measures)
+
+Many children are measured more than once, and the within-child view is sharper than the pooled scatter: each line below joins one child's visits on one checklist form, drawn against the pooled median, mean and interquartile range (computed over all observations in the window, single-visit children included). Lines are deliberately linked **within form only** — a child measured on two forms at one visit, or moved between forms, records counts on different item inventories, and joining those would draw measurement-scale changes as development. The Down syndrome figures cover the 8–72 month reporting window.
+
+![Words understood by age — individual repeated-measures trajectories (Down syndrome), by study](figures/repeat_measures_age_understood_ds.png){#fig-rm-understood .lightbox fig-align="left"}
+
+![Words spoken by age — individual repeated-measures trajectories (Down syndrome), by study](figures/repeat_measures_age_spoken_ds.png){#fig-rm-spoken .lightbox fig-align="left"}
+
+Individual trajectories fan widely around the pooled centre: same-age children span an order of magnitude in vocabulary, and individual slopes vary far more than the median slope — the case for child-level random effects, made visually. The spoken panel also shows the median child speaking very few words before roughly 30 months while the upper quartile is already in the hundreds, the right skew the dispersion model carries.
+
+### The typically-developing reference pool
+
+The same view of the Wordbank typically-developing pool the models compare against, over its 8–30 month admission window (3-month bins; comprehension is measured only on the bivariate forms, so the understood panel ends where those forms do). Its repeat measures are concentrated in a few longitudinal datasets, and the pace difference is direct: the typically-developing median passes 300 words understood soon after 22 months, a level the Down syndrome pool's median approaches around 40.
+
+![Words understood by age — individual repeated-measures trajectories (typically developing), by dataset](figures/repeat_measures_age_understood_td.png){#fig-rm-understood-td .lightbox fig-align="left"}
+
+![Words spoken by age — individual repeated-measures trajectories (typically developing), by dataset](figures/repeat_measures_age_spoken_td.png){#fig-rm-spoken-td .lightbox fig-align="left"}
 
 ## Words understood versus words spoken
 

--- a/docs/report/methods-data.qmd
+++ b/docs/report/methods-data.qmd
@@ -45,3 +45,94 @@ This data was collected as part of two studies investigating longitudinal trends
 In the first study, 18 children with Down syndrome were studied longitudinally, including 10 children who were 2 years old and were followed for a 2-year period until they reached the age of 4 years. Moreover, eight other 3-year-old children were followed for a 1-year period until they reached the age of 4 years. For the second study, 27 children were selected from the sample of 60 toddlers attending our monitoring program on language development. The inclusion criteria for these children were a developmental age of approximately 18 (M = 18.22, range: 16–20), 24 (M = 24.11, range: 23–25), and 30 (M = 29.22, range: 28–30) months. Nine children were included in each group.
 
 \[TODO\]
+
+## Study summaries {#sec-study-summaries}
+
+```{python}
+#| label: tbl-summary-ds
+#| echo: false
+#| tbl-cap: "Pooled Down syndrome data, by study: children, checklist administrations, and the range, median and mean (SD) of age (months) and of the observed words-understood and words-spoken counts. Blank cells mean the study records no such measure (or the loader masks it). The All row pools every observation."
+from pathlib import Path
+
+import pandas as pd
+
+
+def _summary_display(path, group_label):
+    p = Path(path)
+    if not p.exists():
+        return pd.DataFrame({"note": ["Run scripts/generate_descriptive_report.py first."]})
+    d = pd.read_csv(p)
+
+    def rng(prefix):
+        return [
+            "" if pd.isna(lo) else f"{lo:.0f}–{hi:.0f}"
+            for lo, hi in zip(d[f"{prefix}_min"], d[f"{prefix}_max"])
+        ]
+
+    def med(prefix):
+        return [
+            "" if pd.isna(v) else (f"{v:.0f}" if float(v).is_integer() else f"{v:.1f}")
+            for v in d[f"{prefix}_median"]
+        ]
+
+    def mean_sd(prefix):
+        return [
+            "" if pd.isna(m) else (f"{m:.1f} ({s:.1f})" if pd.notna(s) else f"{m:.1f}")
+            for m, s in zip(d[f"{prefix}_mean"], d[f"{prefix}_sd"])
+        ]
+
+    return pd.DataFrame(
+        {
+            group_label: d["study"],
+            "Children": d["n_subjects"].astype(int),
+            "Obs.": d["n_observations"].astype(int),
+            "Age range": rng("age"),
+            "Age mdn": med("age"),
+            "Age mean (SD)": mean_sd("age"),
+            "Und. range": rng("understood"),
+            "Und. mdn": med("understood"),
+            "Und. mean (SD)": mean_sd("understood"),
+            "Spoken range": rng("spoken"),
+            "Spoken mdn": med("spoken"),
+            "Spoken mean (SD)": mean_sd("spoken"),
+        }
+    )
+
+
+_summary_display("figures/descriptives/summary_table_ds.csv", "Study")
+```
+
+```{python}
+#| label: tbl-summary-td
+#| echo: false
+#| tbl-cap: "Typically-developing Wordbank reference pool, by dataset: children, administrations, and the range, median and mean (SD) of age (months) and of the observed words-understood and words-spoken counts. Comprehension is measured only on the bivariate forms, so its columns cover fewer administrations than the spoken ones. The All row pools every observation."
+_summary_display("figures/descriptives/summary_table_td.csv", "Dataset")
+```
+
+## Vocabulary by age {#sec-vocabulary-by-age}
+
+Every observation in the pooled Down syndrome data, coloured by study, against the pooled interquartile band (25th–75th percentile) per 6-month age bin, drawn where a bin holds at least five observations. The scatter covers the pool's full age range deliberately: beyond about 72 months coverage rests on a couple of studies, which is why the results are reported to 72 months.
+
+![Words understood by age in the pooled Down syndrome data, coloured by study, against the pooled interquartile band.](figures/descriptives/observations_age_understood_ds){#fig-obs-understood-ds .lightbox}
+
+![Words spoken by age in the pooled Down syndrome data, coloured by study, against the pooled interquartile band.](figures/descriptives/observations_age_spoken_ds){#fig-obs-spoken-ds .lightbox}
+
+The typically-developing Wordbank reference pool is too dense for a scatter — hundreds of administrations at each integer age — so its by-age view is the monthly distribution: one violin per month (density clipped to that month's observed range), with the pooled monthly median and interquartile band. Comprehension is measured only on the bivariate forms, so the understood panel ends where those forms do:
+
+![Words understood by age in the typically-developing reference pool — monthly distributions with the pooled median and interquartile band.](figures/descriptives/violins_age_understood_td){#fig-obs-understood-td .lightbox}
+
+![Words spoken by age in the typically-developing reference pool — monthly distributions with the pooled median and interquartile band.](figures/descriptives/violins_age_spoken_td){#fig-obs-spoken-td .lightbox}
+
+## Repeated measures {#sec-repeated-measures}
+
+Many children are measured more than once, and the within-child trajectories motivate the models' subject-level random effects. In the figures below each line joins one child's visits on one checklist form, drawn against the pooled median, mean and interquartile range for that age window (computed over all observations, single-visit children included). Lines are linked **within form only**: a child measured on two forms at one visit, or moved between forms, records counts on different item inventories, and joining those would draw measurement-scale changes as development. The Down syndrome figures cover the 8–72 month reporting window; individual trajectories fan widely around the pooled centre — same-age children span an order of magnitude in vocabulary, and individual slopes vary far more than the median slope.
+
+![Words understood by age — repeated measures in the pooled Down syndrome data, coloured by study, against the pooled median (solid), mean (dashed) and interquartile band.](figures/descriptives/repeat_measures_age_understood_ds){#fig-rm-understood-ds .lightbox}
+
+![Words spoken by age — repeated measures in the pooled Down syndrome data, coloured by study, against the pooled median (solid), mean (dashed) and interquartile band.](figures/descriptives/repeat_measures_age_spoken_ds){#fig-rm-spoken-ds .lightbox}
+
+The same view of the typically-developing Wordbank reference pool, over its 8–30 month admission window (3-month bins; comprehension is measured only on the bivariate forms, so the understood panel ends where those forms do):
+
+![Words understood by age — repeated measures in the typically-developing reference pool, coloured by dataset.](figures/descriptives/repeat_measures_age_understood_td){#fig-rm-understood-td .lightbox}
+
+![Words spoken by age — repeated measures in the typically-developing reference pool, coloured by dataset.](figures/descriptives/repeat_measures_age_spoken_td){#fig-rm-spoken-td .lightbox}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ environments = [
 # dse-research-utils isn't published to PyPI — resolve it from the public git
 # tag. To develop against a sibling checkout instead, comment this out and use:
 #   dse-research-utils = { path = "../research/src/python", editable = true }
-dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.12.0" }
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.12.1" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"
@@ -114,3 +114,4 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["vocab_growth"]
+

--- a/scripts/generate_descriptive_report.py
+++ b/scripts/generate_descriptive_report.py
@@ -3,12 +3,15 @@
 
 """Generate the descriptive-data report artefacts (issue #111).
 
-Writes a per-study summary table and study-coloured scatter plots for the pooled
-Down syndrome dataset into ``docs/descriptive/figures/`` — the standalone
-descriptive report (``docs/descriptive/index.qmd``, a sibling of the model and
-comparison reports). The same artefacts are mirrored into the main report's
-figure cache (``docs/report/figures/descriptives/``) so its "Data and measures"
-chapter keeps rendering. Run after ``prepare_data.py``:
+Writes a per-study summary table, study-coloured scatter plots and
+repeated-measures trajectory plots (individual children linked within form,
+against the pooled median/IQR) for the pooled Down syndrome dataset — plus the
+equivalent trajectory plots for the typically-developing Wordbank reference
+pool — into ``docs/descriptive/figures/``, the standalone descriptive report
+(``docs/descriptive/index.qmd``, a sibling of the model and comparison
+reports). The same artefacts are mirrored into the main report's figure cache
+(``docs/report/figures/descriptives/``) so its "Data and measures" chapter
+keeps rendering. Run after ``prepare_data.py``:
 
     python scripts/generate_descriptive_report.py
 """
@@ -17,11 +20,22 @@ import os
 import shutil
 
 import dse_research_utils.environment.setup as setup
+import dse_research_utils.plot.styles as plot_styles
 import matplotlib.pyplot as plt
+from dse_research_utils.plot.styles import categorical_palette
+from matplotlib.colors import to_rgb
 
 import vocab_growth.environment as local_env
-from vocab_growth.data_utils import load_combined_data
-from vocab_growth.descriptive import scatter_by_group, summarise_by_group
+from vocab_growth.data_utils import load_combined_data, load_data
+from vocab_growth.descriptive import (
+    plot_monthly_violins,
+    plot_observations_by_group,
+    plot_repeat_measures_by_group,
+    scatter_by_group,
+    summarise_by_group,
+    summary_table_by_group,
+)
+from vocab_growth.models.definitions import Population
 
 SCATTERS = [
     # (x, y, xlabel, ylabel, filename)
@@ -31,9 +45,56 @@ SCATTERS = [
     ("age", "signed", "Age (months)", "Words signed", "scatter_age_signed_ds"),
 ]
 
+REPEAT_OUTCOMES = [
+    # (outcome, ylabel)
+    ("understood", "Words understood (raw count)"),
+    ("spoken", "Words spoken (raw count)"),
+]
+
+# The Down syndrome trajectory figures stop at 72 months — the reporting
+# window; the sparse older visits are excluded rather than clipped. The
+# typically-developing pool is bounded at 30 months by its own admission
+# window, and its density supports finer bins.
+DS_REPEAT_AGE_RANGE = (8, 72)
+TD_REPEAT_AGE_RANGE = (8, 30)
+TD_REPEAT_BIN_WIDTH = 3
+
+
+def _shared_group_colours(groups):
+    """One group -> colour mapping shared by every figure of a population.
+
+    Built over ALL groups the population's frames contain, so a study keeps
+    one colour across the observation scatters and the repeated-measures
+    trajectories alike (each figure's legend lists only the groups it draws).
+    Reddish palette entries are skipped: the pooled-summary overlay every
+    figure draws is pure red, and a red-toned study would read as part of it.
+    """
+    groups = sorted(set(groups))
+    colours: list = []
+    extra = 0
+    while len(colours) < len(groups):
+        candidates = categorical_palette(len(groups) + extra)
+        colours = [c for c in candidates if not _is_reddish(c)]
+        extra += 2
+    mapping = dict(zip(groups, colours[: len(groups)], strict=True))
+    # teal, used by no palette entry, was chosen for uk_01 when its default
+    # colour collided with the overlay; keep that choice stable.
+    if "uk_01" in mapping:
+        mapping["uk_01"] = "teal"
+    return mapping
+
+
+def _is_reddish(colour) -> bool:
+    r, g, b = to_rgb(colour)
+    return r > 0.55 and g < 0.45 and b < 0.45
+
 
 def main():
     setup.init_script()
+    # The 12pt base font the figures render at comes from the shared style
+    # (dse-research-utils FONT_SIZE_DEFAULT, 10 -> 12 in v0.12.1), applied here
+    # explicitly so the generator does not depend on init_script's defaults.
+    plot_styles.set_matplotlib_default_style()
     # Primary home: the standalone descriptive report (docs/descriptive/).
     out_dir = os.path.join(local_env.DOCS_DIR, "descriptive", "figures")
     # Mirror: the main report's figure cache, so methods-data.qmd keeps rendering.
@@ -48,6 +109,13 @@ def main():
     summary.to_csv(os.path.join(out_dir, "dataset_summary_ds.csv"), index=False)
     print(f"Wrote dataset summary for {len(summary)} studies to {out_dir}")
 
+    # Report summary table: per-study range/median/mean/SD of age and both
+    # outcomes, plus a pooled All row.
+    summary_table_by_group(df, {"understood": df, "spoken": df}).to_csv(
+        os.path.join(out_dir, "summary_table_ds.csv"), index=False
+    )
+    print("Wrote summary_table_ds")
+
     for x, y, xlabel, ylabel, filename in SCATTERS:
         if y not in df.columns or not df[y].notna().any():
             print(f"Skipping {filename}: no '{y}' observations")
@@ -55,7 +123,88 @@ def main():
         fig = scatter_by_group(
             df, x, y, group="study",
             xlabel=xlabel, ylabel=ylabel,
-            title=f"{ylabel} vs {xlabel.lower()} (Down syndrome), by study",
+            output_dir=out_dir, filename=filename,
+        )
+        plt.close(fig)
+        print(f"Wrote {filename}")
+
+    # Age-trajectory views of the Down syndrome pool against the pooled
+    # median/IQR: every observation as a study-coloured point over the FULL
+    # age range (so where the data thins is visible), and the repeat-measures
+    # children linked within form over the reporting window.
+    ds = load_combined_data(max_age_months=DS_REPEAT_AGE_RANGE[1])
+    ds_colours = _shared_group_colours(df["study"].unique())
+    for outcome, ylabel in REPEAT_OUTCOMES:
+        filename = f"observations_age_{outcome}_ds"
+        fig = plot_observations_by_group(
+            df, outcome,
+            age_range=(DS_REPEAT_AGE_RANGE[0], None),
+            group_colors=ds_colours,
+            ylabel=ylabel,
+            output_dir=out_dir, filename=filename,
+        )
+        plt.close(fig)
+        print(f"Wrote {filename}")
+
+        filename = f"repeat_measures_age_{outcome}_ds"
+        fig = plot_repeat_measures_by_group(
+            ds, outcome,
+            age_range=DS_REPEAT_AGE_RANGE,
+            group_colors=ds_colours,
+            ylabel=ylabel,
+            output_dir=out_dir, filename=filename,
+        )
+        plt.close(fig)
+        print(f"Wrote {filename}")
+
+    # The same view of the typically-developing Wordbank reference pool. Each
+    # outcome is loaded on its own: requesting understood restricts the TD
+    # loader to the bivariate forms, so a joint frame would silently drop the
+    # Words & Sentences spoken observations. The ~1,000 repeat-measures
+    # children need fainter lines.
+    td_frames = {
+        outcome: load_data(
+            Population.TYPICALLY_DEVELOPING,
+            ["study", "subject_id", "form", "age", outcome],
+        )
+        for outcome, _ in REPEAT_OUTCOMES
+    }
+    td_colours = _shared_group_colours(
+        set().union(*[set(frame["study"].unique()) for frame in td_frames.values()])
+    )
+
+    # The TD summary table: the spoken frame covers every admitted form, so it
+    # supplies the age statistics and counts; understood comes from its own
+    # bivariate-form frame.
+    summary_table_by_group(
+        td_frames["spoken"],
+        {"understood": td_frames["understood"], "spoken": td_frames["spoken"]},
+    ).to_csv(os.path.join(out_dir, "summary_table_td.csv"), index=False)
+    print("Wrote summary_table_td")
+    for outcome, ylabel in REPEAT_OUTCOMES:
+        # The TD pool is too dense for a scatter (hundreds of administrations
+        # at each integer age), so the by-age view is monthly violins. The
+        # axis ends at the measure's own data — comprehension stops where the
+        # bivariate forms do, before the pool's 30-month bound.
+        filename = f"violins_age_{outcome}_td"
+        fig = plot_monthly_violins(
+            td_frames[outcome], outcome,
+            age_range=(TD_REPEAT_AGE_RANGE[0], None),
+            ylabel=ylabel,
+            output_dir=out_dir, filename=filename,
+        )
+        plt.close(fig)
+        print(f"Wrote {filename}")
+
+        filename = f"repeat_measures_age_{outcome}_td"
+        fig = plot_repeat_measures_by_group(
+            td_frames[outcome], outcome,
+            form_col="form",
+            age_range=TD_REPEAT_AGE_RANGE,
+            bin_width=TD_REPEAT_BIN_WIDTH,
+            line_alpha=0.15,
+            group_colors=td_colours,
+            ylabel=ylabel,
             output_dir=out_dir, filename=filename,
         )
         plt.close(fig)
@@ -70,3 +219,6 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+
+

--- a/src/vocab_growth/descriptive.py
+++ b/src/vocab_growth/descriptive.py
@@ -28,6 +28,460 @@ from dse_research_utils.plot.styles import categorical_palette
 
 MEASURES = ("understood", "spoken", "signed")
 
+# The pooled-summary overlay the repeated-measures plots draw: pure red so it
+# reads as one family over any categorical palette, with a near-transparent
+# interquartile band.
+_SUMMARY_COLOUR = "red"
+_IQR_ALPHA = 0.08
+
+
+def drawable_groups(
+    df: pd.DataFrame,
+    outcomes: tuple[str, ...],
+    *,
+    group: str = "study",
+    subject_col: str = "subject_id",
+    form_col: str = "survey_vocab_max",
+) -> list[str]:
+    """Groups contributing at least one drawable repeated-measures fragment.
+
+    A fragment is two or more observations of one subject on one form for any
+    of ``outcomes``. Callers building a shared group -> colour mapping across
+    several figures should assign colours over this union, so a group keeps
+    one colour everywhere and the palette is not wasted on groups that never
+    draw a line.
+    """
+    drawn: set[str] = set()
+    for outcome in outcomes:
+        obs = df.dropna(subset=["age", outcome])
+        frag = (
+            obs[group].astype(str)
+            + "::"
+            + obs[subject_col].astype(str)
+            + "@"
+            + obs[form_col].astype(str)
+        )
+        counts = frag.groupby(frag).transform("size")
+        drawn |= set(obs.loc[counts >= 2, group].astype(str).unique())
+    return sorted(drawn)
+
+
+def summary_table_by_group(
+    age_frame: pd.DataFrame,
+    measure_frames: dict[str, pd.DataFrame],
+    *,
+    group: str = "study",
+    subject_col: str = "subject_id",
+) -> pd.DataFrame:
+    """Per-group range/median/mean/SD summary table, plus a pooled ``All`` row.
+
+    Age statistics and the observation/child counts come from ``age_frame``;
+    each measure's statistics come from its own frame's non-missing values.
+    The split matters for the typically-developing pool, whose comprehension
+    and production are loaded from different form sets — a single frame would
+    either drop the Words & Sentences production rows or misstate the ages the
+    pool covers. For the Down syndrome pool, pass the same frame throughout.
+
+    Columns: ``{group}``, ``n_subjects``, ``n_observations``, and
+    ``{m}_{stat}`` for ``age`` and each measure, with stat in
+    min/max/median/mean/sd (sd with ddof=1; all NaN where a group records no
+    such measure).
+    """
+
+    def stats(series: pd.Series) -> dict[str, float]:
+        s = pd.to_numeric(series, errors="coerce").dropna()
+        if not len(s):
+            return {k: np.nan for k in ("min", "max", "median", "mean", "sd")}
+        return {
+            "min": float(s.min()),
+            "max": float(s.max()),
+            "median": float(s.median()),
+            "mean": float(s.mean()),
+            "sd": float(s.std(ddof=1)),
+        }
+
+    def sub(frame: pd.DataFrame, name: str) -> pd.DataFrame:
+        return frame if name == "All" else frame[frame[group].astype(str) == name]
+
+    names = sorted(
+        set(age_frame[group].astype(str).unique()).union(
+            *[set(f[group].astype(str).unique()) for f in measure_frames.values()]
+        )
+    )
+    rows = []
+    for name in [*names, "All"]:
+        ages = sub(age_frame, name)
+        row: dict[str, object] = {
+            group: name,
+            "n_subjects": int(ages[subject_col].nunique()),
+            "n_observations": int(len(ages)),
+        }
+        for stat, value in stats(ages["age"]).items():
+            row[f"age_{stat}"] = value
+        for measure, frame in measure_frames.items():
+            for stat, value in stats(sub(frame, name)[measure]).items():
+                row[f"{measure}_{stat}"] = value
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def _binned_outcome_summary(
+    obs: pd.DataFrame,
+    outcome: str,
+    lo: float,
+    hi: float,
+    bin_width: int,
+    min_bin_n: int,
+) -> pd.DataFrame:
+    """Pooled per-age-bin summary (n, median, mean, quartiles) of ``outcome``."""
+    edges = np.arange(lo - lo % bin_width, hi + bin_width, bin_width)
+    binned = obs.groupby(pd.cut(obs["age"], edges), observed=False)[outcome]
+    summary = pd.DataFrame(
+        {
+            "age_mid": edges[:-1] + bin_width / 2,
+            "n": binned.size().to_numpy(),
+            "median": binned.median().to_numpy(),
+            "mean": binned.mean().to_numpy(),
+            "q25": binned.quantile(0.25).to_numpy(),
+            "q75": binned.quantile(0.75).to_numpy(),
+        }
+    )
+    return summary[summary["n"] >= min_bin_n]
+
+
+def _draw_pooled_summary(
+    ax, summary: pd.DataFrame, bin_width: int, *, centre_lines: bool = True
+) -> None:
+    """The red pooled overlay: IQR band, plus solid median and dashed mean
+    unless ``centre_lines`` is False (the observation scatters draw the band
+    alone — a fitted-looking centre line overstates what a raw-data figure
+    shows)."""
+    ax.fill_between(
+        summary["age_mid"],
+        summary["q25"],
+        summary["q75"],
+        color=_SUMMARY_COLOUR,
+        alpha=_IQR_ALPHA,
+        linewidth=0,
+        zorder=2,
+        label="Pooled IQR (25th–75th percentile)",
+    )
+    if not centre_lines:
+        return
+    ax.plot(
+        summary["age_mid"],
+        summary["median"],
+        color=_SUMMARY_COLOUR,
+        lw=2.5,
+        zorder=3,
+        label=f"Pooled median ({bin_width}-month bins)",
+    )
+    ax.plot(
+        summary["age_mid"],
+        summary["mean"],
+        color=_SUMMARY_COLOUR,
+        lw=1.8,
+        ls="--",
+        zorder=3,
+        label=f"Pooled mean ({bin_width}-month bins)",
+    )
+
+
+def plot_observations_by_group(
+    df: pd.DataFrame,
+    outcome: str,
+    *,
+    group: str = "study",
+    subject_col: str = "subject_id",
+    age_range: tuple[float, float | None] = (8, None),
+    bin_width: int = 6,
+    min_bin_n: int = 5,
+    point_alpha: float = 0.45,
+    point_size: float = 12,
+    group_colors: dict | None = None,
+    ylabel: str | None = None,
+    title: str | None = None,
+    figsize: tuple[float, float] = (9, 6),
+    output_dir: str | None = None,
+    filename: str | None = None,
+):
+    """Every observation of ``outcome`` by age, coloured by group, with the
+    pooled IQR band.
+
+    The scatter companion to :func:`plot_repeat_measures_by_group`: the same
+    age window, binning and per-group colouring, but overlaying only the
+    pooled interquartile band (no median/mean centre lines — a fitted-looking
+    centre line overstates what a raw-data figure shows) and showing
+    ALL observations as points — single-visit children included — rather than
+    only the repeat-measures subset. An ``age_range`` upper bound of None means
+    the data's own maximum, so the scatter can show where the pool thins while
+    the windowed trajectory figures stay within the reporting range.
+    ``group_colors`` maps group name to colour; pass the same mapping to both
+    plot types so a group keeps one colour across the figures. Saves
+    ``.png``/``.svg`` and the binned summary as ``.csv`` when
+    ``output_dir``/``filename`` are given.
+    """
+    lo, hi = age_range
+    obs = df.dropna(subset=["age", outcome]).copy()
+    if hi is None:
+        hi = float(obs["age"].max())
+    obs = obs[(obs["age"] >= lo) & (obs["age"] <= hi)]
+    n_subjects = (
+        obs[group].astype(str) + "::" + obs[subject_col].astype(str)
+    ).nunique()
+
+    summary = _binned_outcome_summary(obs, outcome, lo, hi, bin_width, min_bin_n)
+
+    groups = sorted(obs[group].astype(str).unique())
+    if group_colors is None:
+        group_colors = dict(zip(groups, categorical_palette(len(groups)), strict=True))
+
+    fig, ax = plt.subplots(figsize=figsize)
+    for name in groups:
+        rows = obs[obs[group].astype(str) == name]
+        ax.scatter(
+            rows["age"],
+            rows[outcome],
+            s=point_size,
+            alpha=point_alpha,
+            color=group_colors[name],
+            edgecolors="none",
+            zorder=1,
+        )
+
+    _draw_pooled_summary(ax, summary, bin_width, centre_lines=False)
+
+    per_group = obs.groupby(obs[group].astype(str))[subject_col].nunique()
+    for name in group_colors:
+        if name in per_group.index:
+            ax.scatter(
+                [], [],
+                s=30,
+                color=group_colors[name],
+                label=f"{name} (n = {per_group[name]})",
+            )
+
+    ax.set_xlabel("Age (months)")
+    if ylabel:
+        ax.set_ylabel(ylabel)
+    if title:
+        ax.set_title(f"{title} — {n_subjects:,} children, {len(obs):,} observations")
+    ax.set_ylim(bottom=0)
+    ax.set_xlim(lo, hi)
+    ax.legend(loc="upper left", frameon=False, ncol=2, fontsize="small")
+    ax.grid(True, alpha=0.25)
+
+    if output_dir is not None and filename is not None:
+        os.makedirs(output_dir, exist_ok=True)
+        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300, bbox_inches="tight")
+        fig.savefig(os.path.join(output_dir, f"{filename}.svg"), bbox_inches="tight")
+        summary.to_csv(os.path.join(output_dir, f"{filename}.csv"), index=False)
+    return fig
+
+
+def plot_monthly_violins(
+    df: pd.DataFrame,
+    outcome: str,
+    *,
+    age_range: tuple[float, float | None] = (8, None),
+    min_month_n: int = 5,
+    body_colour: str = "#4878a8",
+    ylabel: str | None = None,
+    figsize: tuple[float, float] = (9, 6),
+    output_dir: str | None = None,
+    filename: str | None = None,
+):
+    """Per-month distributions of ``outcome`` as violins, with the pooled
+    monthly median and interquartile band.
+
+    Built for pools too dense for a scatter — the typically-developing
+    Wordbank pool records hundreds of administrations at each integer age, so
+    a scatter saturates into stripes while violins show the distribution's
+    shape: the mass on zero before production starts, the growing right tail,
+    and the accumulation at form ceilings. Ages are rounded to the nearest
+    month; months with fewer than ``min_month_n`` observations are omitted.
+    Each violin's density estimate is clipped to that month's observed range,
+    so no mass is drawn below zero or beyond the ceilings. An ``age_range``
+    upper bound of None means the data's own maximum, so the axis ends where
+    the measure's forms do. Saves ``.png``/``.svg`` and the monthly summary as
+    ``.csv`` when ``output_dir``/``filename`` are given.
+    """
+    lo, hi = age_range
+    obs = df.dropna(subset=["age", outcome]).copy()
+    if hi is None:
+        hi = float(obs["age"].max())
+    obs = obs[(obs["age"] >= lo) & (obs["age"] <= hi)]
+    obs["_month"] = obs["age"].round().astype(int)
+
+    months, groups = [], []
+    for month, rows in obs.groupby("_month"):
+        if len(rows) >= min_month_n:
+            months.append(int(month))
+            groups.append(rows[outcome].to_numpy())
+
+    summary = pd.DataFrame(
+        {
+            "age_months": months,
+            "n": [len(g) for g in groups],
+            "median": [float(np.median(g)) for g in groups],
+            "q25": [float(np.quantile(g, 0.25)) for g in groups],
+            "q75": [float(np.quantile(g, 0.75)) for g in groups],
+        }
+    )
+
+    fig, ax = plt.subplots(figsize=figsize)
+    parts = ax.violinplot(
+        groups, positions=months, widths=0.85, showmedians=False, showextrema=False
+    )
+    for body, values in zip(parts["bodies"], groups, strict=True):
+        body.set_facecolor(body_colour)
+        body.set_alpha(0.55)
+        body.set_edgecolor("none")
+        path = body.get_paths()[0]
+        path.vertices[:, 1] = np.clip(
+            path.vertices[:, 1], float(values.min()), float(values.max())
+        )
+
+    ax.fill_between(
+        summary["age_months"],
+        summary["q25"],
+        summary["q75"],
+        color=_SUMMARY_COLOUR,
+        alpha=_IQR_ALPHA,
+        linewidth=0,
+        zorder=2,
+        label="Pooled IQR (25th–75th percentile)",
+    )
+    ax.plot(
+        summary["age_months"],
+        summary["median"],
+        color=_SUMMARY_COLOUR,
+        lw=2.5,
+        zorder=3,
+        label="Pooled median (monthly)",
+    )
+
+    ax.set_xlabel("Age (months)")
+    if ylabel:
+        ax.set_ylabel(ylabel)
+    ax.set_ylim(bottom=0)
+    ax.set_xlim(min(months) - 1, max(months) + 1)
+    ax.legend(loc="upper left", frameon=False)
+    ax.grid(True, alpha=0.25)
+
+    if output_dir is not None and filename is not None:
+        os.makedirs(output_dir, exist_ok=True)
+        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300, bbox_inches="tight")
+        fig.savefig(os.path.join(output_dir, f"{filename}.svg"), bbox_inches="tight")
+        summary.to_csv(os.path.join(output_dir, f"{filename}.csv"), index=False)
+    return fig
+
+
+def plot_repeat_measures_by_group(
+    df: pd.DataFrame,
+    outcome: str,
+    *,
+    group: str = "study",
+    subject_col: str = "subject_id",
+    form_col: str = "survey_vocab_max",
+    age_range: tuple[float, float] = (8, 72),
+    bin_width: int = 6,
+    min_bin_n: int = 5,
+    line_alpha: float = 0.45,
+    group_colors: dict | None = None,
+    ylabel: str | None = None,
+    title: str | None = None,
+    figsize: tuple[float, float] = (9, 6),
+    output_dir: str | None = None,
+    filename: str | None = None,
+):
+    """Repeated-measures trajectories by group, with a pooled median/IQR overlay.
+
+    Every subject with two or more observations of ``outcome`` on one form is
+    drawn as a line joining those visits, coloured by ``group``. Over the fan
+    sit the pooled median (solid red), mean (dashed red) and interquartile band
+    (translucent red), computed in ``bin_width``-month age bins over ALL
+    observations in ``df`` within ``age_range`` — single-visit subjects
+    included, so the central trajectory describes the whole pool rather than
+    the repeat-measures subset.
+
+    Lines join observations of one subject on ONE form only (``form_col``): a
+    same-day dual-form pair or a cross-form transition is a change of
+    measurement scale, not development, so those segments are never drawn.
+
+    ``age_range`` bounds the observations used (excluded, not merely clipped
+    from view), and bins with fewer than ``min_bin_n`` observations are not
+    summarised. ``group_colors`` maps group name to colour; when None the
+    colours come from ``categorical_palette`` over the groups that contribute a
+    fragment — pass a shared mapping (see :func:`drawable_groups`) when several
+    figures must keep group colours aligned. Saves ``.png``/``.svg`` and the
+    binned summary as ``.csv`` when ``output_dir``/``filename`` are given.
+    """
+    lo, hi = age_range
+    obs = df.dropna(subset=["age", outcome]).copy()
+    obs = obs[(obs["age"] >= lo) & (obs["age"] <= hi)]
+
+    obs["_subject"] = obs[group].astype(str) + "::" + obs[subject_col].astype(str)
+    obs["_fragment"] = obs["_subject"] + "@" + obs[form_col].astype(str)
+    n_visits = obs.groupby("_fragment")["age"].transform("size")
+    repeats = obs[n_visits >= 2].sort_values(["_fragment", "age"])
+    n_subjects = repeats["_subject"].nunique()
+
+    summary = _binned_outcome_summary(obs, outcome, lo, hi, bin_width, min_bin_n)
+
+    if group_colors is None:
+        groups = drawable_groups(
+            df, (outcome,), group=group, subject_col=subject_col, form_col=form_col
+        )
+        palette = categorical_palette(len(groups))
+        group_colors = dict(zip(groups, palette, strict=True))
+
+    fig, ax = plt.subplots(figsize=figsize)
+    for _, rows in repeats.groupby("_fragment"):
+        colour = group_colors[str(rows[group].iloc[0])]
+        ax.plot(
+            rows["age"],
+            rows[outcome],
+            color=colour,
+            alpha=line_alpha,
+            lw=1.0,
+            marker="o",
+            ms=2.5,
+            markerfacecolor=colour,
+            markeredgewidth=0,
+            zorder=1,
+        )
+
+    _draw_pooled_summary(ax, summary, bin_width)
+
+    per_group = repeats.groupby(repeats[group].astype(str))["_subject"].nunique()
+    for name in group_colors:
+        if name in per_group.index:
+            ax.plot(
+                [], [],
+                color=group_colors[name],
+                alpha=0.8,
+                lw=2,
+                label=f"{name} (n = {per_group[name]})",
+            )
+
+    ax.set_xlabel("Age (months)")
+    if ylabel:
+        ax.set_ylabel(ylabel)
+    if title:
+        ax.set_title(f"{title} — {n_subjects:,} children, linked within form")
+    ax.set_ylim(bottom=0)
+    ax.set_xlim(lo, hi)
+    ax.legend(loc="upper left", frameon=False, ncol=2, fontsize="small")
+    ax.grid(True, alpha=0.25)
+
+    if output_dir is not None and filename is not None:
+        os.makedirs(output_dir, exist_ok=True)
+        fig.savefig(os.path.join(output_dir, f"{filename}.png"), dpi=300, bbox_inches="tight")
+        fig.savefig(os.path.join(output_dir, f"{filename}.svg"), bbox_inches="tight")
+        summary.to_csv(os.path.join(output_dir, f"{filename}.csv"), index=False)
+    return fig
+
 
 def summarise_by_group(
     df: pd.DataFrame,
@@ -107,3 +561,5 @@ def scatter_by_group(
             os.path.join(output_dir, f"{filename}.csv"), index=False
         )
     return fig
+
+

--- a/uv.lock
+++ b/uv.lock
@@ -518,7 +518,7 @@ wheels = [
 [[package]]
 name = "dse-research-utils"
 version = "0.12.0"
-source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.0#cd5cc18f113d1ca7e78be1e9c23f43078ce1bc01" }
+source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.1#a475db88138714ce5d49a865a4819dcfd7c1dbcb" }
 dependencies = [
     { name = "arviz" },
     { name = "arviz-base" },
@@ -592,7 +592,7 @@ lint = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.0" }]
+requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.1" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Fable 5).

## Overview

Builds the report's data-description layer: study-coloured figures and per-study summary tables for both populations, embedded in the main report's Data chapter (`docs/report/methods-data.qmd`) and the standalone descriptive report (`docs/descriptive/index.qmd`). Follows on from #275 (it builds on that PR's data-quality fixes and report edits, now in `main`).

## What's added

All figures are produced by `scripts/generate_descriptive_report.py` from new functions in `vocab_growth.descriptive`, regenerate from the prepared data after `prepare_data.py`, and are mirrored into the main report's figure cache as before:

- **Repeated-measures trajectories** (`plot_repeat_measures_by_group`): each child's visits joined **within form only** — a same-day dual-form pair or a form transition is a change of measurement scale, not development, so those segments are never drawn. Coloured by study against a pooled median/mean/IQR overlay. Down syndrome over the 8–72 month reporting window; typically-developing over its 8–30 month pool.
- **Observation scatters** (`plot_observations_by_group`): every observation (single-visit children included) with the pooled IQR band only — no centre lines on raw-data figures. The Down syndrome scatter deliberately covers the full 8–115 month range so it is visible that coverage beyond ~72 months rests on a couple of studies, which is why results are reported to 72 months.
- **TD monthly violins** (`plot_monthly_violins`): the typically-developing pool records hundreds of administrations at each integer age, so a scatter saturates into stripes; one violin per month (density clipped to that month's observed range, axis ending where the measure's forms do) shows the mass on zero before production starts, the growing right tail, and the accumulation at form ceilings.
- **Summary tables** (`summary_table_by_group`): per-study children, administrations, and range/median/mean (SD) of age, words understood and words spoken, plus a pooled All row — written as CSVs and rendered as tables in the Data chapter. Each measure takes its own frame because TD comprehension and production are loaded from different form sets.

Presentation decisions carried throughout: one study→colour mapping per population shared across every figure (reddish palette entries skipped, since the pooled overlay is pure red; uk_01 pinned to teal); no figure titles (report captions do that work); legends list only the groups a figure draws, with per-study n.

## Dependency bump

`dse-research-utils` v0.12.0 → v0.12.1, whose only change raises the shared style's `FONT_SIZE_DEFAULT` from 10 to 12 — judged clearer at report figure sizes in a side-by-side comparison. The descriptive figures pick it up immediately; model-fit figures will as fits are regenerated (all are stale pending refits after #275's data-quality fixes anyway). The agent-instruction copies' dependency reference is corrected (it still said v0.11.2). Note: the v0.12.1 tag's package metadata still declares 0.12.0 (upstream version not bumped with the tag); uv pins the exact commit, so this is cosmetic.

## Reviewer notes

- Figures and CSVs are generated artefacts (gitignored caches); run `scripts/prepare_data.py` then `scripts/generate_descriptive_report.py` and render to see them. The descriptive report's in-place render outputs (`index.html`, `index_files/`) are newly gitignored.
- The fast suite passes locally (1157 passed) on the updated lockfile; lint, spellcheck and Prettier are clean, and both documents render with all embeds resolving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
