### PR TITLE
fix: upgrade research utils to v0.13.0 and migrate diagnostics and uploads

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Agent Instructions
 
 > [!NOTE]
-> Maintained with assistance from LLM-based AI tools, including OpenAI Codex/GPT-5.
+> Maintained with assistance from LLM-based AI tools, including OpenAI Codex/GPT-6.
 
 > **Keep in sync:** This file, `CLAUDE.md`, and `.github/copilot-instructions.md` share the same content. When updating one, update all three.
 
@@ -11,7 +11,7 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.12.5` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.13.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent Instructions
 
 > [!NOTE]
-> Maintained with assistance from LLM-based AI tools, including OpenAI Codex/GPT-5.
+> Maintained with assistance from LLM-based AI tools, including OpenAI Codex/GPT-6.
 
 > **Keep in sync:** This file, `CLAUDE.md`, and `.github/copilot-instructions.md` share the same content. When updating one, update all three.
 
@@ -11,7 +11,7 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.12.5` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.13.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Agent Instructions
 
 > [!NOTE]
-> Maintained with assistance from LLM-based AI tools, including OpenAI Codex/GPT-5.
+> Maintained with assistance from LLM-based AI tools, including OpenAI Codex/GPT-6.
 
 > **Keep in sync:** This file, `CLAUDE.md`, and `.github/copilot-instructions.md` share the same content. When updating one, update all three.
 
