### PR TITLE
test(comparison): derive the registry-resolution path from the configured output root

### DIFF
--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -1,16 +1,25 @@
 # Copyright (c) 2026 Down Syndrome Education International and contributors
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import os
+
 import numpy as np
 import pytest
 
 from vocab_growth import comparison
+from vocab_growth import environment as env
 
 
 # ---- registry resolution ----
 def test_registry_resolution():
+    # The output root is resolved at call time (an explicit override, then
+    # DSE_VOCAB_GROWTH_OUTPUT_DIR, then the repo-local default), so the expected
+    # directory is derived from the same resolution rather than assuming the
+    # default; the test then holds wherever the fits have been redirected.
+    expected = os.path.join(env.models_output_dir(), "VG11-age-spoken-td-re")
+    assert os.path.normcase(comparison.model_dir("vg11")) == os.path.normcase(expected)
     assert comparison.model_dir("vg11").replace("\\", "/").endswith(
-        "output/models/VG11-age-spoken-td-re"
+        "/models/VG11-age-spoken-td-re"
     )
     assert comparison.n_trials("vg11") == 810
     assert comparison.n_trials("vg10") == 810


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Fable 5.1).

## What changed

`tests/test_comparison.py::test_registry_resolution` now derives its expected directory from `environment.models_output_dir()`, the same call `comparison.model_dir` uses, instead of asserting the repo-local `output/models/...` suffix.

## Why

The output root is resolved at call time in three steps (an explicit override, then `DSE_VOCAB_GROWTH_OUTPUT_DIR`, then the repo-local default), so the fits can be redirected to a scratch disk without touching the layout. The test hard-coded the default, so it failed on any machine where the variable is set, which is now the case locally since the 2026-09-01 refit's traces were moved to `D:\output\vocabulary-growth`. It was the one failure in an otherwise clean fast suite and had nothing to do with the code under test.

## What a reviewer should know

- The test passes with the variable unset, set to the redirected root, and set to an arbitrary path; the suffix assertion is kept on the model-label part so a wrong label still fails.
- Test-only change; no code under `src/` moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
