### PR TITLE
build(deps): bump dse-research-utils to v0.12.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ environments = [
 # dse-research-utils isn't published to PyPI — resolve it from the public git
 # tag. To develop against a sibling checkout instead, comment this out and use:
 #   dse-research-utils = { path = "../research/src/python", editable = true }
-dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.12.2" }
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.12.3" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,12 @@ revision = 3
 requires-python = ">=3.14"
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
-    "python_full_version < '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "python_full_version < '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
-    "python_full_version < '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32'",
+    "python_full_version < '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux'",
+    "python_full_version < '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
     "python_full_version < '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32'",
 ]
 supported-markers = [
@@ -550,7 +550,7 @@ wheels = [
 [[package]]
 name = "dse-research-utils"
 version = "0.12.0"
-source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.2#50c6f5f3a9dd0d887c0e74772ef8a1b9928fff39" }
+source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.3#1d6d9c3c4789197eb7a463b70dd5551f95210fc0" }
 dependencies = [
     { name = "arviz" },
     { name = "arviz-base" },
@@ -628,7 +628,7 @@ typecheck = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.2" }]
+requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.3" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

## What

Moves the `dse-research-utils` pin from `v0.12.2` to `v0.12.3`.

## Why

[dsegroup/research-data-analysis](https://github.com/dsegroup/research-data-analysis) has migrated off conda and needed the new `boosting-cpu` extra ([dseinternational/research#98](https://github.com/dseinternational/research/pull/98)), so it is now pinned to `v0.12.3`. Leaving this repo and `language-reading-predictors` on `v0.12.2` would reintroduce exactly the version drift the shared pin exists to prevent — the floors are declared once upstream precisely so every consumer sees the same ones.

This is alignment, not a fix: nothing here needs anything in `v0.12.3`.

## What is actually in v0.12.2..v0.12.3

Three commits, none of which changes behaviour for this repository:

| Commit | Effect here |
| --- | --- |
| `feat(deps): add a boosting-cpu extra` | None — purely additive, and this repo takes `columnar,graphs,io,jax,notebook,viz`, not `boosting` |
| `style: apply ruff format to src/python` | None — reformatting only. `git diff -w` still reports changes, but reading the hunks they are all wrapped expressions collapsed onto single lines; no semantic change |
| `build(deps-dev): bump cspell` | None — npm dev tooling in the library repo |

## Verification

- `uv lock` resolves to the same **187 packages**; the only change is the `dse-research-utils` git revision
- `uv run pytest` → **1759 passed, 46 skipped, 291 deselected** (the default `-m 'not slow'` selection)
- `uv run --group lint ruff check .` → clean

The slow-marked tests were not run; if you would like the full `-m ""` sweep before merging, say so and I will run it.
