### PR TITLE
Compute administration-level LOO and expose the marginal fallback for VG14/VG15

### DIFF
--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -161,6 +161,7 @@ lengthscale
 logind
 logit
 logits
+logp
 matplotlib
 microbenchmark
 miscalibrated

--- a/notes/202608261700-issue-266-remediation.md
+++ b/notes/202608261700-issue-266-remediation.md
@@ -58,3 +58,41 @@ Comparison outputs got the provenance they lacked. A generating script records a
 ## 6. Discovered in passing
 
 VG17 and VG18 cannot be fitted at all, on this branch or on `main`: `_build` reuses VG01's `ages_query`, which runs to 90 months, against VG17's 12–66 month GP domain, and the domain check rejects it. This is pre-existing and unrelated to #266; it wants its own issue.
+
+## 7. Second remediation pass (2026-08-31)
+
+Three of the five items in §5 were code changes waiting on nothing, and this pass took them. The two that remain are refits and a statistical design; both are named again at the end.
+
+### Administration-level LOO is now computed, not only relabelled
+
+§5 recorded this as a separate change that "regenerates every model page", and deferred it. It is taken now for a reason that has a deadline attached: **every registered fit already needs re-running**, so the cost of this change is currently zero and rises the moment the refit run starts. Landing it after that run would waste the run.
+
+`vocab_growth.administration_loo` sums every likelihood factor belonging to one row of the analysis frame into a single pointwise entry, and the diagnostics stage computes a LOO over it **alongside** the per-outcome scores rather than instead of them. The per-outcome numbers stay comparable across models on the same conditional units; what they never were is whole-administration predictive accuracy, and the reports said they were.
+
+Three things follow. A paired administration is one held-out case with one importance weight rather than two. Nothing of a held-out row remains in the conditioning set — previously, holding out the comprehension factor left its own observed value in the spoken factor's denominator. And **VG15's two composition terms are included**, so the model's headline association `psi` is scored by leave-one-out at all for the first time; the per-outcome scores omit those terms entirely.
+
+The mechanics are `scripts/loo_compare.py`'s `_attach_joint_log_likelihood`, which has computed this correctly for the bivariate case since #236, generalised to any number of factors including the matrix-valued composition ones. Verified on a real two-chain VG10 fit while it was written: 96 per-outcome terms collapse to 48 administration cases with the total log-likelihood conserved to 0.0 exactly.
+
+**This depended on finding 3 having been fixed first.** The mapping from a factor's likelihood rows back to administration rows is the `obs_*_mask` constant data. A mask marking recorded rows rather than likelihood rows would sum the wrong factors onto the wrong administrations — silently, and plausibly. The combiner refuses a mask that does not match its factor rather than proceeding.
+
+### VG14 and VG15 can run the marginal fallback sensitivity
+
+Finding 8's exposure — roughly 455 of 1,428 Down syndrome spoken rows take an approximation that preserves the mean but not the variance, on rows that are older and clustered by study — could not be measured on either signing model, because both hard-coded the default. Both now carry `spoken_fallback`, route their child-outcome likelihoods through the shared `nested_outcome_alpha_beta`, and have the three arms registered. The treatment applies to the **signed** rows as well as the spoken ones: signing is nested inside comprehension exactly as speech is, so varying one and not the other would leave half the exposure in place.
+
+Two things were found in doing it.
+
+**The trivariate engine carried finding 3's defect, unreachably.** It stored `has_s` and `has_sign` — the _recorded_ masks — where the bivariate engines store the likelihood ones. With no fallback choice to select, no row was ever dropped and the two coincided; exposing the choice would have made it reachable, and the first `paired_only` run would have died at calibration after sampling, exactly as the bivariate fits did. Fixed before it could be discovered that way.
+
+**The joint engine read its indices before applying the drop**, leaving the `obs_s_id` coordinate sized by the unfiltered rows and the trial counts by the filtered ones. That fails at logp evaluation with a bare shape error and no indication of the cause. Caught because the test builds each treatment on a frame that _has_ marginal rows — the graph-equivalence harness's frame is fully paired, so `paired_only` and `moment_matched` are no-ops on it and a test using it would have passed while proving nothing.
+
+**Adding the field invalidated no existing fit**, which is the first real use of the versioned manifest payload from #273 step 5. Under the raw dictionary equality this replaced, adding `spoken_fallback` would have invalidated every VG14 and VG15 fit ever made, for a field whose default is what those fits already did. `BACKFILL_DEFAULTS` records that claim, and it is checkable rather than asserted: `resolve_fallback_treatment` reads the field through `getattr` with exactly this default, so a definition that predates it resolved to `product_marginal`.
+
+Both models also became reachable from `fit_sensitivity.py` and `refit_hightune.py` with no further change, because #273 made those scripts derive their runner map from the catalogue and the variant registry.
+
+### Still outstanding, and still not a code change
+
+**Every registered model needs a reporting-quality refit.** Unchanged from §5, and now also the only way to get an administration-level LOO row onto any model page — the score is computed during the fit.
+
+**VG22's induced prior needs designing.** Unchanged: an explicit prior over the implied correlations, a refit of the rank family, parameter recovery and a whole-child predictive comparison before the default rank is re-selected.
+
+**The fallback sensitivity arms need running.** They can now be run on all four affected engines rather than two, which is what this pass changed; running them is a fitting task.

--- a/src/vocab_growth/administration_loo.py
+++ b/src/vocab_growth/administration_loo.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Leave-one-**administration**-out, as the reports have always claimed.
+
+Issue #266 finding 4. The multi-outcome engines compute a separate PSIS-LOO for
+each outcome, while the report describes the predictive unit as a complete
+checklist administration. Those are not the same score, and the difference is
+not presentational:
+
+* the spoken likelihood's trial count **is the same row's observed
+  comprehension**, so holding out a spoken term scores prediction *conditional
+  on* that comprehension rather than prediction of a withheld administration;
+* holding out an understood term leaves its own observed value in the spoken
+  term's denominator, so the held-out value has not really been withheld;
+* a paired administration becomes two held-out cases with two importance
+  weights, which is not what "one observation" means anywhere in the reports.
+
+The coherent unit is the administration: **sum** every likelihood factor
+belonging to one row of the analysis frame into one pointwise entry, so a
+held-out case is ``log p(U_i) + log p(S_i | U_i)`` where both exist, and the
+single factor where only one does. For VG15 that includes the two composition
+terms -- the four-cell cross-tabulation and the ``nz_01`` produced cells --
+which identify its headline association ``psi`` and which the per-outcome scores
+omit entirely, so its LOO never scored the thing the model exists to estimate.
+
+The mapping from each factor's likelihood rows back to administration rows is
+the ``obs_*_mask`` constant data every engine already stores. That is why the
+mask defect (finding 3) had to be fixed first: a mask that marked recorded rows
+rather than likelihood rows would sum the wrong factors onto the wrong
+administrations, silently.
+
+The mechanics are ``scripts/loo_compare.py``'s ``_attach_joint_log_likelihood``,
+which has computed this correctly for the bivariate case since #236 -- generalised
+to any number of factors, including matrix-valued ones, and moved where the fit
+pipeline itself can use it.
+
+**Repeated administrations of the same child remain separate cases.** This
+scores prediction of another administration like those in the frame, not
+generalisation to a new child; ``scripts/kfold_loso.py`` is what answers the
+latter. Said here because "leave one out" invites the other reading.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import xarray as xr
+
+#: Name of the combined pointwise likelihood attached to the trace, and the
+#: dimension it is indexed by. ``obs_joint`` is the name
+#: ``scripts/loo_compare.py`` has used since #236; kept so the two agree.
+ADMINISTRATION_VAR = "y_administration"
+ADMINISTRATION_DIM = "obs_joint"
+
+#: How the combined score is labelled in `loo_summary.csv` and the reports.
+#: Spelled out rather than abbreviated: the whole finding is that "LOO" alone
+#: was read as this when it was not.
+ADMINISTRATION_LABEL = "administration (all outcomes)"
+
+
+@dataclass(frozen=True)
+class LikelihoodFactor:
+    """One likelihood term, and the mask locating its rows in the frame."""
+
+    variable: str
+    """Its name in the trace's ``log_likelihood`` group."""
+
+    mask: str
+    """The ``constant_data`` mask, over all ``n`` administration rows, marking
+    the rows this factor covers -- in the same order the factor's own rows are
+    stored."""
+
+
+def _factor_dim(array: xr.DataArray) -> str:
+    """The row dimension of a pointwise log-likelihood.
+
+    A composition factor is stored per row *and* per cell (``obs_cells_id`` x
+    ``cell_id``); ArviZ sums the trailing dimensions into the pointwise value,
+    and so does this -- the held-out unit is the administration, not one cell of
+    its cross-tabulation.
+    """
+    dims = [dim for dim in array.dims if dim not in ("chain", "draw")]
+    if not dims:
+        raise ValueError(
+            f"log-likelihood factor has no row dimension (dims {array.dims})."
+        )
+    return dims[0]
+
+
+def administration_log_likelihood(
+    trace, factors: tuple[LikelihoodFactor, ...]
+) -> xr.DataArray | None:
+    """Sum ``factors`` onto administration rows, or ``None`` if not derivable.
+
+    Returns ``None`` -- rather than raising -- when a factor or its mask is
+    absent, because a caller may legitimately be looking at a trace written
+    before this existed or by an engine that stores only one factor. A factor
+    present with a mask that does not match its rows **does** raise: that is the
+    finding-3 defect, and silently summing the wrong rows onto the wrong
+    administrations is exactly what must not happen.
+    """
+    log_likelihood = getattr(trace, "log_likelihood", None)
+    constant_data = getattr(trace, "constant_data", None)
+    if log_likelihood is None or constant_data is None:
+        return None
+
+    usable: list[tuple[xr.DataArray, np.ndarray]] = []
+    for factor in factors:
+        if factor.variable not in log_likelihood.data_vars:
+            return None
+        if factor.mask not in constant_data.data_vars:
+            return None
+        array = log_likelihood[factor.variable]
+        mask = np.asarray(constant_data[factor.mask].values, dtype=bool)
+        dim = _factor_dim(array)
+        if int(mask.sum()) != array.sizes[dim]:
+            raise ValueError(
+                f"{factor.mask} marks {int(mask.sum())} rows but "
+                f"{factor.variable} stores {array.sizes[dim]}; the factor "
+                "cannot be mapped to administrations. This is the shape of "
+                "issue #266 finding 3 -- a mask recording observed rows rather "
+                "than likelihood rows."
+            )
+        usable.append((array, mask))
+
+    if not usable:
+        return None
+
+    any_mask = np.zeros_like(usable[0][1], dtype=bool)
+    for _, mask in usable:
+        any_mask |= mask
+    if not any_mask.any():
+        return None
+
+    # Position of each administration among the rows the combined score keeps.
+    position = np.cumsum(any_mask) - 1
+    template = usable[0][0]
+    n_chain = template.sizes["chain"]
+    n_draw = template.sizes["draw"]
+    combined = np.zeros((n_chain, n_draw, int(any_mask.sum())), dtype=float)
+
+    for array, mask in usable:
+        dim = _factor_dim(array)
+        values = array.transpose("chain", "draw", dim, ...).values
+        if values.ndim > 3:
+            # A composition factor: sum its cells into the row's contribution.
+            values = values.reshape(n_chain, n_draw, values.shape[2], -1).sum(axis=-1)
+        np.add.at(combined, (slice(None), slice(None), position[mask]), values)
+
+    return xr.DataArray(
+        combined,
+        dims=("chain", "draw", ADMINISTRATION_DIM),
+        coords={
+            "chain": template["chain"].values,
+            "draw": template["draw"].values,
+            ADMINISTRATION_DIM: np.flatnonzero(any_mask),
+        },
+    )
+
+
+def attach_administration_log_likelihood(
+    trace, factors: tuple[LikelihoodFactor, ...]
+) -> bool:
+    """Add :data:`ADMINISTRATION_VAR` to ``trace``'s log-likelihood group.
+
+    Returns whether it was added. Idempotent: an already-attached score is left
+    alone, so re-running diagnostics on a trace does not recompute it.
+    """
+    log_likelihood = getattr(trace, "log_likelihood", None)
+    if log_likelihood is None:
+        return False
+    if ADMINISTRATION_VAR in log_likelihood.data_vars:
+        return True
+    combined = administration_log_likelihood(trace, factors)
+    if combined is None:
+        return False
+    trace.log_likelihood = log_likelihood.assign({ADMINISTRATION_VAR: combined})
+    return True

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -47,6 +47,12 @@ import vocab_growth.plotting as plotting
 import vocab_growth.posterior_analysis as posterior_analysis
 import vocab_growth.reporting as vg_reporting
 import vocab_growth.reporting_ages as reporting_ages