@@ -11,7 +11,7 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.12.5` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.13.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 

--- a/notes/202609061630-research-utils-013-migration.md
+++ b/notes/202609061630-research-utils-013-migration.md
@@ -1,0 +1,29 @@
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Codex/GPT-6).
+
+<!-- cspell:words reff invlogit unassessable nonfinite -->
+
+# Shared library 0.13.0 migration
+
+Issue [#309](https://github.com/dseinternational/vocabulary-growth/issues/309) upgrades `dse-research-utils` from 0.12.5 to 0.13.0. The lockfile selects commit `458cc41b1dc33f4c0204919253ac92251c61b2bb`. The existing extras and shared ownership of scientific dependencies remain in place. No other locked package changed. The review used the tagged [migration guide](https://github.com/dseinternational/research/blob/v0.13.0/docs/migrating-to-0.13.md) and [source review](https://github.com/dseinternational/research/blob/v0.13.0/docs/source-review-2026-09-06.md).
+
+## Changed consumer behaviour
+
+- Relative efficiency falls back to ArviZ's default only when sampled-parameter metadata is unavailable. Missing named variables, empty selections, and reader or calculation errors propagate. The local wrapper supplies its metadata reader to the shared helper. The local parameter-name helper raises the shared public `SampledParametersUnavailableError`.
+- Model and comparison LOO tables retain the explicit non-finite and unusable counts. The unusable count includes each observation once, even when its positive infinite value is also above the threshold. The comparison warning uses that count. Model reports use it too. For older model tables, the complement of the finite good count gives the unusable count; adding the old bad bands would omit missing values. A zero threshold remains valid. Non-finite thresholds are rejected before writing a new table.
+- Upload verification compares local filenames with the uploader's raw `relative_paths`. HTTP checks encode those paths once. Simulated Azure and HTTP clients cover spaces, plus signs, percent signs, non-ASCII names, skipped assets, excluded traces, and root versus nested reports. No test publishes files to Azure.
+- The hard convergence gate reads `scan_completed` separately from whether each parameter could be assessed. A completed scan with unavailable values fails with an assessment explanation; a failed or empty scan fails with a completion explanation. Legacy summaries require finite extrema before their scan is treated as complete. The registered R-hat exception cannot excuse unavailable ESS or an unassessable parameter. Sensitivity comparisons and report verdicts now apply the same distinction. Report readers also accept null values in BFMI arrays and nested diagnostic amendments.
+
+## Other release changes
+
+This repository does not call the changed shared `build_hsgp_1d` or `build_tau_modifier` constructors. `models/gp_utils.py` builds `pm.gp.HSGP` directly with `GPGrid.M` and `GPGrid.L`, and uses the recorded grid centre where supplied. The shared constructor change therefore does not change this repository's basis or require a basis migration. The existing model-building and grid tests check the local path.
+
+The interval wrapper delegates to the changed shared summaries. A regression test confirms that a median and its intervals use the same finite draws. Previously generated summaries containing infinite draws should be regenerated. No local code calls the shared numeric `invlogit`; symbolic model expressions use PyMC or PyTensor operations. No local code calls `save_plotcollection` directly. The shared pair-plot helper uses `close=False`, as does the local figure-saving wrapper, so the changed `close=True` behaviour requires no call-site edit.
+
+## Validation and output follow-up
+
+`uv sync --locked`, Ruff, mypy, Markdown formatting and spelling checks pass. The complete suite, selected with `uv run pytest -m "slow or not slow" -n 4 --dist loadfile`, passed with 2,243 tests passing and 11 skipped in 176 seconds. It included the slow sampling and numerical optimisation tests. After the final report edits, all 213 migration regression tests passed again. These cover the changed consumer contracts, including the decisions and explanations read back from written files. The full run emitted figure-count and Numba object-mode warnings; no test failed.
+
+This checkout contains only a descriptive CSV under `output/models/TEST_VG15_NATIVE-test`, with no complete fitted model report or trace available for rendering. A Quarto HTML check therefore executes the actual report functions against labelled synthetic fixtures. It covers a clean legacy summary, a completed scan with null diagnostics, a failed scan, and LOO containing NaN and both infinities at a zero threshold. The resulting HTML contains the expected verdicts and reports four unusable observations out of six. This is a report-function check, not validation of fitted study results.
+
+Before updating published results, regenerate diagnostic and LOO summaries and rerender reports from the corresponding fits. Rebuild comparison tables before aggregating them so they carry the new counts. The existing executable-code signature includes the shared library version and changed package code. It will reject older fits for publication and resume until they are refitted under the current implementation; this migration does not bypass or rewrite that provenance. Rendering an older fit for review remains permitted by the existing render policy. No reporting-quality refits or publication uploads were performed for this code migration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ environments = [
 # dse-research-utils isn't published to PyPI — resolve it from the public git
 # tag. To develop against a sibling checkout instead, comment this out and use:
 #   dse-research-utils = { path = "../research/src/python", editable = true }
-dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.12.5" }
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.13.0" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"

--- a/scripts/aggregate_summary.py
+++ b/scripts/aggregate_summary.py
@@ -166,6 +166,9 @@ def per_model_summary(short: str, label: str,
             summary["elpd_loo"] = float(row["elpd_loo"])
             summary["elpd_loo_se"] = float(row["se"])
             summary["pareto_k_gt_0.7"] = int(row["pareto_k_gt_0.7"])
+            for column in ("pareto_k_nonfinite", "pareto_k_unusable"):
+                # Legacy tables cannot establish how many diagnostics were missing.
+                summary[column] = int(row[column]) if pd.notna(row.get(column)) else None
             summary["n_loo_obs"] = int(row["n_observations"])
 
     return summary

--- a/scripts/loo_compare.py
+++ b/scripts/loo_compare.py
@@ -93,7 +93,7 @@ class LooEntry:
     n_high_pareto: int
 
 
-#: Share of observations above Pareto-k 0.7 beyond which the PSIS estimate is
+#: Share of unusable observations beyond which the PSIS estimate is
 #: reported as unusable rather than merely caveated. PSIS-LOO degenerates for the
 #: subject-random-effect models -- leaving one observation out swings the child
 #: intercept it is nearly the only evidence for -- and past this fraction the
@@ -113,11 +113,11 @@ def _warn_if_unusable(label: str, row: dict) -> None:
     n = row["n_observations"]
     if not n:
         return
-    share = row["pareto_k_gt_0.7"] / n
+    share = row["pareto_k_unusable"] / n
     if share < HIGH_PARETO_K_UNUSABLE_SHARE:
         return
     print(
-        f"      [unusable] {label}: {share:.0%} of observations above Pareto-k 0.7 "
+        f"      [unusable] {label}: {share:.0%} of observations have non-finite Pareto-k or exceed 0.7 "
         f"(p_loo = {row['p_loo']:.0f} on {n} observations).\n"
         "      PSIS-LOO has degenerated here; do not compare this elpd with another "
         "model's.\n"
@@ -157,6 +157,8 @@ def _loo_summary_row(label: str, loo, reff=None) -> dict:
         "looic": shared["looic"],
         "looic_se": shared["looic_se"],
         "pareto_k_gt_0.7": shared["pareto_k_above"],
+        "pareto_k_nonfinite": shared["pareto_k_nonfinite"],
+        "pareto_k_unusable": shared["pareto_k_unusable"],
         "n_observations": shared["n_observations"],
     }
 

--- a/scripts/loso_compare.py
+++ b/scripts/loso_compare.py
@@ -393,6 +393,8 @@ def _summary_row(label: str, loo, reff: float) -> dict:
         "se": shared["se"],
         "p_loo": shared["p_loo"],
         "pareto_k_gt_0.7": shared["pareto_k_above"],
+        "pareto_k_nonfinite": shared["pareto_k_nonfinite"],
+        "pareto_k_unusable": shared["pareto_k_unusable"],
         "n_subjects": shared["n_subjects"],
         "reff": shared["reff"],
     }

--- a/src/vocab_growth/fit_artifacts.py
+++ b/src/vocab_growth/fit_artifacts.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import shutil
 import subprocess
@@ -442,6 +443,28 @@ CONVERGENCE_EXCEPTIONS: dict[str, ConvergenceException] = {
 }
 
 
+def diagnostics_scan_completed(summary: dict) -> bool:
+    """Read explicit scan status, requiring finite extrema for legacy files."""
+    if "scan_completed" in summary:
+        return summary["scan_completed"] is True
+    return all(
+        summary.get(key) is not None and math.isfinite(float(summary[key]))
+        for key in ("max_rhat", "min_ess")
+    )
+
+
+def diagnostics_assessable(summary: dict) -> bool:
+    """Require usable extrema and no missing parameter diagnostics."""
+    return (
+        not summary.get("unassessable_parameters")
+        and (summary.get("checks") or {}).get("diagnostics_assessable") is not False
+        and all(
+            summary.get(key) is not None and math.isfinite(float(summary[key]))
+            for key in ("max_rhat", "min_ess")
+        )
+    )
+
+
 def accepted_rhat_exception(
     model_id: str | None, gate_summary: dict | None
 ) -> ConvergenceException | None:
@@ -457,7 +480,9 @@ def accepted_rhat_exception(
     exception = CONVERGENCE_EXCEPTIONS.get(model_id)
     if exception is None:
         return None
-    if gate_summary.get("ess_failing"):
+    if not diagnostics_scan_completed(gate_summary) or not diagnostics_assessable(gate_summary):
+        return None
+    if gate_summary.get("ess_failing") or (gate_summary.get("checks") or {}).get("ess") is False:
         return None
     max_rhat = gate_summary.get("max_rhat")
     if max_rhat is None or float(max_rhat) > exception.max_rhat:

--- a/src/vocab_growth/loo_reff.py
+++ b/src/vocab_growth/loo_reff.py
@@ -26,7 +26,7 @@ pinned when the caller can name the parameters (a rebuilt model); otherwise
 
 The computation lives in :mod:`dse_research_utils.statistics.loo` (v0.12.0);
 this module binds it to this repository's trace-attribute reader and keeps the
-project-specific ``LookupError`` message, which names the date the attribute
+project-specific ``SampledParametersUnavailableError`` message, which names the date the attribute
 was introduced.
 
 See ``notes/202608231530-observation-deterministics-not-sampled.md`` §3 and §7.
@@ -45,14 +45,14 @@ from vocab_growth.fit_artifacts import read_sampled_parameters_attr
 def sampled_parameter_names(trace: Any, *, names: Sequence[str] | None = None) -> list[str]:
     """The sampled parameters of ``trace``: ``names`` if given, else its attribute.
 
-    Raises ``LookupError`` when neither is available — a trace from before the
+    Raises ``SampledParametersUnavailableError`` when neither is available — a trace from before the
     attribute existed, read without a model to name the parameters.
     """
     if names is not None:
         return list(names)
     recorded = read_sampled_parameters_attr(trace)
     if recorded is None:
-        raise LookupError(
+        raise shared_loo.SampledParametersUnavailableError(
             "The trace does not record its sampled parameters (written before "
             "2026-08-23) and none were supplied; pass names=[rv.name for rv in "
             "model.free_RVs] from a rebuilt model, or accept ArviZ's default."
@@ -84,12 +84,10 @@ def reff_or_default(
     comes with a model to name them. The notice is printed rather than swallowed
     because a comparison that mixes the two conventions should say so.
     """
-    try:
-        return sampled_parameter_reff(trace, names=names)
-    except LookupError:
-        warn(
-            f"  {label + ': ' if label else ''}reff left at ArviZ's posterior-wide "
-            "default — the trace predates the sampled-parameters record and no "
-            "model was supplied to pin it."
-        )
-        return None
+    return shared_loo.reff_or_default(
+        trace,
+        names=names,
+        attr_reader=read_sampled_parameters_attr,
+        label=label,
+        warn=warn,
+    )

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -27,6 +27,7 @@ import dse_research_utils.plot.predictive as plot_predictive
 import dse_research_utils.plot.styles as plot_styles
 import dse_research_utils.statistics.descriptive as descriptive_stats
 import dse_research_utils.statistics.diagnostics as shared_diagnostics
+import dse_research_utils.statistics.loo as shared_loo
 import dse_research_utils.statistics.models.data as model_data
 import dse_research_utils.statistics.models.pymc_utils as pymc_utils
 import dse_research_utils.statistics.models.reporting as reporting
@@ -69,6 +70,8 @@ from vocab_growth.fit_artifacts import (
     configured_nutpie_backend,
     convergence_caveats,
     create_staging_root,
+    diagnostics_assessable,
+    diagnostics_scan_completed,
     git_metadata,
     is_reporting_quality_config,
     normalise_for_json,
@@ -1100,30 +1103,28 @@ def emit_loo_summary(
     """
     rows = []
     for label, loo in loo_by_label.items():
-        pareto_k = getattr(loo, "pareto_k", None)
-        good_k = getattr(loo, "good_k", None)
-        counts = {"good": None, "bad": None, "very_bad": None}
-        if pareto_k is not None and good_k is not None:
-            values = np.asarray(pareto_k).ravel()
-            values = values[np.isfinite(values)]
-            counts = {
-                "good": int((values <= float(good_k)).sum()),
-                "bad": int(((values > float(good_k)) & (values <= 1.0)).sum()),
-                "very_bad": int((values > 1.0).sum()),
-            }
+        shared = shared_loo.loo_summary_row(loo, label=label, reff=reff)
+        values = shared_loo.pareto_k_values(loo).ravel()
+        # Bands describe finite diagnostics only; the separate unusable count
+        # includes every non-finite value without double-counting +infinity.
+        counts = shared_loo.pareto_k_bands(
+            values[np.isfinite(values)], shared["k_threshold"]
+        )
         rows.append(
             {
                 "outcome": label,
-                "elpd_loo": float(getattr(loo, "elpd", np.nan)),
+                "elpd_loo": shared["elpd_loo"],
                 "se": float(getattr(loo, "se", np.nan)),
-                "p_loo": float(getattr(loo, "p", np.nan)),
-                "n_data_points": int(getattr(loo, "n_data_points", 0)),
+                "p_loo": shared["p_loo"],
+                "n_data_points": shared["n_observations"],
                 "n_samples": int(getattr(loo, "n_samples", 0)),
                 "n_dropped_degenerate": int(dropped_by_label.get(label, 0)),
                 "pareto_k_good": counts["good"],
                 "pareto_k_bad": counts["bad"],
                 "pareto_k_very_bad": counts["very_bad"],
-                "good_k_threshold": None if good_k is None else float(good_k),
+                "pareto_k_nonfinite": shared["pareto_k_nonfinite"],
+                "pareto_k_unusable": shared["pareto_k_unusable"],
+                "good_k_threshold": shared["k_threshold"],
                 "scale": str(getattr(loo, "scale", "log")),
                 "reff": None if reff is None else float(reff),
             }
@@ -1790,10 +1791,9 @@ def enforce_convergence_gate(
     if not is_reporting_quality_config(sampling_config_name):
         return []
 
-    scan_failed = (
-        gate_summary.get("max_rhat") is None
-        or gate_summary.get("min_ess") is None
-    )
+    scan_failed = not diagnostics_scan_completed(gate_summary)
+    assessable = diagnostics_assessable(gate_summary)
+    checks = gate_summary.get("checks") or {}
     rhat_failing = gate_summary.get("rhat_failing") or []
     ess_failing = gate_summary.get("ess_failing") or []
     unassessable = gate_summary.get("unassessable_parameters") or []
@@ -1821,19 +1821,27 @@ def enforce_convergence_gate(
         rhat_failing = []
         scan_failed = False
 
-    if scan_failed or rhat_failing or ess_failing or unassessable:
+    check_failed = (
+        checks.get("rhat") is False and accepted is None
+    ) or checks.get("ess") is False
+    if scan_failed or not assessable or rhat_failing or ess_failing or check_failed:
         if scan_failed:
             reason = "The R-hat/ESS convergence scan did not complete."
-        elif unassessable and not (rhat_failing or ess_failing):
+        elif not assessable and not (rhat_failing or ess_failing):
             reason = (
-                f"The convergence gate could not assess R-hat/ESS for "
-                f"{len(unassessable)} parameter(s): {', '.join(unassessable[:6])}."
+                "The convergence gate could not assess R-hat/ESS"
+                + (f" for {len(unassessable)} parameter(s): {', '.join(unassessable[:6])}."
+                   if unassessable else ": diagnostic values are unavailable.")
             )
-        else:
+        elif rhat_failing or ess_failing:
             reason = (
                 f"The convergence gate found {len(rhat_failing)} R-hat failure(s) "
                 f"and {len(ess_failing)} ESS failure(s)."
             )
+            if unassessable:
+                reason += f" It also could not assess: {', '.join(unassessable[:6])}."
+        else:
+            reason = "The recorded R-hat/ESS checks failed without naming the failing parameters."
         failure_path = os.path.join(output_dir, CONVERGENCE_FAILURE_FILENAME)
         with open(failure_path, "w", encoding="utf-8") as failure_file:
             failure_file.write(
@@ -1893,6 +1901,12 @@ def report_diagnostic_warnings(gate_summary: dict) -> None:
     min_ess = gate_summary.get("min_ess")
 
     problems: list[str] = []
+    if diagnostics_scan_completed(gate_summary) and not diagnostics_assessable(gate_summary):
+        names = gate_summary.get("unassessable_parameters") or []
+        problems.append(
+            "R-hat/ESS could not be assessed"
+            + (f" for: {', '.join(names[:6])}" if names else ".")
+        )
     rhat_failing = gate_summary.get("rhat_failing") or []
     if rhat_failing:
         detail = f" (max {max_rhat:.3f})" if max_rhat is not None else ""
@@ -1911,7 +1925,7 @@ def report_diagnostic_warnings(gate_summary: dict) -> None:
         console.print()
         for line in problems:
             console.print(f"[bold yellow]⚠ {line}[/bold yellow]")
-    elif max_rhat is not None and min_ess is not None:
+    elif diagnostics_scan_completed(gate_summary) and diagnostics_assessable(gate_summary):
         console.print(
             f"[green]✓ r_hat ≤ {rhat_max} and ESS ≥ {ess_threshold} across all "
             "free parameters (including vector-valued).[/green]"

--- a/src/vocab_growth/publication_checks.py
+++ b/src/vocab_growth/publication_checks.py
@@ -25,6 +25,7 @@ import os
 import re
 import urllib.request
 from collections.abc import Iterable
+from urllib.parse import quote
 
 #: ``src``/``href`` targets in rendered HTML that point at a local file.
 _ASSET = re.compile(r'(?:src|href)="([^"#?][^"]*?)"')
@@ -80,12 +81,13 @@ def verify_published(
 
     Each failure is ``"<status or exception> <path>"``, so the caller can print
     them as a list. ``base_url`` is the directory URL the files were published
-    under, with or without a trailing slash.
+    under, with or without a trailing slash. ``relative_paths`` contains raw
+    filenames, not URL-encoded paths; each is encoded exactly once.
     """
     failures: list[str] = []
     root = base_url.rstrip("/")
     for relative in relative_paths:
-        url = f"{root}/{relative}"
+        url = f"{root}/{quote(relative, safe='/')}"
         try:
             with urllib.request.urlopen(url, timeout=timeout) as response:
                 if response.status != 200:

--- a/src/vocab_growth/report_cells.py
+++ b/src/vocab_growth/report_cells.py
@@ -33,6 +33,10 @@ from collections.abc import Mapping
 from scipy import stats
 
 from vocab_growth.administration_loo import ADMINISTRATION_LABEL
+from vocab_growth.fit_artifacts import (
+    diagnostics_assessable,
+    diagnostics_scan_completed,
+)
 from vocab_growth.glossary import render_glossary  # noqa: F401  (re-exported)
 from vocab_growth.models.diagnostics_utils import (  # noqa: F401  (re-exported)
     render_convergence_caveats,
@@ -1619,9 +1623,16 @@ def render_loo_section(directory: str = ".") -> None:
 
     # The estimate is not usable without its reliability diagnostic, so the
     # verdict is printed rather than left for the reader to derive.
-    bad = int(table.get("pareto_k_bad", pd.Series(dtype=int)).fillna(0).sum())
-    very_bad = int(table.get("pareto_k_very_bad", pd.Series(dtype=int)).fillna(0).sum())
-    total = int(table.get("n_data_points", pd.Series(dtype=int)).fillna(0).sum())
+    total = int(table["n_data_points"].sum())
+    very_bad = int(table["pareto_k_very_bad"].fillna(0).sum())
+    if "pareto_k_unusable" in table and table["pareto_k_unusable"].notna().all():
+        unusable = int(table["pareto_k_unusable"].sum())
+    elif table["pareto_k_good"].notna().all():
+        # Older writers counted only finite values in the good band. Its
+        # complement includes missing values, unlike bad + very_bad.
+        unusable = total - int(table["pareto_k_good"].sum())
+    else:
+        unusable = None
     print(
         "The Pareto $k$ counts say whether that estimate can be trusted. "
         "Leave-one-out here is approximated by importance sampling rather than "
@@ -1630,16 +1641,19 @@ def render_loo_section(directory: str = ".") -> None:
         "Counts are against the threshold in the table, which ArviZ sets from "
         "the sample size.\n"
     )
-    if bad == 0 and very_bad == 0:
+    if unusable is None or total == 0:
+        print("The Pareto $k$ counts are unavailable or empty; reliability cannot be assessed.")
+    elif unusable == 0:
         print(
             f"For this fit **every one of the {total:,} observations is within "
             "the threshold**, so the estimate above is reliable."
         )
     else:
-        share = (bad + very_bad) / total if total else 0.0
+        share = unusable / total
         print(
-            f"For this fit **{bad + very_bad} of {total:,} observations "
-            f"({share:.0%}) exceed the threshold** ({very_bad} of them above 1), "
+            f"For this fit **{unusable} of {total:,} observations "
+            f"({share:.0%}) have non-finite Pareto $k$ or exceed the threshold** "
+            f"({very_bad} finite values above 1), "
             "so the estimate above should be treated as indicative rather than "
             "as a precise quantity."
         )
@@ -2079,7 +2093,8 @@ def render_diagnostic_verdict(directory: str = ".") -> None:
 
     divergences = summary.get("divergences")
     bfmi = summary.get("bfmi_per_chain") or []
-    min_bfmi = min(bfmi) if bfmi else None
+    finite_bfmi = [value for value in bfmi if value is not None and math.isfinite(value)]
+    min_bfmi = min(finite_bfmi) if len(finite_bfmi) == len(bfmi) and bfmi else None
 
     def mark(ok):
         return "pass" if ok else "**fail**"
@@ -2095,6 +2110,8 @@ def render_diagnostic_verdict(directory: str = ".") -> None:
             f"| Largest R-hat | {max_rhat:.6f}{where} | ≤ {rhat_max:g} | hard | "
             f"{mark(checks.get('rhat', max_rhat <= rhat_max))} |"
         )
+    else:
+        print(f"| Largest R-hat | unavailable | ≤ {rhat_max:g} | hard | **fail** |")
     if min_ess is not None:
         where = (
             f" ({best_ess_name})" if best_ess_name == unlisted
@@ -2104,6 +2121,8 @@ def render_diagnostic_verdict(directory: str = ".") -> None:
             f"| Smallest effective sample size | {min_ess:,.0f}{where} | ≥ {ess_min:,} | hard | "
             f"{mark(checks.get('ess', min_ess >= ess_min))} |"
         )
+    else:
+        print(f"| Smallest effective sample size | unavailable | ≥ {ess_min:,} | hard | **fail** |")
     if divergences is not None:
         print(
             f"| Divergent transitions | {divergences:,} | 0 | soft | "
@@ -2114,9 +2133,14 @@ def render_diagnostic_verdict(directory: str = ".") -> None:
             f"| Smallest energy BFMI across chains | {min_bfmi:.3f} | ≥ {bfmi_min:g} | soft | "
             f"{mark(checks.get('bfmi', min_bfmi >= bfmi_min))} |"
         )
+    else:
+        print(f"| Smallest energy BFMI across chains | unavailable | ≥ {bfmi_min:g} | soft | **fail** |")
     unassessable = summary.get("unassessable_parameters") or []
-    if unassessable:
-        print(f"| Parameters the gate could not assess | {len(unassessable):,} | 0 | — | noted |")
+    if not diagnostics_scan_completed(summary):
+        print("| R-hat/ESS scan | did not complete | completed | hard | **fail** |")
+    if not diagnostics_assessable(summary):
+        detail = ", ".join(unassessable) if unassessable else "unavailable diagnostics"
+        print(f"| Parameters the gate could not assess | {detail} | none | hard | **fail** |")
     print()
 
     manifest = read_manifest(directory)
@@ -2128,8 +2152,17 @@ def render_diagnostic_verdict(directory: str = ".") -> None:
         effort.append(f"after {params['tune']:,} tuning draws")
     if params.get("target_accept"):
         effort.append(f"at target acceptance {params['target_accept']:g}")
-    hard = bool(checks.get("rhat", True)) and bool(checks.get("ess", True))
-    soft = bool(checks.get("divergences", True)) and bool(checks.get("bfmi", True))
+    hard = (
+        diagnostics_scan_completed(summary)
+        and diagnostics_assessable(summary)
+        and bool(checks.get("rhat", max_rhat is not None and max_rhat <= rhat_max))
+        and bool(checks.get("ess", min_ess is not None and min_ess >= ess_min))
+    )
+    soft = (
+        divergences is not None and divergences == 0
+        and min_bfmi is not None and min_bfmi >= bfmi_min
+        and bool(checks.get("divergences", True)) and bool(checks.get("bfmi", True))
+    )
     if hard and soft:
         verdict = "This fit clears both tiers of the convergence gate."
     elif hard:
@@ -2139,10 +2172,11 @@ def render_diagnostic_verdict(directory: str = ".") -> None:
             "intervals should be read with that in mind."
         )
     else:
-        verdict = (
-            "This fit **does not clear the hard tier** and reaches this page only under a "
-            "recorded exception, which the caveat block above states."
-        )
+        verdict = "This fit **does not clear the hard tier**."
+        if summary.get("accepted_rhat_exception"):
+            verdict += " The caveat block above states the recorded exception."
+        else:
+            verdict += " These results are provisional and must not be published as a completed fit."
     sentence = verdict
     if effort:
         sentence += " Sampled with " + ", ".join(effort) + "."

--- a/src/vocab_growth/sensitivity/compare.py
+++ b/src/vocab_growth/sensitivity/compare.py
@@ -26,6 +26,8 @@ from vocab_growth.fit_artifacts import (
     ACCEPTED_EXCEPTION_KEY,
     DIAGNOSTICS_SUMMARY_FILENAME,
     convergence_caveats,
+    diagnostics_assessable,
+    diagnostics_scan_completed,
     validate_fit_output,
 )
 
@@ -405,7 +407,7 @@ def diagnostics_gate(dirpath: str) -> DiagnosticsGate:
     failed, matching the fit pipeline's own gate), ``passed`` supplies
     :attr:`DiagnosticsGate.clean`, and
     :func:`vocab_growth.fit_artifacts.convergence_caveats` plus the
-    unassessable-parameter list supply the soft tier. Only when the payload is
+    unassessable-parameter list retain the reasons for failure. Only when the payload is
     absent — a fit made before it existed — does this fall back to scanning
     ``diagnostics.csv``, whose values are rounded and scalars-only and which
     records nothing about divergences, BFMI or unassessable parameters; the
@@ -420,8 +422,16 @@ def diagnostics_gate(dirpath: str) -> DiagnosticsGate:
             # A registered exception accepts a narrowly-scoped R-hat failure;
             # convergence_caveats reports it, so it belongs to the soft tier.
             rhat_ok = True
-        converged = rhat_ok and bool(checks.get("ess"))
+        converged = (
+            diagnostics_scan_completed(payload)
+            and diagnostics_assessable(payload)
+            and rhat_ok and bool(checks.get("ess"))
+        )
         caveats = list(convergence_caveats(payload))
+        if not diagnostics_scan_completed(payload):
+            caveats.append("The R-hat/ESS convergence scan did not complete.")
+        elif not diagnostics_assessable(payload) and not payload.get("unassessable_parameters"):
+            caveats.append("The convergence gate could not assess R-hat/ESS.")
         unassessable = payload.get("unassessable_parameters") or []
         if unassessable:
             shown = ", ".join(unassessable[:6])
@@ -439,7 +449,7 @@ def diagnostics_gate(dirpath: str) -> DiagnosticsGate:
             min_ess=None if min_ess is None else float(min_ess),
             caveats=tuple(caveats),
             source=DIAGNOSTICS_SUMMARY_FILENAME,
-            clean=bool(payload.get("passed")),
+            clean=converged and bool(payload.get("passed")),
         )
 
     df = _read(dirpath, "diagnostics.csv")

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -122,8 +122,7 @@ def _verify_report_upload(output_dir: str, model_label: str, result) -> str:
     a broken publication is never reported as complete.
     """
     index_html = os.path.join(output_dir, "index.html")
-    sent = [url[len(result.prefix_url):] for url in result.urls]
-    missing = unpublished_assets(index_html, sent)
+    missing = unpublished_assets(index_html, result.relative_paths)
     if missing:
         shown = ", ".join(missing[:8]) + (", ..." if len(missing) > 8 else "")
         raise RuntimeError(

--- a/tests/test_comparison_script_reporting.py
+++ b/tests/test_comparison_script_reporting.py
@@ -107,7 +107,7 @@ def test_trace_divergences_is_none_for_a_missing_trace(tmp_path):
 # loo_compare._warn_if_unusable
 # ---------------------------------------------------------------------------
 def _row(n_high: int, n_obs: int, p_loo: float = 1.0) -> dict:
-    return {"n_observations": n_obs, "pareto_k_gt_0.7": n_high, "p_loo": p_loo}
+    return {"n_observations": n_obs, "pareto_k_gt_0.7": n_high, "pareto_k_unusable": n_high, "p_loo": p_loo}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_convergence_exception.py
+++ b/tests/test_convergence_exception.py
@@ -50,6 +50,11 @@ def test_the_exception_applies_to_the_failure_it_was_written_for():
         ("a worse r_hat", {"max_rhat": 1.02}),
         ("an ESS failure alongside", {"ess_failing": ["tau_subject"]}),
         ("a scan that did not complete", {"max_rhat": None}),
+        ("an explicitly failed scan", {"scan_completed": False}),
+        ("unavailable ESS", {"min_ess": None}),
+        ("non-finite R-hat", {"max_rhat": float("nan")}),
+        ("an unassessable parameter", {"unassessable_parameters": ["theta"]}),
+        ("an unassessable check", {"checks": {"diagnostics_assessable": False}}),
     ],
 )
 def test_the_exception_refuses_to_widen(label, override):

--- a/tests/test_diagnostics_gate.py
+++ b/tests/test_diagnostics_gate.py
@@ -10,7 +10,11 @@ study/subject random intercepts — element-wise. These tests pin that split,
 and the gate-payload-driven console banner.
 """
 
+import json
+
+import dse_research_utils.statistics.diagnostics as shared_diagnostics
 import numpy as np
+import pandas as pd
 import preliz as pz
 import pymc as pm
 import pytest
@@ -171,6 +175,79 @@ def test_unassessable_parameter_fails_the_hard_tier(tmp_path):
     assert marker.exists()
     assert "could not assess" in marker.read_text()
     assert "frozen_term" in marker.read_text()
+
+
+@pytest.mark.parametrize("case", ["unassessable", "missing_tail", "failed", "empty"])
+def test_shared_scan_status_reaches_the_gate_and_report(tmp_path, monkeypatch, capsys, case):
+    from vocab_growth.report_cells import render_diagnostic_verdict
+    from vocab_growth.sensitivity.compare import diagnostics_gate
+
+    def summary(*args, **kwargs):
+        if case == "failed":
+            raise RuntimeError("scan failed")
+        if case == "empty":
+            return pd.DataFrame(columns=["r_hat", "ess_bulk", "ess_tail"])
+        if case == "missing_tail":
+            return pd.DataFrame({"r_hat": [1.0], "ess_bulk": [1000]}, index=["theta"])
+        return pd.DataFrame({"r_hat": [np.nan], "ess_bulk": [np.nan], "ess_tail": [np.nan]}, index=["theta"])
+
+    monkeypatch.setattr(shared_diagnostics.az, "summary", summary)
+    payload = shared_diagnostics.write_diagnostics_summary(object(), str(tmp_path))
+    completed = case in {"unassessable", "missing_tail"}
+    assert payload["scan_completed"] is completed
+    reason = "could not assess" if completed else "did not complete"
+    with pytest.raises(ConvergenceGateError, match=reason):
+        enforce_convergence_gate(payload, sampling_config_name="rep", output_dir=str(tmp_path))
+    sensitivity = diagnostics_gate(str(tmp_path))
+    assert sensitivity.converged is False
+    assert sensitivity.clean is False
+    assert any(("could not be assessed" if completed else "did not complete") in item for item in sensitivity.caveats)
+    marker = (tmp_path / "CONVERGENCE_FAILED.txt").read_text()
+    assert reason in marker
+    if completed:
+        assert "theta" in marker
+    capsys.readouterr()
+    render_diagnostic_verdict(str(tmp_path))
+    rendered = capsys.readouterr().out
+    assert "does not clear the hard tier" in rendered
+    assert "recorded exception" not in rendered
+    assert "theta" in rendered if completed else "did not complete" in rendered
+
+
+@pytest.mark.parametrize("value", [None, np.nan, np.inf, -np.inf])
+def test_legacy_unavailable_extrema_fail_conservatively(tmp_path, value):
+    with pytest.raises(ConvergenceGateError, match="did not complete"):
+        enforce_convergence_gate(_payload(max_rhat=value), sampling_config_name="rep", output_dir=str(tmp_path))
+
+
+def test_explicit_failed_scan_cannot_pass_with_finite_extrema(tmp_path):
+    with pytest.raises(ConvergenceGateError, match="did not complete"):
+        enforce_convergence_gate({**_payload(), "scan_completed": False}, sampling_config_name="rep", output_dir=str(tmp_path))
+
+
+def test_completed_scan_with_unavailable_extrema_does_not_claim_scan_failure(tmp_path):
+    with pytest.raises(ConvergenceGateError, match="diagnostic values are unavailable"):
+        enforce_convergence_gate({**_payload(max_rhat=None), "scan_completed": True}, sampling_config_name="rep", output_dir=str(tmp_path))
+
+
+def test_nested_amendment_nulls_are_readable_by_reports(tmp_path, capsys):
+    from vocab_growth.fit_artifacts import convergence_caveats
+    from vocab_growth.report_cells import render_diagnostic_verdict
+
+    (tmp_path / "diagnostics_summary.json").write_text(json.dumps({**_payload(), "scan_completed": True}))
+    tables = {}
+    amended = shared_diagnostics.amend_diagnostics_summary(
+        str(tmp_path),
+        {"checks": {"bfmi": False}, "bfmi_per_chain": [0.4, np.nan],
+         "accepted_rhat_exception": {"observed_max_rhat": np.inf, "parameters": ["theta"]},
+         "nested": {"values": np.array([np.nan, -np.inf, 1.0])}},
+        tables=tables,
+    )
+    assert amended == tables["diagnostics_summary"] == json.loads((tmp_path / "diagnostics_summary.json").read_text())
+    assert amended["nested"]["values"] == [None, None, 1.0]
+    assert len(convergence_caveats(amended)) == 2
+    render_diagnostic_verdict(str(tmp_path))
+    assert "soft" in capsys.readouterr().out
 
 
 def test_measured_failures_take_precedence_in_the_reason(tmp_path):

--- a/tests/test_loo_reff.py
+++ b/tests/test_loo_reff.py
@@ -18,6 +18,7 @@ import arviz_stats  # noqa: F401  (registers the ``azstats`` accessor)
 import numpy as np
 import pytest
 import xarray as xr
+from dse_research_utils.statistics.loo import SampledParametersUnavailableError
 
 from vocab_growth.fit_artifacts import SAMPLED_PARAMETERS_ATTR
 from vocab_growth.loo_reff import (
@@ -79,7 +80,7 @@ def test_single_chain_is_one_as_in_arviz():
 
 def test_unpinnable_trace_raises_and_the_default_path_says_so():
     trace = _trace()  # no record, no names
-    with pytest.raises(LookupError, match="sampled parameters"):
+    with pytest.raises(SampledParametersUnavailableError, match="sampled parameters"):
         sampled_parameter_reff(trace)
     notices = []
     assert reff_or_default(trace, label="VG99", warn=notices.append) is None
@@ -93,3 +94,37 @@ def test_unpinnable_trace_raises_and_the_default_path_says_so():
 def test_names_missing_from_the_posterior_are_an_error():
     with pytest.raises(KeyError, match="absent"):
         sampled_parameter_reff(_trace(), names=["mu", "not_there"])
+
+
+@pytest.mark.parametrize("names", [["absent"], []])
+@pytest.mark.parametrize("recorded", [False, True])
+def test_fallback_does_not_hide_invalid_selections(names, recorded):
+    trace = _trace(attr=names if recorded else None)
+    notices = []
+    with pytest.raises(KeyError if names else ValueError):
+        reff_or_default(trace, names=None if recorded else names, warn=notices.append)
+    assert notices == []
+
+
+@pytest.mark.parametrize("error", [LookupError("reader"), KeyError("reader"), RuntimeError("reader")])
+def test_fallback_propagates_reader_errors(monkeypatch, error):
+    def fail(trace):
+        raise error
+
+    monkeypatch.setattr("vocab_growth.loo_reff.read_sampled_parameters_attr", fail)
+    with pytest.raises(type(error), match="reader"):
+        reff_or_default(_trace())
+
+
+def test_fallback_propagates_calculation_errors(monkeypatch):
+    def fail(*args, **kwargs):
+        raise LookupError("calculation")
+
+    monkeypatch.setattr("dse_research_utils.statistics.loo.sampled_parameter_reff", fail)
+    with pytest.raises(LookupError, match="calculation"):
+        reff_or_default(_trace(), names=["mu"])
+
+
+def test_default_notice_preserves_literal_brackets(capsys):
+    assert reff_or_default(_trace(), label="VG99[bold]") is None
+    assert "VG99[bold]:" in capsys.readouterr().out

--- a/tests/test_loo_summary_contract.py
+++ b/tests/test_loo_summary_contract.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 Down Syndrome Education International and contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""LOO writers and report decisions preserve unavailable diagnostics (#309)."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from dse_research_utils.statistics.loo import loo_summary_row
+
+from vocab_growth.models.common import emit_loo_summary
+from vocab_growth.report_cells import render_loo_section
+
+
+def _loo(values, threshold=0.7):
+    return SimpleNamespace(
+        elpd=-10.0, se=1.0, p=2.0, pareto_k=xr.DataArray(values),
+        good_k=threshold, n_data_points=len(values), n_samples=1000,
+    )
+
+
+@pytest.mark.parametrize("threshold", [np.nan, np.inf, -np.inf])
+def test_nonfinite_thresholds_are_rejected_before_writing(tmp_path, threshold):
+    loo = _loo([0.0, 0.2], threshold)
+    with pytest.raises(ValueError, match="finite"):
+        emit_loo_summary({"all": loo}, {}, str(tmp_path))
+    assert not (tmp_path / "loo_summary.csv").exists()
+    with pytest.raises(ValueError, match="finite"):
+        loo_summary_row(_loo([0.1]), label="all", k_threshold=threshold)
+
+
+def test_zero_threshold_and_nonfinite_counts_reach_report(tmp_path, capsys):
+    values = [-0.1, 0.0, 0.2, np.nan, np.inf, -np.inf]
+    row = emit_loo_summary({"all": _loo(values, 0.0)}, {}, str(tmp_path)).iloc[0]
+    assert row["good_k_threshold"] == 0.0
+    assert row["pareto_k_good"] == 2
+    assert row["pareto_k_bad"] == 1
+    assert row["pareto_k_nonfinite"] == 3
+    assert row["pareto_k_unusable"] == 4
+    render_loo_section(str(tmp_path))
+    text = capsys.readouterr().out
+    assert "4 of 6 observations (67%)" in text
+    assert "every one" not in text
+
+
+@pytest.mark.parametrize("script", ["loo_compare", "loso_compare"])
+def test_comparison_rows_keep_union_without_double_counting(script, capsys):
+    spec = importlib.util.spec_from_file_location(script, Path(__file__).parents[1] / "scripts" / f"{script}.py")
+    module = importlib.util.module_from_spec(spec)
+    # Some scripts declare dataclasses, which resolve their module by name.
+    import sys
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    builder = module._loo_summary_row if script == "loo_compare" else module._summary_row
+    row = builder("all", _loo([0.1, 0.8, np.nan, np.inf, -np.inf]), reff=0.8)
+    assert row["pareto_k_gt_0.7"] == 2
+    assert row["pareto_k_nonfinite"] == 3
+    assert row["pareto_k_unusable"] == 4
+    if script == "loo_compare":
+        row = module._loo_summary_row("all", _loo([0.1, np.nan]))
+        module._warn_if_unusable("all", row)
+        assert "50%" in capsys.readouterr().out
+
+
+def test_legacy_report_counts_missing_values_as_unusable(tmp_path, capsys):
+    table = emit_loo_summary({"all": _loo([0.1, np.nan, -np.inf])}, {}, str(tmp_path))
+    table.drop(columns=["pareto_k_nonfinite", "pareto_k_unusable"]).to_csv(tmp_path / "loo_summary.csv", index=False)
+    render_loo_section(str(tmp_path))
+    assert "2 of 3 observations (67%)" in capsys.readouterr().out
+
+
+def test_missing_counts_cannot_produce_reliable_verdict(tmp_path, capsys):
+    table = emit_loo_summary({"all": _loo([0.1])}, {}, str(tmp_path))
+    table["pareto_k_good"] = np.nan
+    table["pareto_k_unusable"] = np.nan
+    table.to_csv(tmp_path / "loo_summary.csv", index=False)
+    render_loo_section(str(tmp_path))
+    assert "reliability cannot be assessed" in capsys.readouterr().out
+
+
+def test_empty_loo_cannot_produce_reliable_verdict(tmp_path, capsys):
+    emit_loo_summary({"all": _loo([])}, {}, str(tmp_path))
+    render_loo_section(str(tmp_path))
+    assert "reliability cannot be assessed" in capsys.readouterr().out
+
+
+def test_interval_wrapper_uses_same_finite_draws_for_median_and_bounds():
+    from vocab_growth.intervals import summarise
+
+    samples = np.array([[1.0, 2.0, 3.0, np.inf, np.nan]])
+    got = summarise(samples, np.array([12.0]))
+    expected = summarise(samples[:, :3], np.array([12.0]))
+    pd.testing.assert_frame_equal(got, expected)

--- a/tests/test_publication_checks.py
+++ b/tests/test_publication_checks.py
@@ -15,6 +15,9 @@ from __future__ import annotations
 import functools
 import http.server
 import threading
+from contextlib import nullcontext
+from types import SimpleNamespace
+from urllib.parse import quote
 
 import pytest
 
@@ -97,3 +100,68 @@ def test_verify_published_reports_an_unreachable_host():
     failures = verify_published("http://127.0.0.1:9/", ["index.html"], timeout=1.0)
     assert len(failures) == 1
     assert failures[0].endswith(" index.html")
+
+
+@pytest.fixture
+def upload_report(tmp_path, monkeypatch):
+    from vocab_growth.storage import ValidatedFitOutput
+
+    names = ["figures/psi (dev).png", "tables/a+b.csv", "figures/café.png", "tables/50%20.csv", "assets/index.html"]
+    for name in names:
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("asset", encoding="utf-8")
+    (tmp_path / "index.html").write_text(
+        "".join(f'<a href="{name}">asset</a>' for name in names), encoding="utf-8"
+    )
+    (tmp_path / "trace.nc").write_bytes(b"excluded")
+    sent, requested = [], []
+
+    def upload_blob(name, data, **kwargs):
+        sent.append(name)
+        assert data.read()
+
+    client = SimpleNamespace(get_container_client=lambda name: SimpleNamespace(upload_blob=upload_blob))
+    monkeypatch.setattr("azure.storage.blob.BlobServiceClient", lambda *a, **k: client)
+    monkeypatch.setattr("azure.identity.DefaultAzureCredential", lambda: object())
+    monkeypatch.setenv("DSERESEARCH_BLOB_CONTAINER_URL", "https://acct.blob.core.windows.net/reports")
+
+    def request(url, **kwargs):
+        requested.append(url)
+        return nullcontext(SimpleNamespace(status=200))
+
+    monkeypatch.setattr("urllib.request.urlopen", request)
+    return ValidatedFitOutput(str(tmp_path)), names, sent, requested
+
+
+def test_upload_matches_raw_names_and_requests_encoded_urls(upload_report):
+    from vocab_growth.storage import upload_to_blob_storage
+
+    output, names, sent, requested = upload_report
+    report = upload_to_blob_storage(output, "model (dev)")
+    prefix = report.removesuffix("index.html")
+    assert "model%20%28dev%29/" in prefix
+    assert requested == [report, *(prefix + quote(name, safe="/") for name in sorted(names))]
+    assert len(sent) == len(names) + 1
+    assert not any(name.endswith("trace.nc") for name in sent)
+    assert report.endswith("/index.html") and not report.endswith("/assets/index.html")
+
+
+@pytest.mark.parametrize("skipped", ["figures/psi (dev).png", "tables/a+b.csv", "figures/café.png"])
+def test_upload_still_rejects_skipped_referenced_files(upload_report, skipped):
+    from vocab_growth.storage import upload_to_blob_storage
+
+    output, _, _, requested = upload_report
+    with pytest.raises(RuntimeError, match="were not uploaded") as error:
+        upload_to_blob_storage(output, "model", skip=lambda name: name == skipped)
+    assert skipped in str(error.value)
+    assert requested == []
+
+
+def test_nested_index_does_not_replace_skipped_root(upload_report):
+    from vocab_growth.storage import upload_to_blob_storage
+
+    output, _, _, requested = upload_report
+    with pytest.raises(RuntimeError, match="No index.html report"):
+        upload_to_blob_storage(output, "model", skip=lambda name: name == "index.html")
+    assert requested == []

--- a/tests/test_report_cells.py
+++ b/tests/test_report_cells.py
@@ -602,11 +602,11 @@ def test_loo_section_reports_a_clean_fit_as_reliable(tmp_path, capsys):
 
 
 def test_loo_section_flags_unreliable_importance_sampling(tmp_path, capsys):
-    row = {**_CLEAN_ROW, "pareto_k_good": 1128, "pareto_k_bad": 258, "pareto_k_very_bad": 30}
+    row = {**_CLEAN_ROW, "pareto_k_good": 1233, "pareto_k_bad": 258, "pareto_k_very_bad": 30}
     report_cells.render_loo_section(str(_loo_fit(tmp_path, [row])))
     out = capsys.readouterr().out
-    assert "288 of 1,521 observations (19%) exceed the threshold" in out
-    assert "30 of them above 1" in out
+    assert "288 of 1,521 observations (19%) have non-finite Pareto $k$ or exceed the threshold" in out
+    assert "30 finite values above 1" in out
 
 
 def test_hierarchical_fits_get_the_wrong_unit_explanation(tmp_path, capsys):
@@ -616,7 +616,7 @@ def test_hierarchical_fits_get_the_wrong_unit_explanation(tmp_path, capsys):
     threshold. Reporting that as unreliability without saying why would send a
     reader looking for a modelling fault that is not there.
     """
-    row = {**_CLEAN_ROW, "pareto_k_good": 1128, "pareto_k_bad": 258, "pareto_k_very_bad": 30}
+    row = {**_CLEAN_ROW, "pareto_k_good": 1233, "pareto_k_bad": 258, "pareto_k_very_bad": 30}
     fit = _loo_fit(tmp_path, [row], parameters=("eta_u", "tau_subj_u"))
     report_cells.render_loo_section(str(fit))
     out = capsys.readouterr().out
@@ -625,7 +625,7 @@ def test_hierarchical_fits_get_the_wrong_unit_explanation(tmp_path, capsys):
 
 
 def test_non_hierarchical_fits_do_not_get_that_explanation(tmp_path, capsys):
-    row = {**_CLEAN_ROW, "pareto_k_good": 1128, "pareto_k_bad": 258, "pareto_k_very_bad": 30}
+    row = {**_CLEAN_ROW, "pareto_k_good": 1233, "pareto_k_bad": 258, "pareto_k_very_bad": 30}
     fit = _loo_fit(tmp_path, [row], parameters=("eta",))
     report_cells.render_loo_section(str(fit))
     assert "wrong unit of prediction" not in capsys.readouterr().out

--- a/tests/test_sensitivity_compare.py
+++ b/tests/test_sensitivity_compare.py
@@ -309,7 +309,7 @@ def test_diagnostics_gate_hard_failure_in_the_payload_is_non_converged(tmp_path)
     assert gate.clean is False
 
 
-def test_diagnostics_gate_flags_unassessable_parameters_as_a_caveat(tmp_path):
+def test_diagnostics_gate_flags_unassessable_parameters_as_a_hard_failure(tmp_path):
     _write_gate_payload(
         tmp_path,
         passed=False,
@@ -320,7 +320,7 @@ def test_diagnostics_gate_flags_unassessable_parameters_as_a_caveat(tmp_path):
         unassessable_parameters=["tau_subj_q"],
     )
     gate = diagnostics_gate(str(tmp_path))
-    assert gate.converged is True
+    assert gate.converged is False
     assert gate.clean is False
     assert any("could not be assessed" in caveat for caveat in gate.caveats)
 

--- a/uv.lock
+++ b/uv.lock
@@ -550,8 +550,8 @@ wheels = [
 
 [[package]]
 name = "dse-research-utils"
-version = "0.12.5"
-source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.5#7b27e8e3ed1b16a5d5ea4eee8ea8789bab30358e" }
+version = "0.13.0"
+source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.13.0#458cc41b1dc33f4c0204919253ac92251c61b2bb" }
 dependencies = [
     { name = "arviz" },
     { name = "arviz-base" },
@@ -629,7 +629,7 @@ typecheck = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.12.5" }]
+requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.13.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Codex/GPT-6).

Upgrade `dse-research-utils` to v0.13.0 and migrate the consumer contracts identified in #309. Missing posterior variables now raise instead of silently changing LOO relative efficiency. Completed scans with unavailable diagnostics fail the hard gate with the right explanation. Upload checks match raw filenames and encode HTTP paths once.

- Retain non-finite and unusable Pareto-k counts in model and comparison tables, use the unusable count for warnings, and handle older model tables without treating missing diagnostics as reliable.
- Align sensitivity checks, report verdicts, and the registered R-hat exception with explicit scan status and unavailable diagnostic values. Handle null BFMI values and nested amendments.
- Pin the released commit in `uv.lock`, preserve the existing extras, and update the three instruction copies. Record the helper audit and output follow-up in [the migration note](notes/202609061630-research-utils-013-migration.md).

Validation passed with 2,243 tests passing and 11 skipped, including the slow tests. All 213 migration regression tests passed again after the final report edits. `uv sync --locked`, Ruff, mypy, formatting and spelling checks pass. Azure uploads and HTTP responses were simulated.

Quarto rendered labelled fixtures for clean legacy diagnostics, completed but unassessable diagnostics, failed scans, and LOO with a zero threshold and non-finite values. The rendered explanations and counts were checked. No complete fitted reports or traces are available in this checkout, so rendering existing study results remains a follow-up. This repository does not use the changed shared HSGP constructors. Existing publication provenance checks still require current fits; this PR does not refit or publish study results.

Closes #309
