### PR TITLE
docs(priors): correct the independence table for the Norwegian, Dutch and Galeote cohorts

### DIFF
--- a/config/spellcheck/allow-en.txt
+++ b/config/spellcheck/allow-en.txt
@@ -1,6 +1,7 @@
 ArviZ
 BFGS
 BFMI
+BPVS
 Babylab
 Bello
 Berglund
@@ -52,6 +53,7 @@ LOSO
 Laudanska
 Laudańska
 Lewandowsky
+Lexi
 Lézine
 MCMC
 MCSE
@@ -75,8 +77,10 @@ Poustka
 Preis
 Psychometrika
 PyMC
+ROWPVT
 Rasch
 Reparameterise
+SECDI
 Savitzky
 Schaaf
 Soto
@@ -93,6 +97,7 @@ UKRI
 Uhlenbeck
 Vehtari
 Venne
+WPPSI
 Wainer
 Walle
 Wilcoxon

--- a/docs/models/PRIORS.md
+++ b/docs/models/PRIORS.md
@@ -598,14 +598,19 @@ Not every published cohort is independent of the fitted data. Where a prior is
 anchored on a study whose participants are already in `vocab_data_merged.csv`,
 it is regularisation, not independent prior evidence.
 
-| Source                                                                                                                      | Role for priors                                 | Independent of training data?                                                                                           |
-| --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Wordbank by-child data (`wordbank_administration_data.csv`)                                                                 | TD anchors, `q`, dispersion                     | **No** — it _is_ the TD training data. Use the published normative percentiles as the non-circular check, not the rows. |
-| Berglund et al. (2001), n=330, Sweden                                                                                       | DS anchors, growth shape, heterogeneity         | Yes                                                                                                                     |
-| Næss et al. (2021), Norway; Galeote et al. (2008), Spain; Deckers et al. (2016), Kaat-van den Os et al. (2017), Netherlands | DS anchors, `q`, signed `r`                     | Yes                                                                                                                     |
-| Miller et al. (1995); Mervis & Robinson (2000), US                                                                          | DS anchors, parent-report validity              | Yes                                                                                                                     |
-| Oliver & Buckley (1994), UK                                                                                                 | DS low-age spoken anchor (10-word stage ~27 mo) | Yes — confirmed **not** to overlap `uk_01`                                                                              |
-| Caselli et al. (1998); Zampini & D'Odorico (2013); Bello & Caselli (2014), Italy                                            | DS trajectory, gesture, dispersion              | **No** — overlap the `it_01` Italian-CDI-DS cohort; treat as regularisation                                             |
+| Source                                                                           | Role for priors                                                                                                                    | Independent of training data?                                                                                                                                                                                                                                               |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Wordbank by-child data (`wordbank_administration_data.csv`)                      | TD anchors, `q`, dispersion                                                                                                        | **No** — it _is_ the TD training data. Use the published normative percentiles as the non-circular check, not the rows.                                                                                                                                                     |
+| Berglund et al. (2001), n=330, Sweden                                            | DS _spoken_ anchors, growth shape, heterogeneity — the SECDI Words & Sentences form is production-only, so no comprehension anchor | Yes                                                                                                                                                                                                                                                                         |
+| Galeote et al. (2008, 2011), Spain                                               | DS spoken-versus-TD comparison by mental age; symbolic-gesture `r`                                                                 | **No** — the 186-child cohort _is_ `es_01`, supplied by the author (see `data/vocab_data_es_01.md`); treat as regularisation                                                                                                                                                |
+| Næss et al. (2021), Norway                                                       | Qualitative corroboration only (receptive ahead of expressive; slower expressive growth than TD)                                   | Yes — but not on the CDI scale: 43 children tested at 6, 7 and 8 years with the BPVS-II and WPPSI-III Picture Naming, no parent report. Supplies no CDI anchor and no `q`                                                                                                   |
+| Deckers et al. (2016, 2019), Netherlands                                         | Signed `r` corroboration; N-CDI validity in DS                                                                                     | Yes — 25–36 children aged 2;0–7;6, two waves 1.5 years apart, N-CDI Words & Sentences (702 words) with an added sign column. A production-only form; the 2019 receptive measure is a composite with the ROWPVT test, and no parent-report comprehension column is described |
+| Kaat-van den Os et al. (2017), Netherlands                                       | Signed `r` corroboration; spurt heterogeneity; sign-to-speech modality shift                                                       | Yes — 26 children followed monthly from 18–24 months for 18 months on the Lexi questionnaire (263 words, a Language Development Survey adaptation, not a CDI); production only, no comprehension                                                                            |
+| Miller et al. (1995); Mervis & Robinson (2000), US                               | DS anchors, parent-report validity                                                                                                 | Yes                                                                                                                                                                                                                                                                         |
+| Oliver & Buckley (1994), UK                                                      | DS low-age spoken anchor (10-word stage ~27 mo)                                                                                    | Yes — confirmed **not** to overlap `uk_01`                                                                                                                                                                                                                                  |
+| Caselli et al. (1998); Zampini & D'Odorico (2013); Bello & Caselli (2014), Italy | DS trajectory, gesture, dispersion                                                                                                 | **No** — overlap the `it_01` Italian-CDI-DS cohort; treat as regularisation                                                                                                                                                                                                 |
+
+Corrected on 2026-09-04 after reading the papers: the Norwegian and Dutch cohorts had been listed together as independent sources of DS anchors and `q`, but none of them reports a parent-report comprehension count at chronological age, and the Galeote cohort is `es_01`. Every DS source in the table that is both independent and on the CDI scale is therefore production-only, which is why the DS understood anchors below rest on the project's own data.
 
 ### Instrument scale (Fenson et al., 2007, via Hutchins, 2013)
 