+from vocab_growth.administration_loo import (
+    ADMINISTRATION_LABEL,
+    ADMINISTRATION_VAR,
+    LikelihoodFactor,
+    attach_administration_log_likelihood,
+)
 from vocab_growth.analysis_frames import analysis_frame_hash
 from vocab_growth.fit_artifacts import (
     ACCEPTED_EXCEPTION_KEY,
@@ -1215,6 +1221,7 @@ def diagnostics(
     *,
     extra_trace_var_names: tuple[str, ...] = (),
     loo_var_names: tuple[tuple[str, str], ...] | None = None,
+    administration_factors: tuple[LikelihoodFactor, ...] | None = None,
     var_names_fn=None,
     round_to: int = 3,
 ):
@@ -1231,6 +1238,17 @@ def diagnostics(
       LOO-CV (bivariate/trivariate/joint likelihoods are named, e.g.
       ``y_u_obs``). ``None`` runs a single unnamed ``az.loo`` call (the
       single-outcome / study-RE engines, which have exactly one likelihood).
+    - ``administration_factors``: the likelihood factors to sum onto
+      administration rows for a leave-one-**administration**-out score
+      (issue #266 finding 4). ``None`` for the single-outcome engines, whose
+      one likelihood term already *is* the administration. Supplied by every
+      multi-outcome engine, whose per-outcome scores hold out one likelihood
+      term rather than one administration -- the spoken factor's trial count is
+      the same row's observed comprehension, so holding it out scores a
+      conditional prediction, and holding out the comprehension factor leaves
+      its own value in that denominator. Both scores are reported: the
+      per-outcome ones are comparable across models on the same conditional
+      units, and the administration one is what the reports describe.
     - ``var_names_fn``: optional ``list[str] -> list[str]`` reordering applied
       before the pair/trace/posterior-density plots only (the joint engine
       prioritises ``psi``/``conc`` first); the summary table always uses the
@@ -1388,10 +1406,46 @@ def diagnostics(
                     f"[yellow]LOO ({label}): dropped {n_dropped} degenerate "
                     f"(constant log-likelihood) observation(s).[/yellow]"
                 )
+        # Leave-one-administration-out, alongside the per-outcome scores rather
+        # than instead of them (issue #266 finding 4). Every factor belonging to
+        # one row of the frame is summed into one pointwise entry, so a paired
+        # administration is one held-out case rather than two, and VG15's
+        # composition terms -- which identify `psi`, and which the per-outcome
+        # scores omit entirely -- are included.
+        if administration_factors:
+            attached = attach_administration_log_likelihood(
+                context.trace, administration_factors
+            )
+            if attached:
+                loocv_by_name[ADMINISTRATION_VAR], n_dropped = (
+                    _loo_dropping_degenerate(
+                        context.trace, var_name=ADMINISTRATION_VAR, reff=reff
+                    )
+                )
+                by_label[ADMINISTRATION_LABEL] = loocv_by_name[ADMINISTRATION_VAR]
+                dropped_by_label[ADMINISTRATION_LABEL] = n_dropped
+                if n_dropped:
+                    console.print(
+                        f"[yellow]LOO ({ADMINISTRATION_LABEL}): dropped "
+                        f"{n_dropped} degenerate observation(s).[/yellow]"
+                    )
+            else:
+                # Loud, because a silently absent administration score would
+                # leave the per-outcome ones reading as whole-administration
+                # accuracy -- the very confusion finding 4 is about.
+                console.print(
+                    "[yellow]Administration-level LOO not computed: the trace "
+                    "does not carry every likelihood factor and observation "
+                    "mask it needs.[/yellow]"
+                )
+
         context.set_loocv(loocv_by_name)
         for var_name, label in loo_var_names:
             heading(f"LOO-CV — {label}", style="bold cyan")
             console.print(loocv_by_name[var_name])
+        if ADMINISTRATION_VAR in loocv_by_name:
+            heading(f"LOO-CV — {ADMINISTRATION_LABEL}", style="bold cyan")
+            console.print(loocv_by_name[ADMINISTRATION_VAR])
         emit_loo_summary(
             by_label, dropped_by_label, context.reporting.output_dir, reff=reff
         )

--- a/src/vocab_growth/models/common_bivariate.py
+++ b/src/vocab_growth/models/common_bivariate.py
@@ -33,6 +33,7 @@ import vocab_growth.intervals as intervals
 import vocab_growth.plotting as plotting
 import vocab_growth.posterior_analysis as posterior_analysis
 import vocab_growth.reporting_ages as reporting_ages
+from vocab_growth.administration_loo import LikelihoodFactor
 from vocab_growth.fit_artifacts import save_trace
 from vocab_growth.models import prior_child_checks
 from vocab_growth.models.build_utils import (
@@ -1069,6 +1070,15 @@ def diagnostics(context: BivariateContext, definition=None):
             loo_var_names=(
                 ("y_s_obs", "words spoken"),
                 ("y_u_obs", "words understood"),
+            ),
+            # Both factors of an administration, summed into one held-out case
+            # (issue #266 finding 4). Not supplied on the cross-lag branch
+            # below, for the reason its own message gives: the lag predictor
+            # embeds earlier observed comprehension, so no pointwise hold-out
+            # is clean there.
+            administration_factors=(
+                LikelihoodFactor("y_u_obs", "obs_u_mask"),
+                LikelihoodFactor("y_s_obs", "obs_s_mask"),
             ),
             var_names_fn=_prioritise if priority else None,
         )

--- a/src/vocab_growth/models/common_joint_modality.py
+++ b/src/vocab_growth/models/common_joint_modality.py
@@ -75,6 +75,7 @@ import vocab_growth.environment as local_env
 import vocab_growth.intervals as intervals
 import vocab_growth.posterior_analysis as posterior_analysis
 import vocab_growth.reporting_ages as reporting_ages
+from vocab_growth.administration_loo import LikelihoodFactor
 from vocab_growth.fit_artifacts import save_trace
 from vocab_growth.models.build_utils import (
     construct_age_grids,
@@ -107,7 +108,12 @@ from vocab_growth.models.gp_utils import (
     tent_and_gp,
     trend_and_gp,
 )
-from vocab_growth.models.likelihood_utils import nested_outcome_spec
+from vocab_growth.models.likelihood_utils import (
+    SPOKEN_FALLBACK_PAIRED_ONLY,
+    nested_outcome_alpha_beta,
+    nested_outcome_spec,
+    resolve_fallback_treatment,
+)
 from vocab_growth.plotting import (
     _save_csv,
     plot_prior_samples,
@@ -980,6 +986,9 @@ def build_model(context: JointContext, definition: JointModelDefinition):
     require_integral_counts(y_u_values, "understood")
     y_u = y_u_values.astype(int)
     marginal_outcome_eligible = ~holdout & ~has_cells
+    # Which treatment the child-outcome rows with no usable understood count
+    # take (issue #266 finding 8), resolved before the graph.
+    spoken_fallback = resolve_fallback_treatment(definition)
     spoken_spec = nested_outcome_spec(
         df,
         parent_col="understood",
@@ -994,16 +1003,42 @@ def build_model(context: JointContext, definition: JointModelDefinition):
         n_trials=n_trials,
         eligible_mask=marginal_outcome_eligible,
     )
+
+    # `paired_only` is applied at data preparation, by dropping the rows, not in
+    # the graph -- so it has to happen here as well as in the treatment the
+    # builder receives. Both nested outcomes lose their marginal rows: signing
+    # is nested inside comprehension exactly as speech is (issue #266 finding 8).
     expected_spoken = marginal_outcome_eligible & df["spoken"].notna().to_numpy()
     expected_signed = marginal_outcome_eligible & df["signed"].notna().to_numpy()
     if not np.array_equal(spoken_spec.indices, np.flatnonzero(expected_spoken)):
         raise ValueError("Spoken likelihood rows do not match the marginal-data mask.")
     if not np.array_equal(signed_spec.indices, np.flatnonzero(expected_signed)):
         raise ValueError("Signed likelihood rows do not match the marginal-data mask.")
+    if spoken_fallback == SPOKEN_FALLBACK_PAIRED_ONLY:
+        n_fallback_dropped = spoken_spec.n_marginal + signed_spec.n_marginal
+        spoken_spec = spoken_spec.conditional_only()
+        signed_spec = signed_spec.conditional_only()
+        # Printed rather than silent: dropping rows changes what the fit is
+        # fitted to, and a sensitivity arm that quietly used fewer observations
+        # than the model of record would not be comparable with it.
+        print(
+            f"Marginal fallback treatment {spoken_fallback!r}: dropped "
+            f"{n_fallback_dropped} child-outcome row(s) with no usable "
+            "understood count from the likelihood.",
+            flush=True,
+        )
+
+    # Every one of these derives from the FILTERED spec, so the coords, the
+    # observed data, the trial counts and the stored masks all describe the same
+    # rows. Reading them before the drop -- as this did while the drop was being
+    # added -- leaves the coordinate sized by the unfiltered rows and the trial
+    # counts by the filtered ones, which fails at logp evaluation with a shape
+    # error and no indication of the cause.
     idx_s = spoken_spec.indices
     idx_sign = signed_spec.indices
     y_s = spoken_spec.observed
     y_sign = signed_spec.observed
+
     has_s_likelihood = np.zeros(len(df), dtype=bool)
     has_sign_likelihood = np.zeros(len(df), dtype=bool)
     has_s_likelihood[idx_s] = True
@@ -1486,26 +1521,43 @@ def build_model(context: JointContext, definition: JointModelDefinition):
         pm.BetaBinomial("y_u_obs", n=n_trials, alpha=p_u_sel * k_u, beta=(1 - p_u_sel) * k_u,
                         observed=y_u, dims="obs_u_id")
 
-        # Spoken: nested where U is usable, otherwise marginal over the inventory.
-        p_s_sel = pm.math.switch(
-            s_is_conditional,
-            q_obs[idx_s],
-            (p_u_obs * q_obs)[idx_s],
+        # Spoken: nested where U is usable, otherwise marginal over the
+        # inventory. Through the shared builder since issue #266 finding 8, so
+        # this engine can run the marginal fallback sensitivity the bivariate
+        # engines have had since #240. Under the default `product_marginal` it
+        # emits the ops it always did, which `tests/test_graph_equivalence.py`
+        # checks.
+        alpha_s, beta_s = nested_outcome_alpha_beta(
+            treatment=spoken_fallback,
+            is_conditional=s_is_conditional,
+            conditional_p=q_obs[idx_s],
+            marginal_p=(p_u_obs * q_obs)[idx_s],
+            parent_p=p_u_obs[idx_s],
+            parent_kappa=kappa_u_obs[idx_s],
+            kappa=kappa_s_obs[idx_s],
+            epsilon=EPSILON,
+            outcome="s",
+            fallback_kappa_sigma=definition.spoken_fallback_kappa_sigma,
         )
-        p_s_sel = pm.math.clip(p_s_sel, EPSILON, 1 - EPSILON)
-        k_s = kappa_s_obs[idx_s]
-        pm.BetaBinomial("y_s_obs", n=s_likelihood_n, alpha=p_s_sel * k_s, beta=(1 - p_s_sel) * k_s,
+        pm.BetaBinomial("y_s_obs", n=s_likelihood_n, alpha=alpha_s, beta=beta_s,
                         observed=y_s, dims="obs_s_id")
 
-        # Signed: nested where U is usable, otherwise marginal over the inventory.
-        p_sign_sel = pm.math.switch(
-            sign_is_conditional,
-            r_obs[idx_sign],
-            (p_u_obs * r_obs)[idx_sign],
+        # Signed: the same treatment. Signing is nested inside comprehension
+        # exactly as speech is, so exposing the choice for one outcome and not
+        # the other would leave half the exposure unmeasurable.
+        alpha_sign, beta_sign = nested_outcome_alpha_beta(
+            treatment=spoken_fallback,
+            is_conditional=sign_is_conditional,
+            conditional_p=r_obs[idx_sign],
+            marginal_p=(p_u_obs * r_obs)[idx_sign],
+            parent_p=p_u_obs[idx_sign],
+            parent_kappa=kappa_u_obs[idx_sign],
+            kappa=kappa_sign_obs[idx_sign],
+            epsilon=EPSILON,
+            outcome="sign",
+            fallback_kappa_sigma=definition.spoken_fallback_kappa_sigma,
         )
-        p_sign_sel = pm.math.clip(p_sign_sel, EPSILON, 1 - EPSILON)
-        k_sign = kappa_sign_obs[idx_sign]
-        pm.BetaBinomial("y_sign_obs", n=sign_likelihood_n, alpha=p_sign_sel * k_sign, beta=(1 - p_sign_sel) * k_sign,
+        pm.BetaBinomial("y_sign_obs", n=sign_likelihood_n, alpha=alpha_sign, beta=beta_sign,
                         observed=y_sign, dims="obs_sign_id")
 
         # uk_02 four cells (Dirichlet-Multinomial), within-understood composition.
@@ -1691,6 +1743,18 @@ def diagnostics(context: JointContext):
             ("y_u_obs", "words understood"),
             ("y_s_obs", "words spoken"),
             ("y_sign_obs", "words signed"),
+        ),
+        # Every factor of an administration, the two composition terms included
+        # (issue #266 finding 4). Those terms are what identify `psi`, this
+        # model's headline association, and the per-outcome scores above omit
+        # them entirely -- so before this the LOO never scored the quantity the
+        # model exists to estimate.
+        administration_factors=(
+            LikelihoodFactor("y_u_obs", "obs_u_mask"),
+            LikelihoodFactor("y_s_obs", "obs_s_mask"),
+            LikelihoodFactor("y_sign_obs", "obs_sign_mask"),
+            LikelihoodFactor("cells_obs", "obs_cells_mask"),
+            LikelihoodFactor("nz_prod_cells_obs", "obs_prod_mask"),
         ),
     )
 

--- a/src/vocab_growth/models/common_trivariate.py
+++ b/src/vocab_growth/models/common_trivariate.py
@@ -47,6 +47,7 @@ import vocab_growth.intervals as intervals
 import vocab_growth.plotting as plotting
 import vocab_growth.posterior_analysis as posterior_analysis
 import vocab_growth.reporting_ages as reporting_ages
+from vocab_growth.administration_loo import LikelihoodFactor
 from vocab_growth.fit_artifacts import save_trace
 from vocab_growth.models.build_utils import (
     construct_age_grids,
@@ -78,7 +79,12 @@ from vocab_growth.models.gp_utils import (
     tent_and_gp,
     trend_and_gp,
 )
-from vocab_growth.models.likelihood_utils import nested_outcome_spec
+from vocab_growth.models.likelihood_utils import (
+    SPOKEN_FALLBACK_PAIRED_ONLY,
+    nested_outcome_alpha_beta,
+    nested_outcome_spec,
+    resolve_fallback_treatment,
+)
 from vocab_growth.plotting import (
     _save_csv,
     plot_comprehension_production_gap,
@@ -508,6 +514,10 @@ def build_model(
     n = len(X_obs)
     n_u = len(y_u_observed)
     n_trials = context.model_data.n_trials
+    # Which treatment the child-outcome rows with no usable understood count
+    # take (issue #266 finding 8). Resolved before the graph so an unknown value
+    # is refused against the definition.
+    spoken_fallback = resolve_fallback_treatment(definition)
     spoken_spec = nested_outcome_spec(
         analysis_df,
         parent_col="understood",
@@ -520,16 +530,40 @@ def build_model(
         outcome_col="signed",
         n_trials=n_trials,
     )
+
     if not np.array_equal(spoken_spec.indices, np.flatnonzero(has_s)):
         raise ValueError("Spoken likelihood rows do not match the observed-data mask.")
     if not np.array_equal(signed_spec.indices, np.flatnonzero(has_sign)):
         raise ValueError("Signed likelihood rows do not match the observed-data mask.")
+    # `paired_only` is applied at data preparation, by dropping the rows, not in
+    # the graph -- so it has to happen here as well as in the treatment the
+    # builder receives. Both nested outcomes lose their marginal rows: signing
+    # is nested inside comprehension exactly as speech is (issue #266 finding 8).
+    # After the checks above, which are written to test the UNFILTERED spec and
+    # still do so under every treatment.
+    n_fallback_dropped = 0
+    if spoken_fallback == SPOKEN_FALLBACK_PAIRED_ONLY:
+        n_fallback_dropped = spoken_spec.n_marginal + signed_spec.n_marginal
+        spoken_spec = spoken_spec.conditional_only()
+        signed_spec = signed_spec.conditional_only()
     y_s_observed = spoken_spec.observed
     y_sign_observed = signed_spec.observed
     idx_s = spoken_spec.indices
     idx_sign = signed_spec.indices
     n_s = spoken_spec.n_observed
     n_sign = signed_spec.n_observed
+    # Stored masks mark the rows the likelihood actually carries, not every row
+    # with a recorded count. Identical to `has_s` / `has_sign` under every
+    # treatment but `paired_only`, which drops rows -- and storing the recorded
+    # mask there is issue #266 finding 3, which killed every paired-only
+    # bivariate fit at calibration after sampling. This engine had no fallback
+    # choice when that was found, so it carried the same latent defect
+    # unreachably; exposing the choice makes it reachable, so it is fixed here
+    # rather than discovered by the first run.
+    has_s_likelihood = np.zeros(n, dtype=bool)
+    has_s_likelihood[spoken_spec.indices] = True
+    has_sign_likelihood = np.zeros(n, dtype=bool)
+    has_sign_likelihood[signed_spec.indices] = True
 
     # Validate
     if not np.all(y_u_observed >= 0):
@@ -561,6 +595,8 @@ def build_model(
             ("Signed conditional on understood", signed_spec.n_conditional),
             ("Signed marginal fallback", signed_spec.n_marginal),
             ("Signed > understood violations", signed_spec.n_parent_violations),
+            ("Marginal fallback treatment", spoken_fallback),
+            ("Marginal fallback rows dropped", n_fallback_dropped),
             ("n_trials", n_trials),
             ("Age mean (months)", X_obs_mean),
             ("Age std (months)", X_obs_std),
@@ -640,8 +676,10 @@ def build_model(
 
         # Store masks for extraction
         _ = pm.Data("obs_u_mask", has_u.astype(int), dims=("obs_id",))
-        _ = pm.Data("obs_s_mask", has_s.astype(int), dims=("obs_id",))
-        _ = pm.Data("obs_sign_mask", has_sign.astype(int), dims=("obs_id",))
+        _ = pm.Data("obs_s_mask", has_s_likelihood.astype(int), dims=("obs_id",))
+        _ = pm.Data(
+            "obs_sign_mask", has_sign_likelihood.astype(int), dims=("obs_id",)
+        )
         s_likelihood_n = pm.Data(
             "s_likelihood_n", spoken_spec.trials, dims=("obs_s_id",)
         )
@@ -922,15 +960,24 @@ def build_model(
             dims=("obs_u_id",),
         )
 
-        # Spoken likelihood (only where observed)
-        p_s_likelihood = pm.math.switch(
-            s_is_conditional,
-            q_obs[idx_s],
-            p_s_obs[idx_s],
+        # Spoken likelihood (only where observed). Through the shared builder
+        # since issue #266 finding 8, so this engine can run the marginal
+        # fallback sensitivity the bivariate engines have had since #240. Under
+        # the default `product_marginal` it emits the same ops it always did --
+        # `nested_outcome_alpha_beta`'s `else` branch is the two lines this
+        # replaced -- which `tests/test_graph_equivalence.py` checks.
+        alpha_s, beta_s = nested_outcome_alpha_beta(
+            treatment=spoken_fallback,
+            is_conditional=s_is_conditional,
+            conditional_p=q_obs[idx_s],
+            marginal_p=p_s_obs[idx_s],
+            parent_p=p_u_obs[idx_s],
+            parent_kappa=kappa_u_obs[idx_s],
+            kappa=kappa_s_obs[idx_s],
+            epsilon=EPSILON,
+            outcome="s",
+            fallback_kappa_sigma=definition.spoken_fallback_kappa_sigma,
         )
-        p_s_likelihood = pm.math.clip(p_s_likelihood, EPSILON, 1 - EPSILON)
-        alpha_s = p_s_likelihood * kappa_s_obs[idx_s]
-        beta_s = (1 - p_s_likelihood) * kappa_s_obs[idx_s]
 
         _ = pm.BetaBinomial(
             "y_s_obs",
@@ -941,15 +988,23 @@ def build_model(
             dims=("obs_s_id",),
         )
 
-        # Signed likelihood (only where observed)
-        p_sign_likelihood = pm.math.switch(
-            sign_is_conditional,
-            r_obs[idx_sign],
-            p_sign_obs[idx_sign],
+        # Signed likelihood (only where observed). The same treatment applies:
+        # signing is nested inside comprehension exactly as speech is, and a
+        # signed row with no usable understood count takes the same
+        # approximation, so exposing the choice for one outcome and not the
+        # other would leave half the exposure unmeasurable.
+        alpha_sign, beta_sign = nested_outcome_alpha_beta(
+            treatment=spoken_fallback,
+            is_conditional=sign_is_conditional,
+            conditional_p=r_obs[idx_sign],
+            marginal_p=p_sign_obs[idx_sign],
+            parent_p=p_u_obs[idx_sign],
+            parent_kappa=kappa_u_obs[idx_sign],
+            kappa=kappa_sign_obs[idx_sign],
+            epsilon=EPSILON,
+            outcome="sign",
+            fallback_kappa_sigma=definition.spoken_fallback_kappa_sigma,
         )
-        p_sign_likelihood = pm.math.clip(p_sign_likelihood, EPSILON, 1 - EPSILON)
-        alpha_sign = p_sign_likelihood * kappa_sign_obs[idx_sign]
-        beta_sign = (1 - p_sign_likelihood) * kappa_sign_obs[idx_sign]
 
         _ = pm.BetaBinomial(
             "y_sign_obs",
@@ -1262,6 +1317,15 @@ def diagnostics(context: TrivariateContext):
             ("y_u_obs", "words understood"),
             ("y_s_obs", "words spoken"),
             ("y_sign_obs", "words signed"),
+        ),
+        # All three factors of an administration, summed into one held-out case
+        # (issue #266 finding 4). The spoken and signed likelihoods take the
+        # same row's observed comprehension as their trial count, so the
+        # per-outcome scores above are conditional on it.
+        administration_factors=(
+            LikelihoodFactor("y_u_obs", "obs_u_mask"),
+            LikelihoodFactor("y_s_obs", "obs_s_mask"),
+            LikelihoodFactor("y_sign_obs", "obs_sign_mask"),
         ),
     )
 

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -1285,6 +1285,30 @@ class TrivariateModelDefinition:
     out of a flat intercept-only mean; that hack is no longer needed.)"""
     ell_months_range: tuple[int, int] = (6, 18)
     n_plot: int = 500
+    # -- Child-outcome rows with no usable understood count (issues #266, #240) --
+    spoken_fallback: str = SPOKEN_FALLBACK_PRODUCT
+    """How child-outcome rows that cannot condition on an observed understood
+    count are modelled. One of
+    :data:`~vocab_growth.models.likelihood_utils.SPOKEN_FALLBACK_TREATMENTS`,
+    documented individually there, and applied to the **signed** rows as well as
+    the spoken ones on this engine.
+
+    Exposed here by issue #266 finding 8, which is explicit that the
+    approximation is a methodological exposure rather than a detail: the default
+    gives such a row ``BB(810, p_U*q, kappa)``, which is mean-correct but is not
+    the marginal implied by the paired model, and the affected rows are older and
+    clustered by study. The bivariate engines have carried the choice since #240;
+    this engine hard-coded the default, so no sensitivity could be run at all.
+
+    Part of the model graph: changing it requires a refit. Adding the field does
+    **not** invalidate existing fits -- ``resolve_fallback_treatment`` returned
+    this same default for every fit made before it existed, and
+    :data:`~vocab_growth.models.fit_identity.BACKFILL_DEFAULTS` records that."""
+    spoken_fallback_kappa_sigma: float = 0.5
+    """Normal SD for the fallback branch's log concentration offset. Read only
+    under ``spoken_fallback="separate_dispersion"``; see the bivariate
+    definition's field of the same name for the calibration."""
+
     kappa_u: KappaPriorParams | KappaAnchorPriorParams = field(default_factory=KappaPriorParams)
     kappa_s: KappaPriorParams | KappaAnchorPriorParams = field(default_factory=KappaPriorParams)
     kappa_sign: KappaPriorParams | KappaAnchorPriorParams = field(default_factory=KappaPriorParams)
@@ -1478,6 +1502,30 @@ class JointModelDefinition:
     eta_sign_sigma: float = 0.4  # reverted to standard (matches VG14): the three-anchor mean now carries the hump, so the GP only models smooth departures
     ell_months_range: tuple[int, int] = (6, 18)
     n_plot: int = 500
+    # -- Child-outcome rows with no usable understood count (issues #266, #240) --
+    spoken_fallback: str = SPOKEN_FALLBACK_PRODUCT
+    """How child-outcome rows that cannot condition on an observed understood
+    count are modelled. One of
+    :data:`~vocab_growth.models.likelihood_utils.SPOKEN_FALLBACK_TREATMENTS`,
+    documented individually there, and applied to the **signed** rows as well as
+    the spoken ones on this engine.
+
+    Exposed here by issue #266 finding 8, which is explicit that the
+    approximation is a methodological exposure rather than a detail: the default
+    gives such a row ``BB(810, p_U*q, kappa)``, which is mean-correct but is not
+    the marginal implied by the paired model, and the affected rows are older and
+    clustered by study. The bivariate engines have carried the choice since #240;
+    this engine hard-coded the default, so no sensitivity could be run at all.
+
+    Part of the model graph: changing it requires a refit. Adding the field does
+    **not** invalidate existing fits -- ``resolve_fallback_treatment`` returned
+    this same default for every fit made before it existed, and
+    :data:`~vocab_growth.models.fit_identity.BACKFILL_DEFAULTS` records that."""
+    spoken_fallback_kappa_sigma: float = 0.5
+    """Normal SD for the fallback branch's log concentration offset. Read only
+    under ``spoken_fallback="separate_dispersion"``; see the bivariate
+    definition's field of the same name for the calibration."""
+
     kappa_u: KappaPriorParams | KappaAnchorPriorParams = field(default_factory=KappaPriorParams)
     kappa_s: KappaPriorParams | KappaAnchorPriorParams = field(default_factory=KappaPriorParams)
     # `kappa_sign` deliberately stays on the legacy dispersion form for VG15,

--- a/src/vocab_growth/models/fit_identity.py
+++ b/src/vocab_growth/models/fit_identity.py
@@ -47,6 +47,8 @@ from dataclasses import fields, is_dataclass
 from enum import Enum
 from typing import Any
 
+from vocab_growth.models.likelihood_utils import SPOKEN_FALLBACK_PRODUCT
+
 #: Version of the payload's own structure, recorded alongside it. Bumped when
 #: the *shape* changes, not when a model does: a reader must be able to tell a
 #: payload it can interpret from one it cannot.
@@ -155,12 +157,24 @@ FIELD_ROLES: dict[str, FieldRole] = {
 #: justified where it is added -- the value alone does not show that the
 #: pre-field behaviour matched it.
 #:
-#: Empty at introduction, deliberately. Every field currently on a registered
-#: definition class is present in every manifest that class ever wrote, so
-#: nothing needs backfilling yet; the mechanism exists so the *next* field can
-#: be added without a refit of everything, and the first entry will come with
-#: the change that adds that field.
-BACKFILL_DEFAULTS: dict[str, Any] = {}
+#: The two entries here are the mechanism's first use, and they are what it was
+#: built for. Issue #266 finding 8 needed ``spoken_fallback`` on the trivariate
+#: and joint definitions so VG14 and VG15 could run the sensitivity the
+#: bivariate models have had since #240 -- and under raw dictionary equality
+#: adding it would have invalidated every VG14 and VG15 fit ever made, for a
+#: field whose default is what those fits already did.
+#:
+#: The claim each entry makes is checkable, not asserted:
+#: ``likelihood_utils.resolve_fallback_treatment`` reads the field through
+#: ``getattr`` with exactly this default, so an engine and a definition that
+#: predate the field resolved to ``product_marginal``; and
+#: ``spoken_fallback_kappa_sigma`` is read **only** under
+#: ``separate_dispersion``, which no fit without the field could have selected,
+#: so its value could not have affected one.
+BACKFILL_DEFAULTS: dict[str, Any] = {
+    "spoken_fallback": SPOKEN_FALLBACK_PRODUCT,
+    "spoken_fallback_kappa_sigma": 0.5,
+}
 
 
 def role_of(field_name: str) -> FieldRole:

--- a/src/vocab_growth/report_cells.py
+++ b/src/vocab_growth/report_cells.py
@@ -32,6 +32,7 @@ from collections.abc import Mapping
 
 from scipy import stats
 
+from vocab_growth.administration_loo import ADMINISTRATION_LABEL
 from vocab_growth.glossary import render_glossary  # noqa: F401  (re-exported)
 from vocab_growth.models.diagnostics_utils import (  # noqa: F401  (re-exported)
     render_convergence_caveats,
@@ -204,12 +205,20 @@ _PRIOR_SPECS: list[tuple[str, str, str, str]] = [
         "log_conc",
         "log_concentration",
     ),
-    # Sampled only under `spoken_fallback="separate_dispersion"`, which is a
-    # registered VG10 sensitivity variant -- and a variant fit renders the model
-    # of record's template, so a prior with no row shows up on a real page.
+    # Sampled only under `spoken_fallback="separate_dispersion"`, a registered
+    # sensitivity variant -- and a variant fit renders the model of record's
+    # template, so a prior with no row shows up on a real page. One per nested
+    # outcome: the signing engines apply the treatment to their signed rows too,
+    # so VG14 and VG15 sample `log_kappa_sign_fallback` as well (#266 finding 8).
     (
         "log_kappa_s_fallback",
-        "Dispersion offset for spoken rows with no usable understood count",
+        "Dispersion offset, spoken rows with no usable understood count",
+        "spoken_fallback_kappa",
+        "log_multiplier",
+    ),
+    (
+        "log_kappa_sign_fallback",
+        "Dispersion offset, signed rows with no usable understood count",
         "spoken_fallback_kappa",
         "log_multiplier",
     ),
@@ -1425,11 +1434,16 @@ def render_loo_section(directory: str = ".") -> None:
             "study. " + scale_sentences
         )
     else:
+        # `emit_loo_summary` writes the label into an `outcome` column -- the
+        # name predates there being anything in the table that is not one.
+        has_administration_row = ADMINISTRATION_LABEL in set(
+            table.get("outcome", pd.Series(dtype=str)).astype(str)
+        )
         print(
             "Leave-one-out cross-validation estimates how well this model would "
             "predict an observation it had not seen. This model carries a separate "
             "likelihood term for each outcome, and the table below reports a "
-            "separate estimate for each of them, so **each row is "
+            "separate estimate for each of them, so **each per-outcome row is "
             "leave-one-likelihood-term-out for that outcome, not "
             "leave-one-administration-out**. The difference is not a technicality "
             "here, because the expressive outcomes are nested inside "
@@ -1443,28 +1457,62 @@ def render_loo_section(directory: str = ".") -> None:
             "same observed comprehension count in the spoken term's denominator, "
             "so the held-out value has not left the conditioning set and the two "
             "rows are not independent held-out units. Comparing models on these "
-            "numbers is still sound — every model is scored on the same "
-            "conditional units, computed the same way — but they must not be read "
-            "as whole-administration predictive accuracy. " + scale_sentences
+            "per-outcome numbers is still sound — every model is scored on the "
+            "same conditional units, computed the same way — but they must not be "
+            "read as whole-administration predictive accuracy. " + scale_sentences
         )
+        if has_administration_row:
+            print(
+                f"The **{ADMINISTRATION_LABEL}** row is the one that can be: it "
+                "sums every likelihood factor belonging to one administration "
+                "into a single held-out case, so a paired administration is one "
+                "observation with one importance weight rather than two, and "
+                "nothing of the held-out row remains in the conditioning set. "
+                "Repeated administrations of the same child are still separate "
+                "cases, so it scores prediction of another administration like "
+                "those in the frame — not generalisation to a new child, which "
+                "is what grouped leave-one-subject-out answers. It is the row to "
+                "read as this model's predictive accuracy, and the one to compare "
+                "against another model of the same administrations.\n"
+            )
+        else:
+            print(
+                "This fit carries **no administration-level row**: it was made "
+                "before that score was computed (issue #266, finding 4), so the "
+                "conditional rows above are all it has. A refit produces one.\n"
+            )
         if {"psi", "conc"} <= parameters:
             # The joint sign/speech engine is the only one that adds
             # Dirichlet-Multinomial composition terms, and `psi` (the Plackett
             # odds ratio) with `conc` (the composition concentration) is the
             # pair only it samples, so their presence identifies the model
             # without the report cell having to be told which model it is in.
-            print(
+            composition = (
                 "Two further likelihood terms — the within-understood four-cell "
                 "composition and the within-produced three-cell composition — are "
-                "excluded from every row above, because a Dirichlet-Multinomial "
-                "over cells is not the per-observation Beta-Binomial the other "
-                "terms are. Those are precisely the terms that identify the "
-                "sign–speech association $\\psi$, so **$\\psi$ is not scored by "
-                "leave-one-out at all**. A cross-tabulation row does still "
-                "contribute its words-understood term, so the words-understood "
-                "row holds out one of that row's two factors while leaving its "
-                "composition factor in the conditioning set.\n"
+                "excluded from every **per-outcome** row above, because a "
+                "Dirichlet-Multinomial over cells is not the per-observation "
+                "Beta-Binomial the other terms are. Those are precisely the terms "
+                "that identify the sign–speech association $\\psi$."
             )
+            if has_administration_row:
+                print(
+                    composition
+                    + " They **are** included in the administration row, which is "
+                    "why that row is the only one that scores $\\psi$ at all: a "
+                    "cross-tabulation row's composition factor is summed into the "
+                    "same held-out case as its words-understood factor, rather "
+                    "than left in the conditioning set.\n"
+                )
+            else:
+                print(
+                    composition
+                    + " so **$\\psi$ is not scored by leave-one-out at all** in "
+                    "this fit. A cross-tabulation row does still contribute its "
+                    "words-understood term, so the words-understood row holds out "
+                    "one of that row's two factors while leaving its composition "
+                    "factor in the conditioning set.\n"
+                )
 
     display = table.copy()
     for column in ("elpd_loo", "se", "p_loo", "good_k_threshold"):

--- a/src/vocab_growth/sensitivity/registry.py
+++ b/src/vocab_growth/sensitivity/registry.py
@@ -396,6 +396,27 @@ VARIANTS: dict[tuple[str, str], dict] = {
     ("vg10", "marginal-moments"): {"suffix": "marginal-moments", "scalar": {
         "spoken_fallback": SPOKEN_FALLBACK_MOMENT_MATCHED}},
 
+    # The same three arms for the two signing models, registered once their
+    # engines could run them (#266 finding 8). VG14 and VG15 hard-coded the
+    # default, so the exposure the finding names -- an approximation that
+    # preserves the mean but not the variance, on rows that are older and
+    # clustered by study -- could not be measured on either at all. On these
+    # engines the treatment applies to the SIGNED rows as well as the spoken
+    # ones: signing is nested inside comprehension exactly as speech is, so
+    # varying one and not the other would leave half the exposure in place.
+    ("vg14", "paired-only"): {"suffix": "paired-only", "scalar": {
+        "spoken_fallback": SPOKEN_FALLBACK_PAIRED_ONLY}},
+    ("vg14", "fallback-dispersion"): {"suffix": "fallback-dispersion", "scalar": {
+        "spoken_fallback": SPOKEN_FALLBACK_SEPARATE_DISPERSION}},
+    ("vg14", "marginal-moments"): {"suffix": "marginal-moments", "scalar": {
+        "spoken_fallback": SPOKEN_FALLBACK_MOMENT_MATCHED}},
+    ("vg15", "paired-only"): {"suffix": "paired-only", "scalar": {
+        "spoken_fallback": SPOKEN_FALLBACK_PAIRED_ONLY}},
+    ("vg15", "fallback-dispersion"): {"suffix": "fallback-dispersion", "scalar": {
+        "spoken_fallback": SPOKEN_FALLBACK_SEPARATE_DISPERSION}},
+    ("vg15", "marginal-moments"): {"suffix": "marginal-moments", "scalar": {
+        "spoken_fallback": SPOKEN_FALLBACK_MOMENT_MATCHED}},
+
     # -- VG13 observation window (#228) --
     #
     # These two are the widest-scoped variants registered on VG13, and the only

--- a/tests/test_administration_loo.py
+++ b/tests/test_administration_loo.py
@@ -1,0 +1,324 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Leave-one-administration-out, as the reports have always claimed.
+
+Issue #266 finding 4. The multi-outcome engines computed a PSIS-LOO per
+*outcome* while the reports described the predictive unit as a complete
+administration, and the two differ in a way that flatters the model: the spoken
+likelihood's trial count is the same row's observed comprehension, so holding
+out a spoken term scores prediction conditional on that comprehension, and
+holding out a comprehension term leaves its own value in the spoken term's
+denominator. A paired administration also became two held-out cases with two
+importance weights.
+
+The combined score sums every factor belonging to one row of the frame. The
+arithmetic is small; what it depends on is the ``obs_*_mask`` constant data
+mapping each factor's likelihood rows back to administration rows, which is why
+finding 3's mask defect had to be fixed first -- a mask marking recorded rows
+rather than likelihood rows would sum the wrong factors onto the wrong
+administrations, silently and plausibly.
+
+These tests are on synthetic traces, so the arithmetic is checked against values
+computed by hand rather than against a fit nobody can reproduce.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from vocab_growth.administration_loo import (
+    ADMINISTRATION_DIM,
+    ADMINISTRATION_VAR,
+    LikelihoodFactor,
+    administration_log_likelihood,
+    attach_administration_log_likelihood,
+)
+
+_BIVARIATE = (
+    LikelihoodFactor("y_u_obs", "obs_u_mask"),
+    LikelihoodFactor("y_s_obs", "obs_s_mask"),
+)
+
+
+class _Trace:
+    """The two groups the combination reads, and nothing else."""
+
+    def __init__(self, log_likelihood=None, constant_data=None):
+        self.log_likelihood = log_likelihood
+        self.constant_data = constant_data
+
+
+def _factor(values, dim):
+    """A pointwise log-likelihood shaped (chain, draw, row[, cell])."""
+    array = np.asarray(values, dtype=float)
+    dims = ("chain", "draw", dim) + tuple(
+        f"{dim}_cell{i}" for i in range(array.ndim - 3)
+    )
+    return xr.DataArray(
+        array,
+        dims=dims,
+        coords={"chain": np.arange(array.shape[0]), "draw": np.arange(array.shape[1])},
+    )
+
+
+def _trace(masks: dict[str, np.ndarray], factors: dict[str, xr.DataArray]) -> _Trace:
+    return _Trace(
+        log_likelihood=xr.Dataset(factors),
+        constant_data=xr.Dataset(
+            {name: ("obs_id", np.asarray(mask)) for name, mask in masks.items()}
+        ),
+    )
+
+
+# --- the arithmetic -------------------------------------------------------------
+
+
+def test_a_paired_administration_becomes_one_case_not_two():
+    """The defect, stated as the property that was violated."""
+    # Four administrations: rows 0 and 2 paired, row 1 understood-only, row 3
+    # spoken-only.
+    u_mask = np.array([True, True, True, False])
+    s_mask = np.array([True, False, True, True])
+    # One chain, one draw, values chosen so every sum is distinguishable.
+    u = _factor([[[-1.0, -2.0, -4.0]]], "obs_u_id")   # rows 0, 1, 2
+    s = _factor([[[-0.5, -8.0, -16.0]]], "obs_s_id")  # rows 0, 2, 3
+
+    combined = administration_log_likelihood(
+        _trace({"obs_u_mask": u_mask, "obs_s_mask": s_mask},
+               {"y_u_obs": u, "y_s_obs": s}),
+        _BIVARIATE,
+    )
+    assert combined.dims == ("chain", "draw", ADMINISTRATION_DIM)
+    # One entry per administration, not one per likelihood term.
+    assert combined.sizes[ADMINISTRATION_DIM] == 4
+    assert u.sizes["obs_u_id"] + s.sizes["obs_s_id"] == 6
+    np.testing.assert_allclose(
+        combined.values[0, 0],
+        [
+            -1.0 + -0.5,   # paired: both factors summed
+            -2.0,          # understood only
+            -4.0 + -8.0,   # paired
+            -16.0,         # spoken only
+        ],
+    )
+
+
+def test_the_kept_rows_are_labelled_by_their_frame_position():
+    """A reader must be able to map a held-out case back to its administration."""
+    u_mask = np.array([False, True, False, True, False])
+    s_mask = np.array([False, False, True, True, False])
+    combined = administration_log_likelihood(
+        _trace(
+            {"obs_u_mask": u_mask, "obs_s_mask": s_mask},
+            {
+                "y_u_obs": _factor([[[-1.0, -2.0]]], "obs_u_id"),
+                "y_s_obs": _factor([[[-3.0, -4.0]]], "obs_s_id"),
+            },
+        ),
+        _BIVARIATE,
+    )
+    # Row 0 and row 4 carry no factor at all and are absent, not zero.
+    np.testing.assert_array_equal(combined[ADMINISTRATION_DIM].values, [1, 2, 3])
+    np.testing.assert_allclose(combined.values[0, 0], [-1.0, -3.0, -2.0 + -4.0])
+
+
+def test_a_composition_factor_contributes_its_row_not_its_cells():
+    """VG15's cross-tabulation is stored per row AND per cell.
+
+    The held-out unit is the administration, so a row's cells sum into one
+    contribution. Treating each cell as a case would multiply that row's weight
+    by four.
+    """
+    u_mask = np.array([True, True])
+    cells_mask = np.array([True, False])
+    cells = _factor([[[[-1.0, -2.0, -3.0, -4.0]]]], "obs_cells_id")
+    combined = administration_log_likelihood(
+        _trace(
+            {"obs_u_mask": u_mask, "obs_cells_mask": cells_mask},
+            {"y_u_obs": _factor([[[-10.0, -20.0]]], "obs_u_id"), "cells_obs": cells},
+        ),
+        (
+            LikelihoodFactor("y_u_obs", "obs_u_mask"),
+            LikelihoodFactor("cells_obs", "obs_cells_mask"),
+        ),
+    )
+    np.testing.assert_allclose(
+        combined.values[0, 0], [-10.0 + (-1.0 - 2.0 - 3.0 - 4.0), -20.0]
+    )
+
+
+def test_every_chain_and_draw_is_combined_independently():
+    u_mask = np.array([True])
+    s_mask = np.array([True])
+    u = _factor([[[-1.0], [-2.0]], [[-3.0], [-4.0]]], "obs_u_id")
+    s = _factor([[[-0.1], [-0.2]], [[-0.3], [-0.4]]], "obs_s_id")
+    combined = administration_log_likelihood(
+        _trace({"obs_u_mask": u_mask, "obs_s_mask": s_mask},
+               {"y_u_obs": u, "y_s_obs": s}),
+        _BIVARIATE,
+    )
+    np.testing.assert_allclose(
+        combined.values[..., 0], [[-1.1, -2.2], [-3.3, -4.4]]
+    )
+
+
+# --- what it refuses ------------------------------------------------------------
+
+
+def test_a_mask_that_does_not_match_its_factor_raises():
+    """Finding 3's defect, in the place it would do the most damage.
+
+    A mask marking recorded rows rather than likelihood rows would map factors
+    onto the wrong administrations. That must fail loudly, not produce a
+    plausible number.
+    """
+    u_mask = np.array([True, True, True])
+    s_mask = np.array([True, True, True])  # claims 3 rows
+    with pytest.raises(ValueError, match="finding 3"):
+        administration_log_likelihood(
+            _trace(
+                {"obs_u_mask": u_mask, "obs_s_mask": s_mask},
+                {
+                    "y_u_obs": _factor([[[-1.0, -2.0, -3.0]]], "obs_u_id"),
+                    "y_s_obs": _factor([[[-1.0, -2.0]]], "obs_s_id"),  # stores 2
+                },
+            ),
+            _BIVARIATE,
+        )
+
+
+@pytest.mark.parametrize("missing", ["y_s_obs", "obs_s_mask"])
+def test_a_missing_factor_or_mask_yields_nothing_rather_than_a_partial_score(missing):
+    """A partial sum would be a different estimand wearing the same label."""
+    masks = {"obs_u_mask": np.array([True]), "obs_s_mask": np.array([True])}
+    factors = {
+        "y_u_obs": _factor([[[-1.0]]], "obs_u_id"),
+        "y_s_obs": _factor([[[-2.0]]], "obs_s_id"),
+    }
+    masks.pop(missing, None)
+    factors.pop(missing, None)
+    assert administration_log_likelihood(_trace(masks, factors), _BIVARIATE) is None
+
+
+def test_a_trace_without_the_groups_yields_nothing():
+    assert administration_log_likelihood(_Trace(), _BIVARIATE) is None
+
+
+def test_no_observed_rows_yields_nothing():
+    combined = administration_log_likelihood(
+        _trace(
+            {"obs_u_mask": np.array([False, False]), "obs_s_mask": np.array([False, False])},
+            {
+                "y_u_obs": _factor(np.zeros((1, 1, 0)), "obs_u_id"),
+                "y_s_obs": _factor(np.zeros((1, 1, 0)), "obs_s_id"),
+            },
+        ),
+        _BIVARIATE,
+    )
+    assert combined is None
+
+
+# --- attaching it ---------------------------------------------------------------
+
+
+def test_attaching_adds_the_variable_and_is_idempotent():
+    trace = _trace(
+        {"obs_u_mask": np.array([True, True]), "obs_s_mask": np.array([True, False])},
+        {
+            "y_u_obs": _factor([[[-1.0, -2.0]]], "obs_u_id"),
+            "y_s_obs": _factor([[[-3.0]]], "obs_s_id"),
+        },
+    )
+    assert attach_administration_log_likelihood(trace, _BIVARIATE)
+    assert ADMINISTRATION_VAR in trace.log_likelihood.data_vars
+    stored = trace.log_likelihood[ADMINISTRATION_VAR].values.copy()
+
+    # Re-running diagnostics must not recompute or double it.
+    assert attach_administration_log_likelihood(trace, _BIVARIATE)
+    np.testing.assert_array_equal(
+        trace.log_likelihood[ADMINISTRATION_VAR].values, stored
+    )
+    np.testing.assert_allclose(stored[0, 0], [-1.0 + -3.0, -2.0])
+
+
+def test_attaching_reports_failure_rather_than_raising():
+    """A trace written before this existed must not break a re-run."""
+    assert not attach_administration_log_likelihood(_Trace(), _BIVARIATE)
+
+
+# --- what the engines declare ---------------------------------------------------
+
+
+def test_every_multi_outcome_engine_declares_its_factors():
+    """A factor left out is a term silently excluded from the score.
+
+    VG15's two composition terms are the case that matters: they identify
+    `psi`, and the per-outcome scores omit them entirely.
+    """
+    import inspect
+
+    from vocab_growth.models import (
+        common_bivariate,
+        common_joint_modality,
+        common_trivariate,
+    )
+
+    expected = {
+        common_bivariate: {"y_u_obs", "y_s_obs"},
+        common_trivariate: {"y_u_obs", "y_s_obs", "y_sign_obs"},
+        common_joint_modality: {
+            "y_u_obs",
+            "y_s_obs",
+            "y_sign_obs",
+            "cells_obs",
+            "nz_prod_cells_obs",
+        },
+    }
+    for module, names in expected.items():
+        source = inspect.getsource(module)
+        assert "administration_factors=" in source, module.__name__
+        for name in names:
+            assert f'LikelihoodFactor("{name}"' in source, (
+                f"{module.__name__} does not declare {name} as an "
+                "administration likelihood factor"
+            )
+
+
+def test_the_single_outcome_engine_needs_no_combination():
+    """One likelihood term over administration rows already IS the unit."""
+    import inspect
+
+    from vocab_growth.models import common
+
+    source = inspect.getsource(common.fit_single_outcome_model)
+    assert "administration_factors" not in source
+
+
+def test_the_total_log_likelihood_is_conserved():
+    """The sharpest invariant: regrouping terms must not change their sum.
+
+    Verified on a real 2-chain VG10 fit while this was written -- 96 per-outcome
+    terms collapsing to 48 administration cases with a maximum absolute
+    difference of 0.0 -- and pinned here on synthetic values so it runs
+    everywhere. A combination that dropped, duplicated or misplaced a factor
+    would break it.
+    """
+    rng = np.random.default_rng(3)
+    n = 12
+    u_mask = rng.random(n) < 0.8
+    s_mask = rng.random(n) < 0.6
+    u_mask[0] = s_mask[0] = True  # at least one paired row
+    u = _factor(rng.normal(size=(2, 5, int(u_mask.sum()))), "obs_u_id")
+    s = _factor(rng.normal(size=(2, 5, int(s_mask.sum()))), "obs_s_id")
+
+    combined = administration_log_likelihood(
+        _trace({"obs_u_mask": u_mask, "obs_s_mask": s_mask},
+               {"y_u_obs": u, "y_s_obs": s}),
+        _BIVARIATE,
+    )
+    per_term = u.sum(dim="obs_u_id") + s.sum(dim="obs_s_id")
+    per_case = combined.sum(dim=ADMINISTRATION_DIM)
+    np.testing.assert_allclose(per_case.values, per_term.values, rtol=0, atol=1e-12)

--- a/tests/test_report_cells.py
+++ b/tests/test_report_cells.py
@@ -656,15 +656,54 @@ def test_multi_outcome_loo_is_not_labelled_leave_one_administration_out(
     report_cells.render_loo_section(str(fit))
     out = capsys.readouterr().out
     assert (
-        "each row is leave-one-likelihood-term-out for that outcome, not "
-        "leave-one-administration-out" in out
+        "each per-outcome row is leave-one-likelihood-term-out for that "
+        "outcome, not leave-one-administration-out" in out
     )
     assert "conditional on the same administration's observed comprehension" in out
     assert "not independent held-out units" in out
     # Still usable for model comparison -- the finding is about the label, not
     # about the number, and a reader must not be sent away from a valid check.
-    assert "Comparing models on these numbers is still sound" in out
+    assert "Comparing models on these per-outcome numbers is still sound" in out
     assert "must not be read as whole-administration predictive accuracy" in out
+    # This fixture carries no administration row, so the section must say so
+    # rather than leave the conditional rows reading as the whole story.
+    assert "no administration-level row" in out
+
+
+def test_an_administration_row_is_named_as_the_one_to_read(tmp_path, capsys):
+    """The score the reports always described, once a fit actually carries it.
+
+    The per-outcome caveats stay -- they are still true of those rows -- but the
+    reader is told which row is whole-administration predictive accuracy rather
+    than left with three conditional ones and a warning.
+    """
+    from vocab_growth.administration_loo import ADMINISTRATION_LABEL
+
+    rows = _MULTI_OUTCOME_ROWS + [{**_CLEAN_ROW, "outcome": ADMINISTRATION_LABEL}]
+    fit = _loo_fit(tmp_path, rows, parameters=("eta_u", "eta_s"))
+    report_cells.render_loo_section(str(fit))
+    out = capsys.readouterr().out
+    assert f"The **{ADMINISTRATION_LABEL}** row is the one that can be" in out
+    assert "one importance weight rather than two" in out
+    # And it must not claim generalisation it does not have.
+    assert "not generalisation to a new child" in out
+    assert "no administration-level row" not in out
+
+
+def test_a_joint_fit_with_an_administration_row_scores_psi(tmp_path, capsys):
+    """The composition terms identify psi and the per-outcome rows omit them.
+
+    Summed into the administration case, they are scored -- which makes that row
+    the only one that touches this model's headline association at all.
+    """
+    from vocab_growth.administration_loo import ADMINISTRATION_LABEL
+
+    rows = _MULTI_OUTCOME_ROWS + [{**_CLEAN_ROW, "outcome": ADMINISTRATION_LABEL}]
+    fit = _loo_fit(tmp_path, rows, parameters=("psi", "conc", "eta_u"))
+    report_cells.render_loo_section(str(fit))
+    out = capsys.readouterr().out
+    assert "They **are** included in the administration row" in out
+    assert "not scored by leave-one-out at all" not in out
 
 
 def test_joint_composition_fits_say_psi_is_unscored(tmp_path, capsys):

--- a/tests/test_sensitivity_overrides.py
+++ b/tests/test_sensitivity_overrides.py
@@ -220,7 +220,15 @@ def test_registry_counts_and_models():
     # `lag-gap-12`, `no-us01` and `lag-continuity`. A field with no variant
     # using it is dead weight in the fingerprint of all twelve bivariate models,
     # so the fields and their variants land together or not at all.
-    assert len(VARIANTS) == 74
+    #
+    # +6 on 2026-08-31 (#266 finding 8): the three marginal-fallback arms for
+    # VG14 and VG15. Their engines hard-coded the default until then, so the
+    # exposure the finding names -- an approximation preserving the mean but not
+    # the variance, on rows that are older and clustered by study -- could not
+    # be measured on either signing model at all. VG14 had no variants before
+    # this and so no entry below.
+    assert len(VARIANTS) == 80
+    assert len(variants_for("vg14")) == 3
     assert len(variants_for("vg16")) == 5
     assert len(variants_for("vg21")) == 1
     assert len(variants_for("vg23")) == 1
@@ -230,7 +238,7 @@ def test_registry_counts_and_models():
     assert len(variants_for("vg11")) == 5
     assert len(variants_for("vg12")) == 5
     assert len(variants_for("vg13")) == 4
-    assert len(variants_for("vg15")) == 27
+    assert len(variants_for("vg15")) == 30
     assert len(variants_for("vg20")) == 6
 
 
@@ -248,9 +256,9 @@ def test_td_models_account_for_repeated_children_by_default():
 
 def test_build_variant_all_and_named():
     all_vg15 = build_variant("vg15", "all")
-    assert len(all_vg15) == 27
+    assert len(all_vg15) == 30
     # All distinct config_names, all still VG15.
-    assert len({d.config_name for d in all_vg15}) == 27
+    assert len({d.config_name for d in all_vg15}) == 30
     assert all(d.model_id == "VG15" for d in all_vg15)
     # psi-neutral applies both hyperparameters.
     (psi,) = build_variant("vg15", "psi-neutral")

--- a/tests/test_trivariate_joint_fallback.py
+++ b/tests/test_trivariate_joint_fallback.py
@@ -1,0 +1,227 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""VG14 and VG15 can now run the marginal-fallback sensitivity (issue #266 finding 8).
+
+Roughly 455 of 1,428 Down syndrome spoken rows cannot condition on an observed
+comprehension count, and take ``BB(810, p_U*q, kappa)`` instead. That is
+mean-correct but is **not** the marginal implied by the paired model — it misses
+the variance — and the affected rows are older and clustered by study, so the
+approximation is not ignorable. The bivariate engines have carried a choice of
+treatment since #240; the trivariate and joint engines hard-coded the default, so
+no sensitivity could be run at all on the two signing models.
+
+Both now route their child-outcome likelihoods through the same shared builder,
+for the **signed** rows as well as the spoken ones: signing is nested inside
+comprehension exactly as speech is, so exposing the choice for one outcome and
+not the other would leave half the exposure unmeasurable.
+
+Two properties matter and are checked separately, because a routing change that
+satisfied only the first would be decorative:
+
+* under the default, the graph is **unchanged** —
+  ``tests/test_graph_equivalence.py`` pins that for all twenty models;
+* under each alternative, the graph **actually differs**, on a frame that has
+  marginal rows to differ on. The synthetic frame the equivalence harness uses
+  is fully paired, so ``paired_only`` and ``moment_matched`` are no-ops there;
+  a test that used it would pass while proving nothing.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+from support.synthetic_graphs import (
+    build_synthetic_model,
+    fixed_point_logp,
+    synthetic_frame,
+)
+
+from vocab_growth.models.catalogue import get
+from vocab_growth.models.definitions import VG14, VG15
+from vocab_growth.models.fit_identity import BACKFILL_DEFAULTS, definition_differences
+from vocab_growth.models.likelihood_utils import (
+    SPOKEN_FALLBACK_MOMENT_MATCHED,
+    SPOKEN_FALLBACK_PAIRED_ONLY,
+    SPOKEN_FALLBACK_PRODUCT,
+    SPOKEN_FALLBACK_SEPARATE_DISPERSION,
+    SPOKEN_FALLBACK_TREATMENTS,
+)
+
+pytestmark = pytest.mark.slow
+
+_MODELS = (VG14, VG15)
+
+
+def _frame_with_marginal_rows(definition, *, n_marginal=8):
+    """A frame where some rows record speech and signing but no comprehension.
+
+    Those are the rows every treatment differs on. The harness's own frame is
+    fully paired, so it cannot distinguish them.
+    """
+    frame = synthetic_frame(definition).copy()
+    rows = frame.index[:n_marginal]
+    frame.loc[rows, "understood"] = np.nan
+    # A row with no comprehension count cannot carry a within-understood
+    # composition either, so it leaves the cross-tabulation entirely. Clearing
+    # only some cells would leave the joint engine reading NaN counts.
+    for column in (
+        "understood_only",
+        "signed_only",
+        "spoken_only",
+        "signed_spoken",
+        "cell_total",
+        "prod_signed_only",
+        "prod_spoken_only",
+        "prod_signed_spoken",
+        "prod_total",
+    ):
+        if column in frame:
+            frame.loc[rows, column] = np.nan
+    return frame
+
+
+def _logp(definition, frame, tmp_path, monkeypatch):
+    engine = get(definition.model_id.lower()).engine
+    context = build_synthetic_model(
+        definition, engine, output_dir=str(tmp_path), monkeypatch=monkeypatch
+    )
+    # The frame is injected by rebuilding with it in place of the default.
+    return context, fixed_point_logp(context.model)
+
+
+@pytest.mark.parametrize("base", _MODELS, ids=lambda d: d.model_id)
+def test_the_definition_carries_the_choice(base):
+    assert base.spoken_fallback == SPOKEN_FALLBACK_PRODUCT
+    assert base.spoken_fallback_kappa_sigma == 0.5
+    for treatment in SPOKEN_FALLBACK_TREATMENTS:
+        variant = dataclasses.replace(base, spoken_fallback=treatment)
+        assert variant.spoken_fallback == treatment
+
+
+@pytest.mark.parametrize("base", _MODELS, ids=lambda d: d.model_id)
+def test_an_unknown_treatment_is_refused(base, tmp_path, monkeypatch):
+    engine = get(base.model_id.lower()).engine
+    variant = dataclasses.replace(base, spoken_fallback="not_a_treatment")
+    with pytest.raises(ValueError, match="Unknown spoken_fallback"):
+        build_synthetic_model(
+            variant, engine, output_dir=str(tmp_path), monkeypatch=monkeypatch
+        )
+
+
+@pytest.mark.parametrize("base", _MODELS, ids=lambda d: d.model_id)
+def test_separate_dispersion_adds_one_offset_per_nested_outcome(
+    base, tmp_path, monkeypatch
+):
+    """Spoken and signed each get their own, because each has its own rows."""
+    engine = get(base.model_id.lower()).engine
+    variant = dataclasses.replace(
+        base, spoken_fallback=SPOKEN_FALLBACK_SEPARATE_DISPERSION
+    )
+    context = build_synthetic_model(
+        variant, engine, output_dir=str(tmp_path), monkeypatch=monkeypatch
+    )
+    names = {rv.name for rv in context.model.free_RVs}
+    assert "log_kappa_s_fallback" in names
+    assert "log_kappa_sign_fallback" in names
+
+    default = build_synthetic_model(
+        base, engine, output_dir=str(tmp_path / "default"), monkeypatch=monkeypatch
+    )
+    baseline = {rv.name for rv in default.model.free_RVs}
+    assert names - baseline == {"log_kappa_s_fallback", "log_kappa_sign_fallback"}
+
+
+@pytest.mark.parametrize("base", _MODELS, ids=lambda d: d.model_id)
+def test_every_treatment_changes_the_likelihood_on_rows_that_have_one(
+    base, tmp_path, monkeypatch
+):
+    """The routing must be substantive, not decorative.
+
+    Checked on a frame that HAS marginal rows. On the fully paired frame the
+    equivalence harness uses, `paired_only` drops nothing and `moment_matched`
+    never selects its branch, so all four treatments agree there — a test that
+    used it would pass while proving nothing.
+    """
+    import dse_research_utils.statistics.models.data as model_data
+
+    engine = get(base.model_id.lower()).engine
+    frame = _frame_with_marginal_rows(base)
+
+    scores = {}
+    for treatment in SPOKEN_FALLBACK_TREATMENTS:
+        variant = dataclasses.replace(base, spoken_fallback=treatment)
+        context = build_synthetic_model(
+            variant,
+            engine,
+            output_dir=str(tmp_path / treatment),
+            monkeypatch=monkeypatch,
+        )
+        # Rebuild against the marginal-row frame rather than the default one.
+        context.set_model_data(
+            model_data.BinomialModelData(
+                X_obs=frame["age"].to_numpy().reshape(-1, 1),
+                y_obs=frame["understood"].fillna(0).to_numpy().astype(int),
+                n_trials=variant.n_trials,
+            ),
+            frame,
+        )
+        engine.resolve("priors")(context, variant)
+        engine.resolve("build")(context, variant)
+        scores[treatment] = fixed_point_logp(context.model)
+
+    # Every treatment is a distinct likelihood on these rows.
+    assert len(set(scores.values())) == len(SPOKEN_FALLBACK_TREATMENTS), (
+        f"{base.model_id}: treatments do not all differ — {scores}"
+    )
+    # And paired-only drops the marginal rows, so it scores strictly fewer of them.
+    assert scores[SPOKEN_FALLBACK_PAIRED_ONLY] != scores[SPOKEN_FALLBACK_PRODUCT]
+    assert scores[SPOKEN_FALLBACK_MOMENT_MATCHED] != scores[SPOKEN_FALLBACK_PRODUCT]
+
+
+# --- and adding the field invalidated nothing -----------------------------------
+
+
+@pytest.mark.parametrize("base", _MODELS, ids=lambda d: d.model_id)
+def test_a_fit_made_before_the_field_existed_still_validates(base):
+    """The first real use of the backfill mechanism (#273 step 5).
+
+    Under raw dictionary equality, adding this field would have invalidated
+    every VG14 and VG15 fit ever made, for a field whose default is what those
+    fits already did.
+    """
+    from vocab_growth.fit_artifacts import normalise_for_json
+
+    recorded = normalise_for_json(base)
+    for field in ("spoken_fallback", "spoken_fallback_kappa_sigma"):
+        assert field in BACKFILL_DEFAULTS
+        recorded.pop(field)
+    assert definition_differences(recorded, base) == []
+
+
+@pytest.mark.parametrize("base", _MODELS, ids=lambda d: d.model_id)
+def test_the_backfill_does_not_excuse_a_real_change(base):
+    """It says what the absence meant, not that the field may be anything."""
+    from vocab_growth.fit_artifacts import normalise_for_json
+
+    recorded = normalise_for_json(base)
+    recorded.pop("spoken_fallback")
+    altered = dataclasses.replace(base, spoken_fallback=SPOKEN_FALLBACK_PAIRED_ONLY)
+    differences = definition_differences(recorded, altered)
+    assert any(d.field == "spoken_fallback" for d in differences)
+
+
+def test_the_backfill_claim_matches_what_the_resolver_actually_did():
+    """The entry is a claim about history; this is the code that made it true."""
+    from vocab_growth.models.likelihood_utils import resolve_fallback_treatment
+
+    class _WithoutTheField:
+        pass
+
+    assert (
+        resolve_fallback_treatment(_WithoutTheField())
+        == BACKFILL_DEFAULTS["spoken_fallback"]
+        == SPOKEN_FALLBACK_PRODUCT
+    )


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

A second remediation pass on [#266](https://github.com/dseinternational/vocabulary-growth/issues/266). The first pass is recorded in [`notes/202608261700-issue-266-remediation.md`](notes/202608261700-issue-266-remediation.md); its §5 listed five things a code change could not fix at the time. Three of them can now, and this takes them. **The issue is not closed** — what remains is refits and a statistical design, named at the end.

Verified against `tests/test_graph_equivalence.py`: no registered model's graph moves under any default.

## Finding 4 — administration-level LOO is computed, not only relabelled

The first pass relabelled the per-outcome scores accurately and deferred computing the real one as "a separate change that regenerates every model page". That framing is exactly why it is taken now rather than later: **every registered fit already needs re-running**, so the cost of this change is currently zero and rises the moment the refit run starts. Landing it afterwards would waste that run.

`vocab_growth.administration_loo` sums every likelihood factor belonging to one row of the analysis frame into a single pointwise entry, and the diagnostics stage scores it **alongside** the per-outcome ones rather than instead of them — those stay comparable across models on the same conditional units. What they never were is whole-administration predictive accuracy, and that is what the reports described.

Three consequences:

- a paired administration is one held-out case with one importance weight, not two;
- nothing of a held-out row remains in the conditioning set — previously, holding out the comprehension factor left its own observed value in the spoken factor's denominator;
- **VG15's two composition terms are included**, so `psi` — the association that model exists to estimate — is scored by leave-one-out at all for the first time. The per-outcome scores omit those terms entirely.

The mechanics are `scripts/loo_compare.py`'s `_attach_joint_log_likelihood`, which has computed this correctly for the bivariate case since #236, generalised to any number of factors including the matrix-valued composition ones. Verified on a real two-chain VG10 fit while it was written: **96 per-outcome terms collapse to 48 administration cases with the total log-likelihood conserved to 0.0 exactly.**

This depended on finding 3 having been fixed first. The mapping from a factor's likelihood rows back to administration rows is the `obs_*_mask` constant data; a mask marking recorded rows rather than likelihood rows would sum the wrong factors onto the wrong administrations — silently, and plausibly. The combiner refuses such a mask rather than proceeding.

## Finding 8 — VG14 and VG15 can run the marginal fallback sensitivity

Roughly 455 of 1,428 Down syndrome spoken rows take an approximation that preserves the mean but not the variance, on rows that are older and clustered by study. The bivariate engines have carried a choice of treatment since #240; the trivariate and joint engines hard-coded the default, so the exposure could not be measured on either signing model **at all**.

Both now carry `spoken_fallback`, route their child-outcome likelihoods through the shared `nested_outcome_alpha_beta`, and have the three arms registered. The treatment applies to the **signed** rows as well as the spoken ones: signing is nested inside comprehension exactly as speech is, so varying one and not the other would leave half the exposure in place.

### Two defects surfaced in doing it

**The trivariate engine carried finding 3's mask defect, unreachably.** It stored `has_s` and `has_sign` — the *recorded* masks — where the bivariate engines store the likelihood ones. With no fallback choice to select, no row was ever dropped and the two coincided. Exposing the choice would have made it reachable, and the first `paired_only` run would have died at calibration *after sampling*, exactly as the bivariate fits did before #266. Fixed before it could be discovered that way.

**The joint engine read its indices before applying the drop**, leaving the `obs_s_id` coordinate sized by the unfiltered rows and the trial counts by the filtered ones. That fails at logp evaluation with a bare `Vectorized input 1 has an incompatible shape in axis 0` and no indication of the cause.

Both were caught only because the test builds each treatment on a frame that **has** marginal rows. The graph-equivalence harness's own frame is fully paired, so `paired_only` and `moment_matched` are no-ops on it — a test using it would have passed while proving nothing. That is stated in the test, because the next person to extend it will reach for the harness's frame first.

## For the reviewer

**Adding `spoken_fallback` invalidated no existing fit.** This is the first real use of the versioned manifest payload from [#277](https://github.com/dseinternational/vocabulary-growth/pull/277). Under the raw dictionary equality it replaced, adding the field would have invalidated every VG14 and VG15 fit ever made — for a field whose default is what those fits already did. The `BACKFILL_DEFAULTS` entry is a checkable claim, not an assertion: `resolve_fallback_treatment` reads the field through `getattr` with exactly this default, so a definition predating it resolved to `product_marginal`, and a test pins that against the resolver itself.

**Both models became reachable from the sensitivity scripts with no further change**, because [#276](https://github.com/dseinternational/vocabulary-growth/pull/276) made `fit_sensitivity.py` and `refit_hightune.py` derive their runner map from the catalogue and the variant registry. VG14 had no registered variants at all before this.

**The per-outcome LOO scores are kept, not replaced.** They are still the right thing for comparing models on the same conditional units, and the report now names which row is which rather than warning the reader off the only numbers it has. A fit predating the administration score says so explicitly instead of leaving the conditional rows reading as the whole story.

**No registered model's default graph moves.** Every alternative treatment is verified to *actually* change the likelihood on rows that have one — a routing change that only satisfied the first property would be decorative.

## Verification

Ruff, mypy, Prettier and CSpell clean. `uv run pytest -m "slow or not slow"` — the whole suite, fast and slow — passes with zero failures against a branch freshly merged with `main` (which has since taken #279).

## Still outstanding, and still not a code change

- **Every registered model needs a reporting-quality refit.** All 19 existing fits fail publication validation, which is the correct state. It is now also the only way to get an administration-level LOO row onto any model page, since the score is computed during the fit.
- **VG22's induced prior needs designing**, not documenting: an explicit prior over the implied correlations, a refit of the rank family, parameter recovery and a whole-child predictive comparison before the default rank is re-selected.
- **The fallback sensitivity arms need running.** They can now be run on all four affected engines rather than two, which is what this pass changed; running them is a fitting task.

Refs [#266](https://github.com/dseinternational/vocabulary-growth/issues/266)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
