### PR TITLE
docs(models): record that VG21 has landed

### DIFF
--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -262,9 +262,9 @@ model:
   variants were fitted on 2026-08-20 and the study owner **adopted the
   8–22-month specification** for the matched-comprehension comparison,
   rejecting 8–25 as ceiling-contaminated
-  (`notes/202608211100-window-22-adopted.md`); its promotion as a registered
-  successor model (VG21) is tracked in issue #240, and until it lands VG13
-  remains the 8–18-month model of record.
+  (`notes/202608211100-window-22-adopted.md`); that promotion landed as **VG21**, registered and
+  fitted at `rep` on 2026-09-02 (issue #240), and VG13 is retained as the
+  historical 8–18-month model.
 
 ### Typically developing single-outcome, with hierarchy (VG11, VG12)
 


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

Follow-on to #302, which merged before this correction was ready. Same class of staleness as the VG16 row fixed there, found while closing #228.

## What changed

The window-variant paragraph in `docs/models/README.md` still said VG21's promotion "is tracked in issue #240, and until it lands VG13 remains the 8–18-month model of record".

VG21 landed in the #281 cycle: registered, fitted at `rep` on 2026-09-02, and carried in the inventory table a few rows above the very same paragraph — where it already records reaching **328** matched understood words against VG13's ~221. The two passages contradicted each other.

Only the `until it lands` conditional was wrong. VG13 *is* retained as the historical 8–18-month model, which is what #240 asked for, so that half is preserved rather than rewritten.

## For the reviewer

One sentence, three lines, no code. Rebased onto current `main` (after #301 and #302), where the cherry-pick applied cleanly and the surrounding paragraph is unchanged.

Verified after rebasing onto the post-#301 tree: `uv run pytest -n auto --dist loadfile` — 1843 passed, 51 skipped, 0 failed; `ruff` clean; `format:check` and `spellcheck` clean. `docs/models/**` is a CI carve-out that always runs the full suite, so this was run rather than skipped as documentation.

Refs #228, #240, #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