@@ -697,7 +702,9 @@ The DS anchors (24 and 84 months) can be checked against the independent DS CDI
 cohorts — those not overlapping the training data. Only expressive (spoken)
 vocabulary can be anchored this way: the usable cohorts report production, and DS
 comprehension at chronological age has no independent source here (Berglund's
-form is production-only, Galeote et al. (2008) is mental-age-based, and the
+form is production-only, Galeote et al. (2008) is reported by mental age and is
+in any case the `es_01` cohort, the Dutch and Norwegian cohorts carry no
+parent-report comprehension (see the independence table), and the
 Italian comprehension cohorts overlap `it_01`).
 
 Berglund et al. (2001) — 330 DS children on a 710-item Swedish CDI — give a full
@@ -738,11 +745,11 @@ Comparison with the DS spoken prior (VG01, `Beta(1, 25)` at 24 months, median 0.
   [`notes/202608041216-ds-understood-trajectory-prior.md`](../../notes/202608041216-ds-understood-trajectory-prior.md).
 
 Milestone timing corroborates the shape: the 50-word level is reached by ~25% of
-DS children at age 3, ~50% at age 4, and ~75% at age 5 (Berglund et al., 2001;
-consistent with Næss et al., 2021). Galeote et al. (2008) add that, matched on
-mental age, DS spoken vocabulary is comparable to TD while gesture use is
-superior — evidence for the signed ratio `r(a)` rather than a chronological-age
-anchor.
+DS children at age 3, ~50% at age 4, and ~75% at age 5 (Berglund et al., 2001).
+Galeote et al. (2008, 2011) add that, matched on mental age, DS spoken vocabulary
+is comparable to TD while gesture use is superior — evidence for the signed ratio
+`r(a)` rather than a chronological-age anchor, and in-sample evidence at that,
+since the cohort is `es_01`.
 
 ### Dispersion (`kappa`)
 
@@ -770,9 +777,10 @@ Against the shared prior (`kappa` median ~13–17, 5–95% ~5–60; `b_kappa < 0
   `kappa` clearly falls with age — dispersion rises with age, exactly the sign the
   prior encodes. Comprehension is roughly flat, and on the typically-developing
   random-effects frame very slightly rising, which the shared prior's
-  `b_kappa_mag >= 0` cannot represent at all. Independently, Zampini & D'Odorico
-  (2013) report DS vocabulary variability _increasing_ from 36 months, the same
-  direction.
+  `b_kappa_mag >= 0` cannot represent at all. Zampini & D'Odorico (2013) report DS
+  vocabulary variability _increasing_ from 36 months, the same direction — but as
+  corroboration rather than independent evidence, since that cohort overlaps
+  `it_01`.
 - **The floor is real and is about 3.** Three independent pools (DS spoken, and
   the two typically-developing spoken frames) put `kappa_min` at 3.08–3.54,
   against a shared prior centred at 5 whose 5th percentile was 1.86. Dropping the
@@ -888,9 +896,10 @@ are not neutral defaults and need explicit labelling.
   reference ages), so its prior median is a hill — replacing the intercept-only mean
   (flat median) and avoiding the monotone-slope young-extrapolation failure. The
   anchor ages/levels come from the independent DS sign literature (peak ~mental age
-  17 mo ≈ chronological ~36 mo; Miller/Clibbens, Zampini, Te Kaat-van den Os), not
-  the in-sample data; `eta_sign` reverts to the standard ~0.4 since the mean now
-  carries the hump.
+  17 mo ≈ chronological ~36 mo, Miller/Clibbens; longer sign retention, Te
+  Kaat-van den Os), not the in-sample data; Zampini corroborates the inverted-U
+  _shape_ only, since that cohort overlaps `it_01`. `eta_sign` reverts to the
+  standard ~0.4 since the mean now carries the hump.
 - The shared kappa prior encodes substantial extra-binomial heterogeneity and a
   monotone increase in heterogeneity with age.
 - Random-effect scale priors allow meaningful study and subject differences and

--- a/src/vocab_growth/models/definitions.py
+++ b/src/vocab_growth/models/definitions.py
@@ -1304,8 +1304,9 @@ class TrivariateModelDefinition:
     # Anchor ages/levels come from the INDEPENDENT DS sign literature, not the fitted
     # data: signing peaks ~mental age 17 mo (Miller 1992 via Clibbens: signed = 2x
     # spoken there, declining by MA ~26 mo) which at a DS DQ ~0.5 is chronological
-    # ~34 mo; the inverted-U shape is confirmed by Zampini (parabolic gesture
-    # trajectory); DS retain signs longer than TD (Te Kaat-van den Os review), so the
+    # ~34 mo; the inverted-U shape is corroborated by Zampini (parabolic gesture
+    # trajectory -- shape only, since that cohort overlaps it_01); DS retain signs
+    # longer than TD (Te Kaat-van den Os review), so the
     # old anchor stays modest (not near-zero) and uk_06 has real 60-115 mo signers.
     # The peak LEVEL is kept broad because the peak AGE is only weakly identifiable.
     sign_anchor_ages: tuple[float, float, float] = (15.0, 36.0, 96.0)
@@ -1500,8 +1501,9 @@ class JointModelDefinition:
     # reference ages (sign_anchor_ages) and built as a tent meeting at the peak
     # anchor (gp_utils.tent_and_gp) so the prior median is a hill. Anchor ages/levels
     # come from the independent DS sign literature (peak ~MA 17 mo ~= chronological
-    # ~34 mo, Miller/Clibbens; inverted-U shape, Zampini; DS retain signs longer,
-    # Te Kaat) — see the VG14 (TrivariateModelDefinition) comment for the full
+    # ~34 mo, Miller/Clibbens; inverted-U shape, Zampini, whose cohort overlaps
+    # it_01 so shape only; DS retain signs longer, Te Kaat) — see the VG14
+    # (TrivariateModelDefinition) comment for the full
     # rationale. Study REs carry between-study level; the GP (anchored at 54 mo,
     # below) carries smooth departures.
     sign_anchor_ages: tuple[float, float, float] = (15.0, 36.0, 96.0)


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Fable 5.1).

## What changed

The "Independence of candidate sources" table in `docs/models/PRIORS.md` listed Næss et al. (2021), Galeote et al. (2008), Deckers et al. (2016) and Kaat-van den Os et al. (2017) in a single row as independent sources of Down syndrome anchors, `q` and signed `r`. That row is now four rows, each stating what the cohort measured, on what instrument, at what ages and with how many children, and whether it overlaps the training data:

- **Galeote et al. (2008, 2011)** is marked **not independent**: the 186-child cohort is `es_01`, supplied by the author (`data/vocab_data_es_01.md`).
- **Næss et al. (2021)** is independent but not on the CDI scale: 43 children tested at 6, 7 and 8 years with the BPVS-II and WPPSI-III Picture Naming, no parent report, so it supplies no CDI anchor and no `q`.
- **Deckers et al. (2016, 2019)** is independent: 25 to 36 children aged 2;0 to 7;6, two waves, N-CDI Words & Sentences (702 words) with an added sign column. A production-only form; the 2019 receptive measure is a composite with the ROWPVT test and no parent-report comprehension column is described.
- **Kaat-van den Os et al. (2017)** is independent: 26 children followed monthly from 18 to 24 months for 18 months on the 263-word Lexi questionnaire, production only.

Berglund's role is qualified as spoken-only, and a dated correction sentence after the table draws the consequence: every Down syndrome source that is both independent and on the CDI scale is production-only, which is why the DS understood anchors rest on the project's own data.

Two downstream sentences that relied on the old row are fixed: the list of why no independent comprehension source exists, and the milestone paragraph, which cited Næss 2021 as consistent with 50-word timing that paper does not report.

The same class of error was corrected for Zampini & D'Odorico, whose cohort the table already marks as overlapping `it_01`: the dispersion section no longer calls it independent, and the closing sign-hump bullet plus the VG14 and VG15 sign-anchor comments in `definitions.py` credit it for the inverted-U shape only.

## Why

The table is what separates independent prior evidence from regularisation drawn from the training data. It was consulted this week when weighing which authors to approach for data, and it pointed at the Norwegian and Dutch cohorts as sources that would fill the comprehension-anchor gap. None of them does.

## For the reviewer

- `definitions.py` changes are comments only. No serialised definition field moves, so no existing fit is invalidated.
- Five instrument names (`BPVS`, `Lexi`, `ROWPVT`, `SECDI`, `WPPSI`) were added to `config/spellcheck/allow-en.txt`; its line endings were normalised to LF to match the index.
- `npm run spellcheck`, `npm run format:check` and `ruff check` on the touched module all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
