### PR TITLE
Upgrade to dse-research-utils 0.14.0 and adopt the shared helpers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.13.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.14.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.13.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.14.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This project is an exploratory study of vocabulary development in children with 
 
 The Python package `vocab_growth` (in `src/vocab_growth/`) defines a series of PyMC models that are fitted to vocabulary assessment data aggregated from multiple international studies. Reports are authored in Quarto (`.qmd`).
 
-This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.13.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
+This project depends on a sibling repository, `dseinternational/research`, which provides shared utilities via the `dse_research_utils` package. It is installed from the public git tag `v0.14.0` (see [Environment setup](#environment-setup)); a commented local-dev override in `pyproject.toml` lets you point at a sibling `../research/src/python` checkout instead.
 
 ## Environment setup
 

--- a/docs/report/_report_data.qmd
+++ b/docs/report/_report_data.qmd
@@ -15,6 +15,7 @@ import pandas as pd
 from dse_research_utils.report.data import ReportData
 from dse_research_utils.report.data import num as _num
 from dse_research_utils.report.data import show_or_pending as _show_or_pending
+from dse_research_utils.report.readers import nearest_row
 from vocab_growth.models.definitions import MODEL_REGISTRY
 
 FIG_ROOT = Path("figures")
@@ -109,8 +110,8 @@ def comp_at(name, match_col, match_val, col):
     df = comp_load(name)
     if df is None or match_col not in df or col not in df:
         return None
-    row = df.iloc[(df[match_col] - match_val).abs().argmin()]
-    return row[col]
+    row = nearest_row(df, key=match_col, at=match_val)
+    return None if row is None else row[col]
 
 
 def words(model_id, summary, age_months, column="Ey_median"):
@@ -177,7 +178,7 @@ def comp_row(name, grid_col, grid_val, *, prefix="d", bare=False):
     if bare:
         df = df.rename(
             columns={c: f"{prefix}_{c}" for c in _BARE_COLS if c in df.columns})
-    return df.iloc[int((df[grid_col] - grid_val).abs().argmin())]
+    return nearest_row(df, key=grid_col, at=grid_val)
 
 
 def band(row, prefix="d", fmt="{:.1f}", unit=""):

--- a/notes/202609071034-research-utils-014-migration.md
+++ b/notes/202609071034-research-utils-014-migration.md
@@ -1,0 +1,96 @@
+> [!NOTE]
+> Drafted by an LLM-based AI tool (Claude Code/Opus 5).
+
+<!-- cspell:words nonfinite dtypes umask netCDF PSIS reff -->
+
+# Shared library 0.14.0 migration
+
+Issue [#313](https://github.com/dseinternational/vocabulary-growth/issues/313) upgrades `dse-research-utils` from 0.13.0 to 0.14.0 and routes this repository's remaining local copies through the helpers that release adds. The lockfile selects commit `50390f4f9cd19033e3d0dc9bd050b383bd413c36`. The existing extras and shared ownership of scientific dependencies are unchanged, and no other locked package moved. The work followed the tagged [0.14.0 upgrade notes](https://github.com/dseinternational/research/blob/v0.14.0/docs/migrating-to-0.14.md) and [combined migration guide](https://github.com/dseinternational/research/blob/v0.14.0/docs/consolidation-migration.md).
+
+The guide's own summary of what the release does and does not establish applies here: it moved library code, and it did not migrate this repository's production code, refit anything or publish anything. What follows is what this repository decided, and what was checked.
+
+## What now delegates, and what deliberately does not
+
+### Files, directories and provenance
+
+`write_json_atomic` keeps its serialisation — two-space indent, sorted keys, the existing `_json_default` encoder, trailing newline — and replaces its own temporary-file dance with `storage.files.atomic_write`. The stored bytes matter beyond readability: a `comparison_manifest.json` records the SHA-256 of each contributing fit's manifest, so a changed encoding would invalidate every comparison on disk.
+
+The shared helper creates its temporary file with `mkstemp`, which is owner-only. Every file this repository has written came from a plain `open` and carries `0o666 & ~umask`, and those files are read back by other accounts on the fitting VM and by the uploader, so `write_atomic` restores that mode explicitly. It is now the single place that decision is made; `scripts/sync_report_figures.py` writes its two generated tables through it as well.
+
+`promote_staged_fit` delegates its two renames to `storage.directories.promote_directory`, which validates the three paths against each other — no nesting, no aliasing through a mounted tree, no symlink in any component, one filesystem — before it touches the destination, and restores the previous directory itself when the second rename fails. Two decisions stay local because the helper leaves them to the caller. The lock is `fit_artifacts.PROMOTION_LOCK`, whose scope is threads of one process: a fit promotes the one `models/<label>/` directory it staged, and two concurrent fits of the same model into the same output root would already be racing for that directory long before promotion. The retained backup is deleted on success, as it always was — `.previous` is a rollback slot, not an archive, and a fit's output can be tens of gigabytes — and a cleanup failure after a successful promotion is reported rather than raised.
+
+`promote_directory` refuses a symlinked ancestor, and on the fitting VM `<repo>/output` _is_ a symlink to a scratch volume, as is `/tmp` on macOS. `fit_artifacts.promotion_path` therefore resolves the parent chain deliberately, which is what the guide documents for that case, and leaves the final component alone so a destination that is itself a symlink is still refused. `scripts/sync_report_figures.py` promotes its figure cache through the same rule.
+
+`git_metadata` keeps its four manifest keys and their meanings and obtains them from `metadata.provenance.git_snapshot`: one bounded `status --porcelain=v2 --branch` call instead of three commands, with inherited `GIT_*` overrides stripped and optional index locks and the filesystem-monitor hook disabled. `dirty` still counts staged, unstaged, unmerged and untracked changes and excludes ignored files, and is still `None` — never `False` — when the query could not establish it, because `validate_fit_output` turns `dirty is not False` into a refusal to resume or publish. The 10-second timeout this repository has always allowed is passed explicitly rather than inheriting the shared default of 5. `comparisons_provenance._file_sha256` is now `sha256_file` plus this repository's `sha256:` prefix.
+
+Two provenance values are deliberately **not** delegated. `source_data_hash` is one digest over `name + NUL + bytes + NUL` for every CSV in `data/`, not a per-file digest; changing its composition would invalidate every recorded raw-data fingerprint. The manifest's `runtime.packages` enumerates every installed distribution and reads each one's `direct_url.json` for a commit, which `package_versions` — an explicit name list returning versions only — cannot reproduce.
+
+Two write-then-replace sites elsewhere keep their own code, with reasons. `scripts/compact_traces.py` writes the rewritten trace while the source `DataTree` is still open and verifies it only after closing that handle; expressing that as one callback would mean two concurrent handles on the same netCDF file. `scripts/prepare_data.py` writes its DuckDB database through a connection opened at the top of the script, so the callback model would mean restructuring the whole script for no change in behaviour.
+
+### Administration-level likelihood aggregation
+
+`administration_loo.administration_log_likelihood` now hands its factors to `statistics.log_likelihood.aggregate_log_likelihood` with the output units stated explicitly: `unit_ids=np.flatnonzero(any_mask)`, the administration rows of the analysis frame, and `row_unit_ids=np.flatnonzero(mask)` per factor. `obs_joint` therefore _is_ the frame position, rather than a rank among the kept rows that happened to coincide with it.
+
+Everything that decides which unit a row belongs to stays local: the factor/mask pairs each engine declares, the `None` return for a trace missing a factor or its mask, and the issue #266 finding-3 check that a mask marking recorded rather than likelihood rows fails loudly. One refusal is added here rather than taken from the library — a trace variable declared as two factors would be summed onto the same administrations twice, and the shared duplicate-array guard cannot see it because indexing a `Dataset` twice yields two distinct objects.
+
+The shared aggregator adds two refusals of its own: `NaN` or `+inf` in a likelihood raises instead of propagating into a plausible-looking score, while `-inf` is retained because an impossible observation genuinely has that log likelihood. It also permits a zero-row factor, which the previous reshape did not.
+
+`scripts/loo_compare.py` carried the original of this arithmetic and kept its own copy of it. It now delegates too, keeping its `y_joint` variable name — the comparison tables and every regenerated CSV use it — and its two refusals, since it is pointed at arbitrary traces on disk and must say why one cannot be scored.
+
+### Predictive summaries
+
+`models/calibration.predictive_calibration_table` takes its per-observation quantities from `statistics.predictive.predictive_observation_checks`: linear quantiles at `(1 - p) / 2` and its complement, closed-interval inclusion, the predictive mass inside those bounds, and the midpoint PIT with the same `(1 - sum p_k^3) / 12` reference. The age banding, the observed and predictive zero rates, the group means and the written table's columns and order stay here.
+
+Interval widths are differenced in the bounds' own dtype and stored as float64 before the group means, which is the arithmetic the written table has always carried. Non-finite observations are refused here rather than by the shared checks, so the message names the table being written and how many rows are unusable; the shared helper's own empty-input refusal sits behind this repository's, which fires first.
+
+`write_trace_calibration` extracts its draws through `statistics.samples.sample_matrix` and takes the observed values through `SampleMatrix.observed_values`. That is a real change: the observed group and the posterior-predictive group are separate arrays on the trace and were previously flattened and paired by position, so a re-labelled or reordered observed group would have been scored against the wrong replications. Every engine declares the observation dimension in the model's `coords`, so the labels are present in a real trace; the test fixtures now carry them too.
+
+### Report reads and nearest-row access
+
+`report_cells` reads its artefacts through `report.readers.read_csv` / `read_json`, which distinguish present, missing and invalid. The policy is this repository's: a file this engine never writes renders as a pending-fit placeholder, and a damaged one does not. `render_diagnostic_verdict`, `render_loo_section` and `render_variation_table` say which of the two it is; `_read` and `fitted_parameters` raise `ReportArtefactError`, because a reassuring "this fit has yet to produce it" is the wrong sentence about a corrupt file.
+
+`empty_document` — a file with no columns at all — is deliberately treated as an empty table rather than damage. Several writers here build a table with `pd.DataFrame(rows)` and write it whatever `rows` contains; with no rows that produces a column-less frame and `to_csv` writes a single newline. `render_calibration_section` is where that mattered: it read the file with a bare `pd.read_csv` and a fit whose trace carried no recognised outcome aborted the report cell with `EmptyDataError`. It now prints that the table is empty.
+
+`read_manifest` is deliberately left on the permissive parser. `write_json_atomic` serialises with Python's default `allow_nan`, so a definition field holding a non-finite float is written as a bare `NaN` token, and every manifest already on disk has to stay readable. The shared strict reader is used only for `diagnostics_summary.json`, which the shared diagnostics writer sanitises before writing.
+
+`report.readers.nearest_row` replaces the two single-row lookups in `report_cells` — including the reference-child calibration's 0.6-month bound, which is now an explicit `max_distance` — and `comp_at` / `comp_row` in `docs/report/_report_data.qmd`. The two multi-row selections in that file keep their positional `argmin`: they build a set of row _positions_ to slice with, which `nearest_row` deliberately does not return.
+
+### Report assets and upload checks
+
+`publication_checks` is now an adapter over `report.assets`, which parses the HTML rather than matching quoted strings and reports each reference's state instead of dropping the ones it cannot use. `include_navigation=True` is deliberate: these pages offer their summary tables as ordinary download links, which the previous checks already treated as required. `follow_pages` stays off, because both publishers here upload a single rendered page and its assets.
+
+Three behaviours changed, all of them in the direction the checks exist for.
+
+- A required reference to a file that is not on disk is now a failure. The previous scanner dropped it, on the grounds that the render should have complained — so a page referencing a figure that was never written published silently, which is the 2026-09-03 comparison-book failure one step earlier. `scripts/publish_comparison.py` stops before collecting, and the model-report upload stops before requesting anything.
+- `base href`, `srcset` and root-relative URLs are reported as unsupported rather than certified. Each of them decides which file a browser actually requests.
+- An `href` is URL-decoded once. The existing test linked a file literally named `50%20.csv` as `href="50%20.csv"`, which asks the browser for `50 .csv`; the guide names that test as not a valid compatibility target. Both the mismatch and the correctly encoded `50%2520.csv` are now pinned.
+
+`upload_to_blob_storage` gained an optional `fetch_status` transport, threaded through to `verify_published_assets`. It is how the publication path is now exercised end to end in the tests; before it, one of those tests reached a real Azure endpoint because the default transport is `build_opener(...).open`, not the `urlopen` the test patched.
+
+### HSGP construction
+
+`models/common.get_hsgp_hyperparams` returns the two lists `pm.gp.HSGP` takes, taken from a realised `HSGPDesign`; `hsgp_design_for` returns the record itself. The calibration is unchanged — `c_floor=None`, so no boundary floor is imposed and the basis count and boundary factor are exactly PyMC's `approx_hsgp_hyperparams` recommendation, with the boundary the recommendation's factor times the domain half-range and the centre its midpoint.
+
+`gp_utils._gp_from_mean` builds the object with `create_hsgp`, which fixes the centre through a public `prior_linearized` call on the centre alone. That replaces an assignment to PyMC's private `_X_center`. The bounded length-scale prior, the variable names and their order, the dimensions, the observed-row projection and the anchoring are untouched. The unpinned branch remains for the exploratory modules and the experiment arms that deliberately test PyMC's default centring; `create_hsgp` requires an explicit centre, and those have none.
+
+## What was checked
+
+Numerical equivalence was established by comparing each migrated function against its previous implementation, inlined, rather than by reasoning about the code.
+
+- **Administration likelihood.** 200 randomised cases — one to three factors, one of them a matrix-valued composition factor with a 2x2 cell dimension, over 3 to 40 administrations and 1 to 4 chains — are identical bit-for-bit, coordinates included. On a 60-administration, 4x500-draw case the pointwise PSIS-LOO `elpd_i` and Pareto-k arrays are identical too. Equal totals would not have established that; the pointwise arrays are what a comparison turns on.
+- **Predictive calibration.** 364 complete tables compared with `assert_frame_equal(check_exact=True, check_dtype=True)` across 120 randomised shapes and three chunk sizes, plus one case each at float64, float32, int32 and int64 predictive draws. All identical, dtypes included. The float32 case is the one the guide flags, because the shared helper preserves the input reduction dtype in its bounds and medians.
+- **HSGP.** 500 randomised calibrations reproduce the previous `m`, `L` and centre exactly. 200 randomised constructions give a bit-for-bit equal basis, spectral density and pinned centre under the factory and under the private assignment. The `trend_and_gp` latent draws identically under both for three centres and three seeds, with the same free RVs in the same order (`p_slope_low`, `p_slope_hi`, `ell_unit`, `eta`, `g_unit_hsgp_coeffs`) and the same deterministics. Saved geometry replays identically on a full grid, a subset of it, and a grid extended beyond the observed range — the issue #234 property, now a property of the record rather than of a pin.
+
+`uv sync --locked`, Ruff, mypy, Prettier and CSpell pass. The complete suite selected with `-m "slow or not slow" -n auto --dist loadfile` passes: 2,283 tests, 11 skipped, in about three minutes, including the slow sampling and numerical-optimisation tests.
+
+This checkout contains no complete fitted model output, so the report check is again a render of the actual report functions against labelled synthetic fixtures rather than of study results. Quarto rendered a page exercising a healthy fit, a fit whose diagnostics payload and LOO summary are corrupt, a fit whose calibration table is the column-less file described above, and an absent fit. The three states read as intended: the healthy fit renders its gate verdict and LOO table; the damaged one says each artefact "could not be read (parse_error)"; the absent one says the file is absent. The `_report_data.qmd` helpers were executed against a synthetic figure cache, which covers `val`, `words`, `comp_at`, `comp_row` and `comp_band`.
+
+## Identity, refits and publication
+
+Adopting these helpers changes files across `src/vocab_growth/`, and the executable-code signature (`models/implementation_identity.py`) hashes every module in the package together with the installed version of `dse-research-utils`. Both moved. Every existing fit therefore fails the signature check under `resume`, `sync` and `publish`, and needs a reporting-quality refit before its results are syndicated into the report or built on. That is the intended behaviour of that check and is not bypassed here; `render` and `provisional-sync` do not ask for the signature, so an existing fit can still be re-rendered and reviewed.
+
+No manifest is rewritten. Historical manifests remain records of the code that actually produced them.
+
+Model definitions are untouched, so `fit_manifest.json`'s `model.definition` payload is unchanged and no definition-level refit is implied beyond the signature. The verified equivalences above say what a refit should reproduce: the same administration likelihood arrays and pointwise LOO, the same calibration tables, and the same HSGP basis. A refit is required because the code that produces them moved, not because the numbers did.
+
+Before updating published results, refit at reporting quality, regenerate the comparison tables so they carry manifests fingerprinting the new fits, and re-render. No reporting-quality refits and no publication uploads were performed for this migration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ environments = [
 # dse-research-utils isn't published to PyPI — resolve it from the public git
 # tag. To develop against a sibling checkout instead, comment this out and use:
 #   dse-research-utils = { path = "../research/src/python", editable = true }
-dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.13.0" }
+dse-research-utils = { git = "https://github.com/dseinternational/research.git", subdirectory = "src/python", tag = "v0.14.0" }
 
 [tool.hatch.version]
 path = "src/vocab_growth/__init__.py"

--- a/scripts/loo_compare.py
+++ b/scripts/loo_compare.py
@@ -57,6 +57,10 @@ import pandas as pd
 import xarray as xr
 
 from vocab_growth import environment as env
+from vocab_growth.administration_loo import (
+    LikelihoodFactor,
+    administration_log_likelihood,
+)
 from vocab_growth.loo_reff import reff_or_default
 from vocab_growth.models.definitions import MODEL_REGISTRY, ModelType
 
@@ -176,7 +180,19 @@ def _attach_joint_log_likelihood(idata: xr.DataTree) -> None:
     pre-#236 behaviour) made every paired administration two held-out cases
     with two PSIS weights, and when its understood factor was held out the
     spoken factor still conditioned on the observed understood count —
-    leaking information relative to leave-one-administration-out."""
+    leaking information relative to leave-one-administration-out.
+
+    The summation itself is :func:`vocab_growth.administration_loo.administration_log_likelihood`,
+    which since #266 finding 4 is where the fit pipeline computes the same
+    thing, and which since the shared library's 0.14.0 release delegates to
+    :func:`dse_research_utils.statistics.log_likelihood.aggregate_log_likelihood`.
+    This function was the original of that arithmetic and kept its own copy;
+    two copies of a sum whose rows must line up is one copy too many. What
+    stays here are the two refusals this script owes its callers -- it is
+    pointed at an arbitrary trace on disk, so it must say *why* one cannot be
+    scored rather than quietly returning nothing -- and the ``y_joint`` name,
+    which the comparison tables and every regenerated CSV already use.
+    """
     ll = idata.log_likelihood
     if "y_joint" in ll.data_vars:
         return
@@ -199,23 +215,18 @@ def _attach_joint_log_likelihood(idata: xr.DataTree) -> None:
             f"({u.sizes[u_dim]}, {s.sizes[s_dim]}); factors cannot be mapped "
             "to administrations."
         )
-    any_mask = u_mask | s_mask
-    # Position of each administration row among the rows kept in y_joint.
-    joint_pos = np.cumsum(any_mask) - 1
-    u_vals = u.transpose("chain", "draw", u_dim).values
-    s_vals = s.transpose("chain", "draw", s_dim).values
-    joint = np.zeros(u_vals.shape[:2] + (int(any_mask.sum()),), dtype=float)
-    joint[..., joint_pos[u_mask]] += u_vals
-    joint[..., joint_pos[s_mask]] += s_vals
-    joint_da = xr.DataArray(
-        joint,
-        dims=("chain", "draw", "obs_joint"),
-        coords={
-            "chain": u["chain"].values,
-            "draw": u["draw"].values,
-            "obs_joint": np.flatnonzero(any_mask),
-        },
+    joint_da = administration_log_likelihood(
+        idata,
+        (
+            LikelihoodFactor("y_u_obs", "obs_u_mask"),
+            LikelihoodFactor("y_s_obs", "obs_s_mask"),
+        ),
     )
+    if joint_da is None:
+        raise ValueError(
+            "no administration in this trace carries an understood or spoken "
+            "likelihood row, so there is nothing to score."
+        )
     idata.log_likelihood = ll.assign({"y_joint": joint_da})
 
 

--- a/scripts/publish_comparison.py
+++ b/scripts/publish_comparison.py
@@ -49,7 +49,13 @@ import subprocess
 import sys
 
 from vocab_growth import environment as env
-from vocab_growth.publication_checks import referenced_assets, verify_published
+from vocab_growth.publication_checks import (
+    describe_failures,
+    inspect_report,
+    local_failures,
+    present_assets,
+    verify_published,
+)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BOOK_DIR = os.path.join(REPO_ROOT, "docs", "comparison")
@@ -106,12 +112,29 @@ def render() -> None:
 
 
 def collect(destination: str) -> list[str]:
-    """Assemble exactly the page and the assets it references."""
+    """Assemble exactly the page and the assets it references.
+
+    A reference the page makes that no upload could satisfy -- a figure that was
+    never written, a link out of the published directory, a construct whose
+    target cannot be determined -- stops the collection here. Before the shared
+    inspection those were silently dropped, so the page published referring to
+    a file nobody had noticed was absent, which is the 2026-09-03 failure in a
+    different disguise.
+    """
+    inspection = inspect_report(BOOK_HTML)
+    failures = local_failures(inspection)
+    if failures:
+        listed = "\n  ".join(describe_failures(failures))
+        raise SystemExit(
+            f"[collect] {BOOK_HTML} requires {len(failures)} file(s) that cannot "
+            f"be published:\n  {listed}\nRe-render the book, or correct the "
+            "reference, before publishing."
+        )
     if os.path.isdir(destination):
         shutil.rmtree(destination)
     os.makedirs(destination)
     shutil.copy2(BOOK_HTML, os.path.join(destination, "index.html"))
-    assets = referenced_assets(BOOK_HTML)
+    assets = present_assets(inspection)
     for relative in assets:
         target = os.path.join(destination, relative)
         os.makedirs(os.path.dirname(target), exist_ok=True)
@@ -127,8 +150,10 @@ def verify(base_url: str, assets: list[str], timeout: float = 30.0) -> list[str]
     Shared with the model-report upload through ``publication_checks`` since
     #289 task 4.10, so the two paths cannot drift.
     """
-    return verify_published(
-        base_url.rsplit("/", 1)[0], ["index.html", *assets], timeout=timeout
+    return describe_failures(
+        verify_published(
+            base_url.rsplit("/", 1)[0], ["index.html", *assets], timeout=timeout
+        )
     )
 
 

--- a/scripts/sync_report_figures.py
+++ b/scripts/sync_report_figures.py
@@ -38,9 +38,11 @@ import shutil
 import tempfile
 import uuid
 from dataclasses import asdict
+from pathlib import Path
 from typing import Any
 
 import dse_research_utils.statistics.models.sampling as sampling
+from dse_research_utils.storage.directories import promote_directory
 
 from vocab_growth import environment as env
 from vocab_growth.analysis_frames import expected_analysis_frame_hash
@@ -50,12 +52,15 @@ from vocab_growth.comparisons_provenance import (
 )
 from vocab_growth.fit_artifacts import (
     DIAGNOSTICS_SUMMARY_FILENAME,
+    PROMOTION_LOCK,
     FitValidationError,
     fit_validation_kwargs,
+    promotion_path,
     read_convergence_caveats,
     read_json,
     source_data_hash,
     validate_fit_output,
+    write_atomic,
 )
 from vocab_growth.models.catalogue import CATALOGUE
 from vocab_growth.models.definitions import MODEL_REGISTRY
@@ -67,15 +72,22 @@ CONVERGENCE_DIAGNOSTICS_TABLE = "convergence_diagnostics.csv"
 
 
 def _write_csv(filename: str, header: list[str], rows: list[list[Any]]) -> str:
-    """Atomically (re)write one generated table into the report figure cache."""
-    os.makedirs(env.REPORT_FIGS_DIR, exist_ok=True)
+    """Atomically (re)write one generated table into the report figure cache.
+
+    The replacement is the shared ``atomic_write``; the ``newline=""`` and the
+    ``csv`` writer stay here, because they are what makes these tables the same
+    bytes on every platform (without it, ``csv`` and the text layer each add a
+    carriage return on Windows).
+    """
     path = os.path.join(env.REPORT_FIGS_DIR, filename)
-    tmp = f"{path}.{uuid.uuid4().hex}.tmp"
-    with open(tmp, "w", encoding="utf-8", newline="") as handle:
-        writer = csv.writer(handle)
-        writer.writerow(header)
-        writer.writerows(rows)
-    os.replace(tmp, path)
+
+    def write_temporary(temporary: Path) -> None:
+        with temporary.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(header)
+            writer.writerows(rows)
+
+    write_atomic(path, write_temporary)
     return path
 
 
@@ -159,7 +171,19 @@ def _write_convergence_records(model_sources: list[tuple[str, str]]) -> None:
 
 
 def _sync_dir(src: str, dst: str) -> int:
-    """Replace ``dst`` with an allowlisted snapshot of ``src``."""
+    """Replace ``dst`` with an allowlisted snapshot of ``src``.
+
+    The staging tree is built here -- the allowlist is the point of this
+    function -- and the two renames are the shared ``promote_directory``. The
+    lock is this process's own promotion lock: one sync run replaces each
+    cached directory once, and a second concurrent run over the same checkout
+    would already be racing for these paths before it reached promotion.
+
+    The retained backup is removed on success, as it was before: this cache is
+    rebuilt from ``output/`` by rerunning the script, so a retained copy is
+    only clutter inside the checkout. A cleanup failure after a successful
+    promotion is reported, not raised.
+    """
     parent = os.path.dirname(dst)
     os.makedirs(parent, exist_ok=True)
     staged = tempfile.mkdtemp(prefix=f".{os.path.basename(dst)}-", dir=parent)
@@ -172,17 +196,17 @@ def _sync_dir(src: str, dst: str) -> int:
                 shutil.copy2(source, os.path.join(staged, name))
                 copied += 1
 
-        had_destination = os.path.exists(dst)
-        if had_destination:
-            os.replace(dst, backup)
-        try:
-            os.replace(staged, dst)
-        except BaseException:
-            if had_destination and os.path.exists(backup):
-                os.replace(backup, dst)
-            raise
-        if had_destination:
-            shutil.rmtree(backup)
+        result = promote_directory(
+            promotion_path(staged),
+            promotion_path(dst),
+            backup=promotion_path(backup),
+            lock=PROMOTION_LOCK,
+        )
+        if result.backup is not None:
+            try:
+                shutil.rmtree(result.backup)
+            except OSError as exc:
+                print(f"  warning: could not remove {result.backup}: {exc}")
     finally:
         if os.path.isdir(staged):
             shutil.rmtree(staged)

--- a/src/vocab_growth/administration_loo.py
+++ b/src/vocab_growth/administration_loo.py
@@ -33,7 +33,13 @@ administrations, silently.
 The mechanics are ``scripts/loo_compare.py``'s ``_attach_joint_log_likelihood``,
 which has computed this correctly for the bivariate case since #236 -- generalised
 to any number of factors, including matrix-valued ones, and moved where the fit
-pipeline itself can use it.
+pipeline itself can use it. Since the shared library's 0.14.0 release the
+summation itself is
+:func:`dse_research_utils.statistics.log_likelihood.aggregate_log_likelihood`,
+which takes the output units *explicitly* rather than inferring them from a
+mask. What stays here is everything that decides which unit a row belongs to:
+the factor/mask pairs each engine declares, the refusal to score a partial set
+of factors, and the finding-3 check below.
 
 **Repeated administrations of the same child remain separate cases.** This
 scores prediction of another administration like those in the frame, not
@@ -47,6 +53,12 @@ from dataclasses import dataclass
 
 import numpy as np
 import xarray as xr
+from dse_research_utils.statistics.log_likelihood import (
+    LogLikelihoodFactor as SharedLikelihoodFactor,
+)
+from dse_research_utils.statistics.log_likelihood import (
+    aggregate_log_likelihood,
+)
 
 #: Name of the combined pointwise likelihood attached to the trace, and the
 #: dimension it is indexed by. ``obs_joint`` is the name
@@ -100,11 +112,35 @@ def administration_log_likelihood(
     present with a mask that does not match its rows **does** raise: that is the
     finding-3 defect, and silently summing the wrong rows onto the wrong
     administrations is exactly what must not happen.
+
+    The shared aggregator adds two refusals this had none of. A likelihood
+    containing ``NaN`` or ``+inf`` raises instead of propagating into a
+    plausible-looking score, while ``-inf`` is retained because an impossible
+    observation genuinely has that log likelihood. Values are summed in
+    float64, which every engine here already stores. Declaring one trace
+    variable as two factors is refused here rather than by the shared helper --
+    see the comment on the check.
     """
     log_likelihood = getattr(trace, "log_likelihood", None)
     constant_data = getattr(trace, "constant_data", None)
     if log_likelihood is None or constant_data is None:
         return None
+
+    # Selecting non-overlapping factors is the caller's responsibility, and the
+    # shared aggregator cannot check it for us: indexing a Dataset twice yields
+    # two distinct objects, so its own duplicate-array guard does not see a
+    # variable named twice. One repeated name is the whole of the overlap this
+    # repository can have -- the factor tuples are engine-declared constants
+    # over disjoint trace variables -- and it would double the term rather than
+    # fail, producing a total that is simply wrong with nothing in the result
+    # to show it.
+    names = [factor.variable for factor in factors]
+    if len(set(names)) != len(names):
+        raise ValueError(
+            "A log-likelihood factor was declared more than once "
+            f"({sorted(name for name in set(names) if names.count(name) > 1)}); "
+            "its contribution would be summed onto the same administrations twice."
+        )
 
     usable: list[tuple[xr.DataArray, np.ndarray]] = []
     for factor in factors:
@@ -134,30 +170,38 @@ def administration_log_likelihood(
     if not any_mask.any():
         return None
 
-    # Position of each administration among the rows the combined score keeps.
-    position = np.cumsum(any_mask) - 1
-    template = usable[0][0]
-    n_chain = template.sizes["chain"]
-    n_draw = template.sizes["draw"]
-    combined = np.zeros((n_chain, n_draw, int(any_mask.sum())), dtype=float)
-
-    for array, mask in usable:
-        dim = _factor_dim(array)
-        values = array.transpose("chain", "draw", dim, ...).values
-        if values.ndim > 3:
-            # A composition factor: sum its cells into the row's contribution.
-            values = values.reshape(n_chain, n_draw, values.shape[2], -1).sum(axis=-1)
-        np.add.at(combined, (slice(None), slice(None), position[mask]), values)
-
-    return xr.DataArray(
-        combined,
-        dims=("chain", "draw", ADMINISTRATION_DIM),
-        coords={
-            "chain": template["chain"].values,
-            "draw": template["draw"].values,
-            ADMINISTRATION_DIM: np.flatnonzero(any_mask),
-        },
+    # The unit is the administration row of the analysis frame, named by its
+    # own position in that frame. Handing the shared helper the frame positions
+    # -- rather than a mask, or a rank among the kept rows -- is what makes the
+    # mapping legible: `obs_joint` then *is* `np.flatnonzero(any_mask)`, the
+    # same coordinate the combined score has carried since #266, and a factor
+    # whose mask disagrees with its rows can no longer land on a neighbour.
+    combined = aggregate_log_likelihood(
+        [
+            SharedLikelihoodFactor(
+                values=array,
+                row_dim=_factor_dim(array),
+                # Rows of this factor, in the order it stores them, named by
+                # the administration each covers.
+                row_unit_ids=np.flatnonzero(mask),
+                # A composition factor is stored per row *and* per cell; the
+                # cells are summed within the row, exactly as ArviZ folds a
+                # pointwise likelihood's trailing dimensions.
+                event_dims=tuple(
+                    dim
+                    for dim in array.dims
+                    if dim not in ("chain", "draw", _factor_dim(array))
+                ),
+            )
+            for array, mask in usable
+        ],
+        unit_ids=np.flatnonzero(any_mask),
+        unit_dim=ADMINISTRATION_DIM,
     )
+    # The shared helper names its result `log_likelihood`; this one is stored
+    # under `ADMINISTRATION_VAR`, and a name that says otherwise would be read
+    # back from the trace.
+    return combined.rename(ADMINISTRATION_VAR)
 
 
 def attach_administration_log_likelihood(

--- a/src/vocab_growth/comparisons_provenance.py
+++ b/src/vocab_growth/comparisons_provenance.py
@@ -31,9 +31,10 @@ source is caught the way one that outlives a refit is.
 
 from __future__ import annotations
 
-import hashlib
 import os
 from datetime import UTC, datetime
+
+from dse_research_utils.metadata.provenance import sha256_file
 
 from vocab_growth.fit_artifacts import (
     FIT_MANIFEST_FILENAME,
@@ -45,11 +46,15 @@ COMPARISON_MANIFEST_FILENAME = "comparison_manifest.json"
 
 
 def _file_sha256(path: str) -> str:
-    digest = hashlib.sha256()
-    with open(path, "rb") as source:
-        for chunk in iter(lambda: source.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return f"sha256:{digest.hexdigest()}"
+    """The recorded digest of one file: the shared hash, this project's prefix.
+
+    :func:`dse_research_utils.metadata.provenance.sha256_file` returns the bare
+    lowercase hexadecimal digest of the file's bytes, read in the same bounded
+    chunks; the ``sha256:`` prefix is this repository's stored form and stays
+    here, so every digest already written into a ``comparison_manifest.json``
+    still compares equal.
+    """
+    return f"sha256:{sha256_file(path)}"
 
 
 def fit_manifest_fingerprint(model_output_dir: str) -> dict:

--- a/src/vocab_growth/fit_artifacts.py
+++ b/src/vocab_growth/fit_artifacts.py
@@ -16,13 +16,18 @@ import json
 import math
 import os
 import shutil
-import subprocess
+import threading
 import uuid
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, is_dataclass
 from datetime import UTC, datetime
 from enum import Enum, StrEnum
 from pathlib import Path
 from typing import Any, Literal
+
+from dse_research_utils.metadata.provenance import git_snapshot
+from dse_research_utils.storage.directories import promote_directory
+from dse_research_utils.storage.files import atomic_write
 
 # `fit_identity` defers its own import of this module to call time, so this is
 # a one-way edge rather than a cycle.
@@ -88,14 +93,64 @@ def read_json(path: str | os.PathLike[str]) -> dict[str, Any]:
     return payload
 
 
+def _umask_file_mode() -> int:
+    """The mode an ordinary ``open(path, "w")`` would give a new file.
+
+    :func:`dse_research_utils.storage.files.atomic_write` creates its temporary
+    file with :func:`tempfile.mkstemp`, which is owner-only (0600) by design.
+    Every manifest, state file and comparison manifest this repository has
+    written was created by a plain ``open`` instead, so it carries
+    ``0o666 & ~umask`` -- readable by the group and by others under the usual
+    022. Those artefacts are read back by other accounts on the shared fitting
+    VM and by the uploader, so narrowing them to 0600 is a behaviour change,
+    not a hardening: this restores the historical mode explicitly rather than
+    inheriting whichever one the helper happens to use.
+
+    ``os.umask`` is the only way to read the process umask before 3.15, and it
+    is a read-modify-write. The window is between two consecutive syscalls in
+    the writing thread; fits create these files from one thread, outside
+    sampling.
+    """
+    current = os.umask(0o022)
+    os.umask(current)
+    return 0o666 & ~current
+
+
+def write_atomic(
+    path: str | os.PathLike[str], write_temporary: Callable[[Path], object]
+) -> None:
+    """:func:`dse_research_utils.storage.files.atomic_write`, with this repo's mode.
+
+    The one place the file-mode decision is made. Every other writer in this
+    repository goes through here so a manifest, a fit-state file and a cached
+    report table cannot end up with three different modes.
+    """
+
+    def write_and_share(temporary: Path) -> None:
+        write_temporary(temporary)
+        os.chmod(temporary, _umask_file_mode())
+
+    atomic_write(path, write_and_share)
+
+
 def write_json_atomic(path: str, payload: dict[str, Any]) -> None:
-    """Write metadata atomically so interruption cannot leave partial JSON."""
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    temporary = f"{path}.{uuid.uuid4().hex}.tmp"
-    with open(temporary, "w", encoding="utf-8") as destination:
-        json.dump(payload, destination, indent=2, sort_keys=True, default=_json_default)
-        destination.write("\n")
-    os.replace(temporary, path)
+    """Write metadata atomically so interruption cannot leave partial JSON.
+
+    The replacement is :func:`write_atomic`; the *serialisation* stays here
+    deliberately. The two-space indent, sorted keys, :func:`_json_default`
+    encoder and trailing newline are the stored format that every manifest on
+    disk and every manifest-hash in a comparison manifest was written with, and
+    the shared helper is explicit that JSON encoding belongs to the caller.
+    """
+
+    def write_temporary(temporary: Path) -> None:
+        with temporary.open("w", encoding="utf-8") as destination:
+            json.dump(
+                payload, destination, indent=2, sort_keys=True, default=_json_default
+            )
+            destination.write("\n")
+
+    write_atomic(path, write_temporary)
 
 
 def write_fit_state(
@@ -148,37 +203,42 @@ def write_fit_state(
     write_json_atomic(path, payload)
 
 
+#: Seconds allowed for the one Git query behind :func:`git_metadata`.
+#:
+#: The shared helper defaults to 5.0; this repository has always allowed 10,
+#: and a status scan on the fitting VM's scratch volume is slower than on a
+#: laptop. Preserved rather than inherited so a timeout does not start
+#: recording ``dirty: None`` -- which fails ``require_clean_fit`` -- on a
+#: checkout that is in fact clean.
+GIT_QUERY_TIMEOUT_SECONDS = 10.0
+
+
 def git_metadata(repo_dir: str) -> dict[str, object]:
-    """Return the repository revision and dirty state without requiring Git."""
+    """Return the repository revision and dirty state without requiring Git.
 
-    def run_git(*args: str) -> str | None:
-        try:
-            result = subprocess.run(
-                ["git", *args],
-                cwd=repo_dir,
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=10,
-            )
-        except (OSError, subprocess.SubprocessError):
-            return None
-        return result.stdout.strip()
+    The four keys are the manifest's stored schema and are unchanged: every
+    fit on disk carries them, and :func:`validate_fit_output` compares
+    ``commit`` and ``dirty``. What moved into
+    :func:`dse_research_utils.metadata.provenance.git_snapshot` (shared library
+    0.14.0) is *how* they are obtained -- one bounded ``status --porcelain=v2
+    --branch`` call instead of three separate commands, with inherited
+    ``GIT_*`` repository overrides stripped, optional index locks and the
+    filesystem-monitor hook disabled.
 
-    commit = run_git("rev-parse", "HEAD")
-    branch_result = run_git("branch", "--show-current")
-    if branch_result is None:
-        branch = None
-        detached = None
-    else:
-        branch = branch_result or None
-        detached = not bool(branch_result)
-    status = run_git("status", "--porcelain", "--untracked-files=normal")
+    The recorded values keep their meaning. ``dirty`` still counts staged,
+    unstaged, unmerged and untracked changes and still excludes ignored files;
+    it is ``None`` whenever the query could not establish it, rather than
+    ``False``, so an unavailable Git never reads as a clean checkout.
+    ``detached`` is now reported by Git itself instead of inferred from an
+    empty ``branch --show-current``. ``commit`` is ``None`` on an unborn
+    branch, as it was when ``rev-parse HEAD`` failed there.
+    """
+    snapshot = git_snapshot(repo_dir, timeout=GIT_QUERY_TIMEOUT_SECONDS)
     return {
-        "commit": commit,
-        "branch": branch,
-        "detached": detached,
-        "dirty": None if status is None else bool(status),
+        "commit": snapshot.commit,
+        "branch": snapshot.branch,
+        "detached": snapshot.detached,
+        "dirty": snapshot.dirty,
     }
 
 
@@ -796,8 +856,58 @@ def create_staging_root(output_root: str, tag: str) -> str:
     return staging_root
 
 
+#: Serialises the two renames a directory promotion performs.
+#:
+#: The shared helper takes the lock rather than choosing one, so the scope is
+#: this repository's to state: it covers *threads of one process*. That is the
+#: whole of the exposure this repository actually has -- a fit promotes the one
+#: ``models/<label>/`` directory it staged, and two concurrent fits of the same
+#: model into the same output root would already be racing for that directory
+#: before either reached promotion. Fitting several models at once (``fit_model.py
+#: all``, the sensitivity runners) targets a different destination per run and is
+#: unaffected. A deployment that did run two processes over one model would need a
+#: process lock here instead. Public, and shared with
+#: ``scripts/sync_report_figures.py``, so the two promoting call sites in this
+#: repository serialise against each other rather than against nothing.
+PROMOTION_LOCK = threading.Lock()
+
+
+def promotion_path(path: str) -> Path:
+    """``path`` with its parents resolved and its own name left alone.
+
+    :func:`dse_research_utils.storage.directories.promote_directory` refuses a
+    symlinked ancestor, and on the fitting VM ``<repo>/output`` *is* a symlink
+    to a scratch volume (see :mod:`vocab_growth.environment`), as is ``/tmp``
+    on macOS. Resolving the parent chain deliberately -- these are directories
+    this repository created itself -- is what the shared helper documents for
+    that case. The final component is **not** resolved: a destination that is
+    itself a symlink must still be rejected rather than silently followed.
+
+    Public so ``scripts/sync_report_figures.py`` promotes its figure cache
+    through the same rule rather than a second copy of it.
+    """
+    absolute = Path(path).absolute()
+    return absolute.parent.resolve() / absolute.name
+
+
 def promote_staged_fit(staged_output_dir: str, canonical_output_dir: str) -> None:
-    """Replace canonical output only after a staged fit has fully completed."""
+    """Replace canonical output only after a staged fit has fully completed.
+
+    Delegates the renames to
+    :func:`dse_research_utils.storage.directories.promote_directory` (shared
+    library 0.14.0), which validates the three paths against each other -- no
+    nesting, no aliasing through a mounted tree, no symlink in any component,
+    one filesystem -- before it touches the destination, and restores the
+    previous directory itself if the second rename fails.
+
+    Two decisions stay here because the helper leaves them to the caller. The
+    lock is :data:`PROMOTION_LOCK`; and the retained backup is deleted on
+    success, as it always has been -- ``.previous`` is a rollback slot for the
+    promotion itself, not an archive, and a fit's output can be tens of
+    gigabytes. A cleanup failure is reported and *not* raised: the promotion
+    has already succeeded at that point, and turning a leftover directory into
+    a failed fit would be a false report.
+    """
     parent = os.path.dirname(canonical_output_dir)
     output_root = os.path.dirname(parent)
     os.makedirs(parent, exist_ok=True)
@@ -808,17 +918,20 @@ def promote_staged_fit(staged_output_dir: str, canonical_output_dir: str) -> Non
         f"{os.path.basename(canonical_output_dir)}-{uuid.uuid4().hex[:8]}",
     )
 
-    had_canonical = os.path.exists(canonical_output_dir)
-    if had_canonical:
-        os.replace(canonical_output_dir, backup)
-    try:
-        os.replace(staged_output_dir, canonical_output_dir)
-    except BaseException:
-        if had_canonical and os.path.exists(backup):
-            os.replace(backup, canonical_output_dir)
-        raise
-    if had_canonical and os.path.exists(backup):
-        shutil.rmtree(backup)
+    result = promote_directory(
+        promotion_path(staged_output_dir),
+        promotion_path(canonical_output_dir),
+        backup=promotion_path(backup),
+        lock=PROMOTION_LOCK,
+    )
+    if result.backup is not None:
+        try:
+            shutil.rmtree(result.backup)
+        except OSError as exc:
+            print(
+                f"Warning: promoted {canonical_output_dir} but could not remove "
+                f"the retained previous copy at {result.backup}: {exc}"
+            )
 
 
 def retain_failed_fit(staged_output_dir: str, output_root: str) -> str | None:

--- a/src/vocab_growth/models/calibration.py
+++ b/src/vocab_growth/models/calibration.py
@@ -20,6 +20,9 @@ import os
 import numpy as np
 import pandas as pd
 import xarray as xr
+from dse_research_utils.report.readers import read_csv
+from dse_research_utils.statistics.predictive import predictive_observation_checks
+from dse_research_utils.statistics.samples import sample_matrix
 
 from vocab_growth import intervals
 
@@ -71,6 +74,15 @@ def predictive_calibration_table(
     mean over observations of the predictive mass inside the tabulated
     interval). Compare the empirical columns against these, not against 1/12 or
     the nominal level (#234).
+
+    The per-observation quantities come from
+    :func:`dse_research_utils.statistics.predictive.predictive_observation_checks`
+    (shared library 0.14.0), which computes exactly this set: linear quantiles
+    at ``(1 - p) / 2`` and its complement, closed-interval inclusion, the
+    predictive mass inside those bounds, and the midpoint PIT with the same
+    ``(1 - sum p_k^3) / 12`` reference. What stays here is this project's
+    reporting: the age banding, the zero rates, the group means, and the column
+    names and order of the written table.
     """
     observed = np.asarray(observed, dtype=float)
     predictive = np.asarray(predictive)
@@ -87,50 +99,55 @@ def predictive_calibration_table(
         raise ValueError("observation_chunk_size must be positive.")
     if observed.size == 0 or predictive.shape[1] == 0:
         raise ValueError("calibration requires observations and predictive samples.")
+    # The shared helper refuses non-finite observations rather than choosing a
+    # population for the caller, which is the right division: an outcome column
+    # carrying NaN here means the engine masked the wrong rows, and every row
+    # reaching this point is one the likelihood scored. Checked here so the
+    # failure names the table being written.
+    if not np.isfinite(observed).all():
+        raise ValueError(
+            "calibration requires finite observations; "
+            f"{int((~np.isfinite(observed)).sum())} of {observed.size} are not. "
+            "Mask unobserved rows before summarising them."
+        )
 
     n_observations = observed.size
-    predictive_mean = np.empty(n_observations, dtype=float)
-    predictive_zero_rate = np.empty(n_observations, dtype=float)
-    pit = np.empty(n_observations, dtype=float)
-    expected_pit_variance = np.empty(n_observations, dtype=float)
+    checks = predictive_observation_checks(
+        observed,
+        predictive,
+        interval_probs=interval_probs,
+        sample_axis=1,
+        pit_method="midpoint",
+        observation_chunk_size=observation_chunk_size,
+    )
+    predictive_mean = checks.predictive_mean
+    pit = checks.midpoint_pit
+    expected_pit_variance = checks.expected_midpoint_pit_variance
     coverage_by_prob = {
-        prob: np.empty(n_observations, dtype=bool) for prob in interval_probs
+        prob: checks.inside[:, column] for column, prob in enumerate(interval_probs)
     }
+    # Predictive mass inside the tabulated interval: what coverage a perfectly
+    # calibrated model would show, discreteness included.
     expected_coverage_by_prob = {
-        prob: np.empty(n_observations, dtype=float) for prob in interval_probs
+        prob: checks.predictive_mass[:, column]
+        for column, prob in enumerate(interval_probs)
     }
+    # Widths are differenced in the bounds' own dtype and then stored as
+    # float64 before the group means below, which is the arithmetic the written
+    # table has always carried.
     width_by_prob = {
-        prob: np.empty(n_observations, dtype=float) for prob in interval_probs
+        prob: (checks.upper[:, column] - checks.lower[:, column]).astype(float)
+        for column, prob in enumerate(interval_probs)
     }
 
+    # The one per-observation quantity the shared checks do not compute: the
+    # zero rate is this project's own column, and a count outcome's floor is
+    # what it reports on. Chunked on the same schedule, so the temporary arrays
+    # stay the size they were.
+    predictive_zero_rate = np.empty(n_observations, dtype=float)
     for start in range(0, n_observations, observation_chunk_size):
         stop = min(start + observation_chunk_size, n_observations)
-        y = observed[start:stop]
-        y_rep = predictive[start:stop]
-        predictive_mean[start:stop] = y_rep.mean(axis=1)
-        predictive_zero_rate[start:stop] = np.mean(y_rep == 0, axis=1)
-        pit[start:stop] = np.mean(y_rep < y[:, None], axis=1) + 0.5 * np.mean(
-            y_rep == y[:, None], axis=1
-        )
-        for offset, row in enumerate(y_rep):
-            _, counts = np.unique(row, return_counts=True)
-            mass = counts / row.size
-            # Var(mid-PIT | calibrated) = (1 - sum p_k^3) / 12 for this
-            # observation's predictive distribution.
-            expected_pit_variance[start + offset] = (
-                1.0 - float(np.sum(mass**3))
-            ) / 12.0
-        for prob in interval_probs:
-            tail = (1 - prob) / 2
-            lower = np.quantile(y_rep, tail, axis=1)
-            upper = np.quantile(y_rep, 1 - tail, axis=1)
-            coverage_by_prob[prob][start:stop] = (y >= lower) & (y <= upper)
-            # Predictive mass inside the tabulated interval: what coverage a
-            # perfectly calibrated model would show, discreteness included.
-            expected_coverage_by_prob[prob][start:stop] = np.mean(
-                (y_rep >= lower[:, None]) & (y_rep <= upper[:, None]), axis=1
-            )
-            width_by_prob[prob][start:stop] = upper - lower
+        predictive_zero_rate[start:stop] = np.mean(predictive[start:stop] == 0, axis=1)
 
     age_starts = np.floor(ages / age_band_months).astype(int) * age_band_months
     groups: list[tuple[str, np.ndarray]] = [("all", np.ones(observed.size, dtype=bool))]
@@ -224,12 +241,26 @@ def write_trace_calibration(
                 f"found {observation_dims}."
             )
         observation_dim = observation_dims[0]
-        predictive = (
-            replicated.stack(sample=("chain", "draw"))
-            .transpose(observation_dim, "sample")
-            .values
-        )
-        observed = np.asarray(trace.observed_data[variable].values)
+        # `sample_matrix` reshapes to (observation, sample) with every
+        # dimension declared, and `observed_values` then checks the observed
+        # array's coordinate index against the replications' own before
+        # flattening it. Every engine declares this dimension in the model's
+        # `coords`, so the labels are there; what changes is that a
+        # disagreement between the two groups is now a failure rather than a
+        # silently mismatched row. Equal lengths never established alignment.
+        try:
+            matrix = sample_matrix(
+                replicated,
+                sample_dims=("chain", "draw"),
+                observation_dims=(observation_dim,),
+            )
+            observed = matrix.observed_values(trace.observed_data[variable])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Cannot align {variable!r} with its observed values: {exc}"
+            ) from exc
+        predictive = matrix.values
+        observed = np.asarray(observed)
         ages = np.asarray(analysis_df.loc[mask, "age"], dtype=float)
         table = predictive_calibration_table(observed, predictive, ages)
         table.insert(0, "outcome", label)
@@ -384,14 +415,28 @@ def render_calibration_section(directory: str = ".") -> None:
     than failing when the fit predates the calibration table, so the section is
     never silently empty.
     """
-    path = os.path.join(directory, "posterior_predictive_calibration.csv")
-    if not os.path.exists(path):
+    read = read_csv(os.path.join(directory, "posterior_predictive_calibration.csv"))
+    if read.status == "missing":
         print(
             "_No calibration table for this fit "
             "(`posterior_predictive_calibration.csv` absent — refit to generate it)._"
         )
         return
-    table = pd.read_csv(path)
+    if read.status == "invalid":
+        if read.reason == "empty_document":
+            # `write_trace_calibration` writes an empty frame -- which has no
+            # columns, so `to_csv` writes a bare newline -- when a trace carries
+            # no posterior-predictive variable it recognises. That is an empty
+            # table, and until this read distinguished the two it reached
+            # `pd.read_csv` and aborted the report cell.
+            print("_The calibration table for this fit is empty._")
+        else:
+            print(
+                "_The calibration table for this fit could not be read "
+                f"(`{read.reason}`)._"
+            )
+        return
+    table = read.value
     if table.empty:
         print("_The calibration table for this fit is empty._")
         return

--- a/src/vocab_growth/models/common.py
+++ b/src/vocab_growth/models/common.py
@@ -39,6 +39,10 @@ import preliz as pz
 import pymc as pm
 import xarray as xr
 from arviz import ELPDData
+from dse_research_utils.statistics.models.hsgp_design import (
+    HSGPDesign,
+    calibrate_hsgp_1d,
+)
 from matplotlib.figure import Figure
 from preliz.distributions.distributions import Continuous
 
@@ -596,6 +600,40 @@ PACKAGE_LIST = [
 ]
 
 
+def hsgp_design_for(X_gp_domain_z, ell_range_z) -> HSGPDesign:
+    """The realised HSGP geometry for the age kernel: ``m``, ``L`` and centre.
+
+    :func:`dse_research_utils.statistics.models.hsgp_design.calibrate_hsgp_1d`
+    (shared library 0.14.0) applies PyMC's own ExpQuad recommendation to the
+    declared domain and length-scale range, then returns the geometry it
+    realised rather than the recipe. ``c_floor=None`` is this repository's
+    calibration unchanged: no boundary floor is imposed, so the basis count and
+    boundary factor are exactly what ``approx_hsgp_hyperparams`` recommends.
+
+    The boundary is the recommendation's factor times the domain's *half-range*
+    ``(x_max - x_min) / 2``, and the centre is its midpoint. That is the same S
+    the recommendation sizes ``(m, c)`` for, and the same midpoint
+    ``HSGP.prior_linearized`` centres X at. Deriving ``L`` from ``max|z|``
+    instead would inflate it past what ``m`` supports -- z-scores are skewed
+    about zero, not about the midpoint -- raising the smallest well-approximated
+    length-scale above ``ell_range_z[0]``.
+
+    Parameters
+    ----------
+    X_gp_domain_z : np.ndarray
+        Standardised lower and upper endpoints of the declared HSGP age domain,
+        shape (2, 1). Reporting query ages are deliberately excluded, so a
+        changed query cannot move the approximation.
+    ell_range_z : tuple of float
+        Length-scale range in z-score scale.
+    """
+    return calibrate_hsgp_1d(
+        X_gp_domain_z,
+        ls_range=(float(ell_range_z[0]), float(ell_range_z[1])),
+        c_floor=None,
+    )
+
+
 def get_hsgp_hyperparams(
     X_gp_domain_z,
     ell_range_z,
@@ -615,31 +653,12 @@ def get_hsgp_hyperparams(
     -------
     tuple[list[float], list[int]]
         ``(L, M)`` where ``L`` is the HSGP boundary and ``M`` is the basis
-        size, each wrapped in a single-element list (one per input dim).
+        size, each wrapped in a single-element list (one per input dim) as
+        ``pm.gp.HSGP`` takes them. :func:`hsgp_design_for` returns the same
+        geometry as one saveable record.
     """
-    x_min = float(np.min(X_gp_domain_z))
-    x_max = float(np.max(X_gp_domain_z))
-
-    ell_low_z = ell_range_z[0]
-    ell_high_z = ell_range_z[1]
-
-    m, c = pm.gp.hsgp_approx.approx_hsgp_hyperparams(
-        x_range=[x_min, x_max],
-        lengthscale_range=[ell_low_z, ell_high_z],
-        cov_func="expquad",
-    )
-
-    # HSGP.prior_linearized centres X at the grid midpoint, so the domain the
-    # basis must cover is the half-range S = (x_max - x_min) / 2 — the same S
-    # that approx_hsgp_hyperparams sizes (m, c) for. Deriving L from max|z|
-    # instead would inflate L past what m supports (z-scores are skewed about
-    # zero, not about the midpoint), raising the smallest well-approximated
-    # length-scale above ell_range_z[0].
-    S = (x_max - x_min) / 2.0
-    L = [S * c]
-    M = [m]
-
-    return L, M
+    design = hsgp_design_for(X_gp_domain_z, ell_range_z)
+    return [design.L], [design.m]
 
 
 def render_model_graph(model: pm.Model, output_dir: str) -> None:

--- a/src/vocab_growth/models/gp_utils.py
+++ b/src/vocab_growth/models/gp_utils.py
@@ -48,6 +48,7 @@ from dataclasses import dataclass
 import numpy as np
 import pymc as pm
 import pytensor.tensor as pt
+from dse_research_utils.statistics.models.hsgp_design import HSGPDesign, create_hsgp
 from dse_research_utils.statistics.models.pymc_utils import logit
 from pytensor.tensor.linalg import solve as pt_solve
 
@@ -960,15 +961,29 @@ def _gp_from_mean(
     )
     eta = cfg_eta.to_pymc(f"eta{suffix}")
     cov = pm.gp.cov.ExpQuad(1, ls=ell)
-    hsgp = pm.gp.HSGP(cov_func=cov, m=grid.M, L=grid.L)
     if grid.x_center_z is not None:
-        # PyMC (6.3.1) exposes no constructor argument for the basis centre; it
-        # sets `_X_center` lazily from min/max of the X passed to `prior`, guarded
-        # by a None check (pymc/gp/hsgp_approx.py). Pre-setting it here pins the
-        # centre to the declared GP domain's midpoint so the reporting grid
-        # cannot move the approximation. Covered by a regression test against the
-        # locked PyMC version.
-        hsgp._X_center = np.array([float(grid.x_center_z)])
+        # The realised geometry, as three saved scalars: basis count, domain
+        # half-width, and the centre the basis is built about. Handing them to
+        # `create_hsgp` (shared library 0.14.0) pins the centre through a public
+        # PyMC call on the centre alone, before any query row enters the object.
+        #
+        # It replaces an assignment to the private `_X_center`. PyMC (6.3.1)
+        # exposes no constructor argument for the centre and sets it lazily from
+        # the min/max of the X passed to `prior`, guarded by a None check
+        # (pymc/gp/hsgp_approx.py), so the reporting grid would otherwise move
+        # the approximation. The pinned value is identical either way -- for a
+        # single row, `(max + min) / 2` is that row -- and a regression test
+        # against the locked PyMC version checks the resulting basis.
+        hsgp = create_hsgp(
+            HSGPDesign(m=grid.M[0], L=grid.L[0], center=float(grid.x_center_z)),
+            cov_func=cov,
+        )
+    else:
+        # No declared centre: PyMC's own, taken from the query rows. Only the
+        # exploratory modules and the experiment arms that deliberately test
+        # that default reach this branch; every registered engine builds its
+        # grid through `GPGrid.from_age_grids`, which sets one.
+        hsgp = pm.gp.HSGP(cov_func=cov, m=grid.M, L=grid.L)
     g_unit = hsgp.prior(f"g_unit{suffix}", X=X_all_z_data, dims="all_id")
     if anchor_idx is not None:
         if n_obs is None or nuisance_basis is None:

--- a/src/vocab_growth/publication_checks.py
+++ b/src/vocab_growth/publication_checks.py
@@ -8,90 +8,139 @@ carries ``index.html`` without them publishes a page whose every image is
 broken -- which is indistinguishable from a healthy one if only the page's own
 URL is checked. That happened to the comparison book on 2026-09-03
 (``scripts/publish_comparison.py`` records it), and nothing in the model-report
-upload path checked for it either. These helpers are shared by both:
+upload path checked for it either. These helpers are shared by both.
 
-* :func:`referenced_assets` derives the asset list **from the page** rather
-  than from a remembered list, because a list that omits something is exactly
-  the failure being guarded against.
-* :func:`unpublished_assets` names the referenced assets an upload left out,
-  whether by a caller's skip filter or the trace exclusion.
-* :func:`verify_published` requests every published file and returns the ones
-  that did not come back ``200``.
+Since the shared library's 0.14.0 release the three steps are
+:mod:`dse_research_utils.report.assets`, which parses the HTML rather than
+matching quoted strings and reports each reference's state instead of dropping
+the ones it cannot use. What stays here is the publication policy:
+
+* **Navigation counts.** ``include_navigation=True`` is deliberate. These pages
+  offer their summary tables as ordinary download links (``<a href="...csv">``),
+  which the current checks already treat as required, and a link that 404s is
+  the same broken publication as a missing image.
+* **A missing reference is a failure, not an omission.** The previous scanner
+  dropped any target that did not exist on disk, on the grounds that the render
+  should have complained -- so a page referencing a figure that was never
+  written published silently. :func:`local_failures` names it instead.
+* **Pages are not followed.** Both publishers here upload a single rendered
+  page and its assets, so ``follow_pages`` would only inspect pages nothing
+  publishes as entry points. A multi-page book would need it.
+
+Two encoding rules the previous scanner had wrong are now enforced by the
+shared parser and are worth knowing before writing an artefact filename: an
+``href`` is URL-decoded once, so a file literally named ``50%20.csv`` has to be
+written ``50%2520.csv`` in the HTML (``50%20.csv`` asks the browser for
+``50 .csv``); and ``base href``/``srcset``, which change what a browser
+actually loads, are reported as unsupported rather than certified.
 """
 
 from __future__ import annotations
 
-import os
-import re
-import urllib.request
-from collections.abc import Iterable
-from urllib.parse import quote
+from collections.abc import Callable, Iterable
 
-#: ``src``/``href`` targets in rendered HTML that point at a local file.
-_ASSET = re.compile(r'(?:src|href)="([^"#?][^"]*?)"')
+from dse_research_utils.report.assets import (
+    AssetFailure,
+    AssetInspection,
+    check_uploaded_assets,
+    inspect_local_assets,
+    verify_published_assets,
+)
 
-#: Targets that are not local files, whatever the attribute.
-_EXTERNAL_PREFIXES = ("http://", "https://", "//", "data:", "mailto:", "javascript:")
+__all__ = [
+    "AssetFailure",
+    "AssetInspection",
+    "check_uploaded_assets",
+    "describe_failures",
+    "inspect_report",
+    "local_failures",
+    "present_assets",
+    "referenced_assets",
+    "upload_failures",
+    "verify_published",
+]
+
+
+def inspect_report(html_path: str) -> AssetInspection:
+    """Every local file the rendered page requires, with each one's state.
+
+    The inspection root is the page's own directory, which is the directory an
+    upload publishes, so the paths compare directly with the uploader's record
+    of what it sent.
+    """
+    return inspect_local_assets(html_path, include_navigation=True)
+
+
+def present_assets(inspection: AssetInspection) -> list[str]:
+    """The required local files that exist, as POSIX paths relative to the root.
+
+    Excludes the inspected page itself, which a caller publishes separately.
+    Callers that copy these paths should check :func:`local_failures` first:
+    this list is what *can* be copied, not a statement that nothing is missing.
+    """
+    present = {
+        reference.relative_path
+        for reference in inspection.references
+        if reference.required and reference.status == "present"
+    }
+    return sorted(present - set(inspection.pages))
 
 
 def referenced_assets(html_path: str) -> list[str]:
-    """Every local file the rendered page references, as POSIX relative paths.
+    """:func:`present_assets` for a page, inspecting it first."""
+    return present_assets(inspect_report(html_path))
 
-    Relative to the page's own directory, which is the directory an upload
-    publishes, so the paths compare directly with the uploader's record of
-    what it sent. A target that does not exist on disk is not an asset the
-    page could have shipped and is left out here; the render is what should
-    have complained about it.
+
+def local_failures(inspection: AssetInspection) -> tuple[AssetFailure, ...]:
+    """Required references the page makes that no upload could satisfy.
+
+    A missing file, a link that escapes the published directory, and a
+    construct whose target cannot be determined (``base href``, ``srcset``) all
+    land here. Passing the inspection's own required paths back as the
+    prospective inventory checks the page without making any request.
     """
-    with open(html_path, encoding="utf-8") as handle:
-        html = handle.read()
-    base = os.path.dirname(os.path.abspath(html_path))
-    assets: set[str] = set()
-    for target in _ASSET.findall(html):
-        if target.startswith(_EXTERNAL_PREFIXES):
-            continue
-        candidate = os.path.normpath(os.path.join(base, target))
-        if not os.path.isfile(candidate):
-            continue
-        relative = os.path.relpath(candidate, base).replace(os.sep, "/")
-        if relative.startswith("../"):
-            # Outside the page's directory: an upload of that directory cannot
-            # carry it, so it is a link out of the page rather than an asset.
-            continue
-        assets.add(relative)
-    return sorted(assets)
+    return check_uploaded_assets(inspection, inspection.required_paths)
 
 
-def unpublished_assets(html_path: str, published: Iterable[str]) -> list[str]:
-    """Referenced assets absent from ``published`` (paths relative to the page).
+def upload_failures(
+    html_path: str, published: Iterable[str]
+) -> tuple[AssetFailure, ...]:
+    """Local failures plus required files this upload left out.
 
-    ``published`` may carry either separator: an uploader walking a Windows
-    directory yields backslashes whatever platform later checks the record, so
-    both are normalised to ``/`` unconditionally rather than through ``os.sep``,
-    which is already ``/`` on POSIX and would leave a backslash path unmatched.
+    ``published`` carries the uploader's **raw** relative filenames -- not URLs
+    and not URL-encoded paths. Either separator is accepted: an uploader
+    walking a Windows directory yields backslashes whatever platform later
+    checks the record. Callers that also need the inspection should call
+    :func:`inspect_report` and :func:`check_uploaded_assets` themselves rather
+    than parse the page twice.
     """
-    sent = {path.replace("\\", "/") for path in published}
-    return [asset for asset in referenced_assets(html_path) if asset not in sent]
+    return check_uploaded_assets(inspect_report(html_path), published)
 
 
 def verify_published(
-    base_url: str, relative_paths: Iterable[str], *, timeout: float = 30.0
-) -> list[str]:
+    base_url: str,
+    relative_paths: Iterable[str],
+    *,
+    timeout: float = 30.0,
+    fetch_status: Callable[[str, float], int] | None = None,
+) -> tuple[AssetFailure, ...]:
     """Request ``base_url/<path>`` for every path; return the ones not returning 200.
 
-    Each failure is ``"<status or exception> <path>"``, so the caller can print
-    them as a list. ``base_url`` is the directory URL the files were published
-    under, with or without a trailing slash. ``relative_paths`` contains raw
-    filenames, not URL-encoded paths; each is encoded exactly once.
+    ``base_url`` is the directory URL the files were published under, with or
+    without a trailing slash. ``relative_paths`` contains raw filenames, each
+    encoded exactly once. A redirect is a failure: a login page reached through
+    one cannot establish that the asset is published.
     """
-    failures: list[str] = []
-    root = base_url.rstrip("/")
-    for relative in relative_paths:
-        url = f"{root}/{quote(relative, safe='/')}"
-        try:
-            with urllib.request.urlopen(url, timeout=timeout) as response:
-                if response.status != 200:
-                    failures.append(f"{response.status} {relative}")
-        except Exception as exc:  # noqa: BLE001 - reported, not raised
-            failures.append(f"{type(exc).__name__} {relative}")
-    return failures
+    return verify_published_assets(
+        base_url, relative_paths, timeout=timeout, fetch_status=fetch_status
+    )
+
+
+def describe_failures(failures: Iterable[AssetFailure]) -> list[str]:
+    """One printable line per failure: the path, why, and any HTTP status."""
+    return [
+        f"{failure.path} ({failure.reason}"
+        + (f" {failure.status_code}" if failure.status_code is not None else "")
+        + ")"
+        for failure in failures
+    ]

--- a/src/vocab_growth/report_cells.py
+++ b/src/vocab_growth/report_cells.py
@@ -30,6 +30,7 @@ import math
 import os
 from collections.abc import Mapping
 
+from dse_research_utils.report.readers import FileRead, nearest_row, read_csv, read_json
 from scipy import stats
 
 from vocab_growth.administration_loo import ADMINISTRATION_LABEL
@@ -43,6 +44,7 @@ from vocab_growth.models.diagnostics_utils import (  # noqa: F401  (re-exported)
 )
 
 MANIFEST_FILENAME = "fit_manifest.json"
+
 
 # Sampling configurations that are reporting-grade. Read from the manifest's
 # recorded name rather than inferred from chains x draws: the old templates
@@ -62,8 +64,50 @@ CONFIG_LABELS = {
 }
 
 
+class ReportArtefactError(RuntimeError):
+    """A file in a fit's output directory exists and cannot be parsed.
+
+    Distinct from a file this engine never writes, which every helper below
+    treats as "not applicable" and renders as a pending-fit placeholder. A
+    damaged file must not become that placeholder: the placeholder reads as
+    "this fit has not produced this yet", which is reassuring and wrong.
+    """
+
+
+def _table(directory: str, name: str) -> FileRead:
+    """Read one summary CSV, keeping missing and damaged apart.
+
+    :func:`dse_research_utils.report.readers.read_csv` (shared library 0.14.0)
+    returns the state; the policy is this repository's. A file that is absent
+    or that parsed to nothing is "not written by this engine". A parse, decode
+    or read failure is a defect and raises.
+
+    ``empty_document`` -- a file with no columns at all -- is deliberately on
+    the first side. Several writers here build their table with
+    ``pd.DataFrame(rows)`` and write it whatever ``rows`` contains; with no rows
+    that produces a column-less frame, and ``to_csv`` then writes a single
+    newline. That file records "there was nothing to tabulate", not damage.
+    """
+    read = read_csv(os.path.join(directory, f"{name}.csv"))
+    if read.status == "invalid" and read.reason != "empty_document":
+        raise ReportArtefactError(
+            f"{read.path} could not be read ({read.reason}: {read.error_type}). "
+            "A damaged artefact is not a fit that has yet to produce one."
+        )
+    return read
+
+
 def read_manifest(directory: str = ".") -> dict:
-    """The fit manifest for a rendered report, or an empty dict when absent."""
+    """The fit manifest for a rendered report, or an empty dict when absent.
+
+    Deliberately **not** routed through the shared strict JSON reader, unlike
+    the diagnostics payload. ``write_json_atomic`` serialises with Python's
+    default ``allow_nan``, so a definition field holding a non-finite float is
+    written as a bare ``NaN`` token; the strict reader rejects those, and every
+    manifest already on disk has to stay readable. The report's own tolerance
+    for a manifest it cannot parse is what it always was: render the fit's
+    pages without the fields the manifest would have supplied.
+    """
     path = os.path.join(directory, MANIFEST_FILENAME)
     if not os.path.isfile(path):
         return {}
@@ -250,15 +294,15 @@ _PRIOR_SPECS: list[tuple[str, str, str, str]] = [
 
 def fitted_parameters(directory: str = ".") -> set[str]:
     """Names of the parameters this fit actually sampled, from its diagnostics."""
-    path = os.path.join(directory, "diagnostics.csv")
-    if not os.path.isfile(path):
+    read = read_csv(os.path.join(directory, "diagnostics.csv"), index_col=0)
+    if read.status == "missing" or read.reason == "empty_document":
         return set()
-    import pandas as pd
-
-    try:
-        return {str(name) for name in pd.read_csv(path, index_col=0).index}
-    except (OSError, ValueError):
-        return set()
+    if read.status == "invalid":
+        raise ReportArtefactError(
+            f"{read.path} could not be read ({read.reason}: {read.error_type}); "
+            "the parameters this fit sampled cannot be established."
+        )
+    return {str(name) for name in read.value.index}
 
 
 def _correlated_block_size(definition: dict) -> int:
@@ -1084,17 +1128,16 @@ _OUTCOME_LABELS = {
 
 
 def _read(directory: str, name: str):
-    """A summary CSV, or None when this engine does not write it."""
-    import pandas as pd
+    """A summary CSV, or None when this engine does not write it.
 
-    path = os.path.join(directory, f"{name}.csv")
-    if not os.path.isfile(path):
+    An empty table reads as absent, as it always has: a section with no rows to
+    show and a section this engine never writes both render as pending. A
+    *damaged* file raises through :func:`_table` instead.
+    """
+    read = _table(directory, name)
+    if read.status != "present":
         return None
-    try:
-        frame = pd.read_csv(path)
-    except (OSError, ValueError):
-        return None
-    return frame if not frame.empty else None
+    return read.value if not read.value.empty else None
 
 
 def _peak_row(frame, column: str):
@@ -1367,15 +1410,16 @@ def render_variation_table(directory: str = ".") -> None:
     number, so the alias row is labelled with the age it refers to and a second
     table gives the scale across the reported ages (#233).
     """
-    import pandas as pd
-
-    path = os.path.join(directory, "diagnostics.csv")
-    if not os.path.isfile(path):
+    read = read_csv(os.path.join(directory, "diagnostics.csv"), index_col=0)
+    if read.status == "missing" or read.reason == "empty_document":
         return
-    try:
-        frame = pd.read_csv(path, index_col=0)
-    except (OSError, ValueError):
+    if read.status == "invalid":
+        print(
+            "_The diagnostics table for this fit could not be read "
+            f"(`{read.reason}`), so the between-group scales are not shown._"
+        )
         return
+    frame = read.value
 
     labels = {
         "tau": "Between studies",
@@ -1494,19 +1538,21 @@ def render_loo_section(directory: str = ".") -> None:
     """
     import pandas as pd
 
-    path = os.path.join(directory, "loo_summary.csv")
-    if not os.path.isfile(path):
+    read = read_csv(os.path.join(directory, "loo_summary.csv"))
+    if read.status == "missing":
         print(
             "_No leave-one-out summary for this fit (`loo_summary.csv` absent — "
             "it was added on 2026-08-16, so fits made before then need a refit "
             "to produce it)._"
         )
         return
-    try:
-        table = pd.read_csv(path)
-    except (OSError, ValueError):
-        print("_The leave-one-out summary for this fit could not be read._")
+    if read.status == "invalid":
+        print(
+            "_The leave-one-out summary for this fit could not be read "
+            f"(`{read.reason}`)._"
+        )
         return
+    table = read.value
     if table.empty:
         print("_The leave-one-out summary for this fit is empty._")
         return
@@ -2040,16 +2086,22 @@ def render_diagnostic_verdict(directory: str = ".") -> None:
     ``diagnostics_summary.json``, the manifest's sampling parameters and
     ``diagnostics.csv`` (for which parameter set each extreme) and says it.
     """
-    path = os.path.join(directory, "diagnostics_summary.json")
-    if not os.path.isfile(path):
+    # The strict shared JSON reader is safe for this file specifically: the
+    # shared diagnostics writer sanitises non-finite values before writing it,
+    # so a bare NaN or Infinity token here would itself be the defect. The fit
+    # manifest is deliberately *not* read this way -- see `read_manifest`.
+    read = read_json(os.path.join(directory, "diagnostics_summary.json"))
+    if read.status == "missing":
         print("_No `diagnostics_summary.json` for this fit, so the gate verdict cannot be shown._")
         return
-    try:
-        with open(path, encoding="utf-8") as handle:
-            summary = json.load(handle)
-    except (OSError, ValueError):
-        print("_The diagnostics summary for this fit could not be read._")
+    if read.status == "invalid" or not isinstance(read.value, dict):
+        print(
+            "_The diagnostics summary for this fit could not be read "
+            f"(`{read.reason or 'not a JSON object'}`), so the gate verdict "
+            "cannot be shown._"
+        )
         return
+    summary = read.value
 
     thresholds = summary.get("thresholds") or {}
     rhat_max = thresholds.get("rhat_max", 1.01)
@@ -2873,7 +2925,9 @@ def render_conditional_production_check(directory: str = ".") -> None:
     for level in _CONDITIONAL_PRODUCTION_LEVELS:
         if level > x_max or float(level) not in observed_rows.index:
             continue
-        row = curve.iloc[int((curve["words_understood"] - level).abs().idxmin())]
+        row = nearest_row(curve, key="words_understood", at=float(level))
+        if row is None:
+            continue
         seen = observed_rows.loc[float(level)]
         curve_cell = f"{float(row['q_median']):.2f}"
         if has_ci:
@@ -2953,8 +3007,11 @@ def render_reference_child_calibration(directory: str = ".") -> None:
         col = next((c for c in table.columns if c.startswith("Ey_median")), None)
         if col is None or table.empty:
             return None
-        i = int((table["age_months"] - age).abs().idxmin())
-        return None if abs(float(table["age_months"].iloc[i]) - age) > 0.6 else float(table[col].iloc[i])
+        # The 0.6-month bound is the point: this reads the monthly summary at
+        # the age asked for, and a grid that does not carry that age must give
+        # nothing rather than the nearest one it happens to have.
+        row = nearest_row(table, key="age_months", at=float(age), max_distance=0.6)
+        return None if row is None else float(row[col])
 
     has_weighted = any(w is not None for _, _, _, w in outcomes)
     header = ["Age", "Outcome", "Reference child"]

--- a/src/vocab_growth/storage.py
+++ b/src/vocab_growth/storage.py
@@ -8,8 +8,9 @@ from typing import Any
 
 from vocab_growth.fit_artifacts import require_valid_fit
 from vocab_growth.publication_checks import (
-    referenced_assets,
-    unpublished_assets,
+    check_uploaded_assets,
+    describe_failures,
+    inspect_report,
     verify_published,
 )
 from vocab_growth.reporting import (
@@ -44,6 +45,7 @@ def upload_to_blob_storage(
     include_traces: bool = False,
     skip: Callable[[str], bool] | None = None,
     verify: bool = True,
+    fetch_status: Callable[[str, float], int] | None = None,
 ) -> str:
     """Upload model output directory to Azure Blob Storage.
 
@@ -63,6 +65,11 @@ def upload_to_blob_storage(
         check ``publish_comparison.py`` performs for the comparison book,
         after a hand-assembled upload published that book with every image
         broken; the model reports had the same gap.
+    fetch_status : callable, optional
+        Transport for the HTTP check, receiving ``(url, timeout)`` and
+        returning an integer status. Defaults to the shared bounded GET that
+        refuses redirects. Supplied by the tests so the publication path can be
+        exercised end to end without reaching a network.
 
     Returns
     -------
@@ -110,32 +117,58 @@ def upload_to_blob_storage(
         ("Report URL", result.report_url),
     ]
     if verify:
-        rows.append(("Verified", _verify_report_upload(output_dir, model_label, result)))
+        rows.append(
+            (
+                "Verified",
+                _verify_report_upload(
+                    output_dir, model_label, result, fetch_status=fetch_status
+                ),
+            )
+        )
     key_value_table(f"Upload complete — {model_label}", rows)
     return result.report_url
 
 
-def _verify_report_upload(output_dir: str, model_label: str, result) -> str:
+def _verify_report_upload(
+    output_dir: str,
+    model_label: str,
+    result,
+    *,
+    fetch_status: Callable[[str, float], int] | None = None,
+) -> str:
     """Every referenced asset was sent, and every published file resolves.
 
     Returns the one-line summary for the upload table; raises on any failure so
-    a broken publication is never reported as complete.
+    a broken publication is never reported as complete. The local and inventory
+    check runs first and no request is made until it passes: a reference the
+    page makes to a file that was never written, or that the skip filter or the
+    trace exclusion left out, is a broken publication whatever the server would
+    have answered.
     """
     index_html = os.path.join(output_dir, "index.html")
-    missing = unpublished_assets(index_html, result.relative_paths)
-    if missing:
-        shown = ", ".join(missing[:8]) + (", ..." if len(missing) > 8 else "")
-        raise RuntimeError(
-            f"{model_label}: index.html references {len(missing)} asset(s) that "
-            f"were not uploaded (excluded by the skip filter or the trace "
-            f"exclusion): {shown}. The page would publish with those missing."
-        )
-    assets = referenced_assets(index_html)
-    failures = verify_published(result.prefix_url, ["index.html", *assets])
+    inspection = inspect_report(index_html)
+    failures = check_uploaded_assets(inspection, result.relative_paths)
     if failures:
-        shown = ", ".join(failures[:8]) + (", ..." if len(failures) > 8 else "")
+        shown = describe_failures(failures)
+        listed = ", ".join(shown[:8]) + (", ..." if len(shown) > 8 else "")
         raise RuntimeError(
-            f"{model_label}: {len(failures)} of {len(assets) + 1} published files "
-            f"did not return 200 under {result.prefix_url}: {shown}"
+            f"{model_label}: index.html requires {len(failures)} file(s) that this "
+            f"upload cannot serve — missing locally, or excluded by the skip filter "
+            f"or the trace exclusion: {listed}. The page would publish broken."
         )
-    return f"index.html and all {len(assets)} referenced assets return 200"
+    # The entry page first, deliberately: the shared check requests paths in the
+    # order given, and a publication whose own page is unreachable is not worth
+    # checking asset by asset.
+    entry = inspection.pages[0]
+    required = (entry, *(path for path in inspection.required_paths if path != entry))
+    http_failures = verify_published(
+        result.prefix_url, required, fetch_status=fetch_status
+    )
+    if http_failures:
+        shown = describe_failures(http_failures)
+        listed = ", ".join(shown[:8]) + (", ..." if len(shown) > 8 else "")
+        raise RuntimeError(
+            f"{model_label}: {len(http_failures)} of {len(required)} published files "
+            f"did not return 200 under {result.prefix_url}: {listed}"
+        )
+    return f"index.html and all {len(required) - 1} referenced assets return 200"

--- a/tests/test_administration_loo.py
+++ b/tests/test_administration_loo.py
@@ -322,3 +322,57 @@ def test_the_total_log_likelihood_is_conserved():
     per_term = u.sum(dim="obs_u_id") + s.sum(dim="obs_s_id")
     per_case = combined.sum(dim=ADMINISTRATION_DIM)
     np.testing.assert_allclose(per_case.values, per_term.values, rtol=0, atol=1e-12)
+
+
+def test_an_impossible_observation_survives_but_a_missing_one_does_not():
+    """``-inf`` is a value; ``NaN`` is an absence wearing one.
+
+    An administration the model gives zero probability has log likelihood
+    ``-inf``, and its case score must stay ``-inf`` rather than being dropped
+    or clipped -- PSIS-LOO reads that as the pointwise term it is. A ``NaN``
+    among the draws means something upstream failed, and summing it produces a
+    score that is quietly missing for that case while still being tabulated.
+    Both come from the shared aggregator; both are checked here because both
+    reach `loo_summary.csv`.
+    """
+    masks = {"obs_u_mask": np.array([True, True]), "obs_s_mask": np.array([True, True])}
+
+    combined = administration_log_likelihood(
+        _trace(
+            masks,
+            {
+                "y_u_obs": _factor([[[-np.inf, -2.0]]], "obs_u_id"),
+                "y_s_obs": _factor([[[-0.5, -4.0]]], "obs_s_id"),
+            },
+        ),
+        _BIVARIATE,
+    )
+    np.testing.assert_array_equal(combined.values[0, 0], [-np.inf, -6.0])
+
+    with pytest.raises(ValueError, match="NaN"):
+        administration_log_likelihood(
+            _trace(
+                masks,
+                {
+                    "y_u_obs": _factor([[[np.nan, -2.0]]], "obs_u_id"),
+                    "y_s_obs": _factor([[[-0.5, -4.0]]], "obs_s_id"),
+                },
+            ),
+            _BIVARIATE,
+        )
+
+
+def test_one_array_declared_as_two_factors_is_refused():
+    """Double counting looks exactly like a well-behaved score.
+
+    Two `LikelihoodFactor` entries naming the same trace variable would sum it
+    onto the same administrations twice and produce a total that is simply
+    wrong, with nothing in the result to show it.
+    """
+    masks = {"obs_u_mask": np.array([True, True]), "obs_s_mask": np.array([True, True])}
+    factors = {"y_u_obs": _factor([[[-1.0, -2.0]]], "obs_u_id")}
+    with pytest.raises(ValueError, match="more than once"):
+        administration_log_likelihood(
+            _trace(masks, factors),
+            (LikelihoodFactor("y_u_obs", "obs_u_mask"), LikelihoodFactor("y_u_obs", "obs_s_mask")),
+        )

--- a/tests/test_fit_artifacts.py
+++ b/tests/test_fit_artifacts.py
@@ -642,3 +642,129 @@ def test_a_failed_fit_keeps_the_model_label_in_its_quarantine_name(tmp_path):
     assert Path(retained).name.startswith(label), (
         f"quarantined fits must stay identifiable by model label: {retained}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Shared-library file and directory operations (dse-research-utils 0.14.0)
+# ---------------------------------------------------------------------------
+# `write_json_atomic` and `promote_staged_fit` delegate their replacement
+# mechanics to `dse_research_utils.storage`. What is pinned here is the part
+# the shared helpers leave to this repository: the stored JSON format and file
+# mode, the lock and backup retention, and the paths promotion must still
+# accept or refuse.
+
+
+def test_write_json_atomic_keeps_the_stored_format_and_creates_parents(tmp_path):
+    """Two-space indent, sorted keys, trailing newline — the format on disk.
+
+    Every manifest hash recorded in a ``comparison_manifest.json`` is a hash of
+    these exact bytes, so the serialisation is a compatibility surface even
+    though the writer beneath it changed.
+    """
+    from vocab_growth.fit_artifacts import write_json_atomic
+
+    target = tmp_path / "nested" / "deeper" / "fit_manifest.json"
+    write_json_atomic(str(target), {"b": 2, "a": {"n": 1}})
+
+    assert target.read_text(encoding="utf-8") == '{\n  "a": {\n    "n": 1\n  },\n  "b": 2\n}\n'
+
+
+def test_write_json_atomic_keeps_the_historical_file_mode(tmp_path):
+    """The shared temporary file is 0600; these artefacts are not.
+
+    Fit output is read back by other accounts on the shared fitting VM and by
+    the uploader, and every file this repository has written carried
+    ``0o666 & ~umask``. Restoring that explicitly is the migration's decision,
+    so it is checked rather than left to whichever mode the helper uses.
+    """
+    import os
+    import stat
+
+    from vocab_growth.fit_artifacts import write_json_atomic
+
+    current = os.umask(0o022)
+    os.umask(current)
+    target = tmp_path / "fit_state.json"
+    write_json_atomic(str(target), {"state": "complete"})
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o666 & ~current
+
+
+def test_write_json_atomic_leaves_the_destination_intact_on_failure(tmp_path):
+    """An unserialisable payload must not truncate the file already there."""
+    from vocab_growth.fit_artifacts import write_json_atomic
+
+    target = tmp_path / "fit_manifest.json"
+    write_json_atomic(str(target), {"schema_version": 1})
+    cycle: dict = {}
+    cycle["self"] = cycle
+
+    with pytest.raises(ValueError):
+        write_json_atomic(str(target), cycle)
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"schema_version": 1}
+    assert sorted(path.name for path in tmp_path.iterdir()) == ["fit_manifest.json"]
+
+
+def test_promote_staged_fit_retains_no_backup_after_success(tmp_path):
+    """``.previous`` is a rollback slot, not an archive.
+
+    The shared helper deliberately performs no cleanup; a fit's output can be
+    tens of gigabytes, so the retained copy is removed here as it always was.
+    """
+    canonical = tmp_path / "models" / "VG01-test"
+    staged = tmp_path / ".staging" / "run" / "models" / "VG01-test"
+    canonical.mkdir(parents=True)
+    staged.mkdir(parents=True)
+    (canonical / "marker.txt").write_text("old", encoding="utf-8")
+    (staged / "marker.txt").write_text("new", encoding="utf-8")
+
+    promote_staged_fit(str(staged), str(canonical))
+
+    previous = tmp_path / ".previous"
+    assert previous.is_dir() and list(previous.iterdir()) == []
+
+
+def test_promote_staged_fit_works_through_a_symlinked_output_root(tmp_path):
+    """``<repo>/output`` is a symlink to a scratch volume on the fitting VM.
+
+    The shared helper refuses a symlinked ancestor, so this repository resolves
+    the parent chain deliberately before calling it. Without that, promotion
+    would fail on every VM fit while passing in every local checkout.
+    """
+    scratch = tmp_path / "scratch"
+    (scratch / "models").mkdir(parents=True)
+    root = tmp_path / "output"
+    root.symlink_to(scratch, target_is_directory=True)
+    canonical = root / "models" / "VG01-test"
+    staged = root / ".staging" / "run" / "models" / "VG01-test"
+    staged.mkdir(parents=True)
+    (staged / "marker.txt").write_text("new", encoding="utf-8")
+
+    promote_staged_fit(str(staged), str(canonical))
+
+    assert (scratch / "models" / "VG01-test" / "marker.txt").read_text(
+        encoding="utf-8"
+    ) == "new"
+
+
+def test_promote_staged_fit_refuses_a_symlinked_destination(tmp_path):
+    """Resolving the parents must not extend to following the destination.
+
+    A ``models/<label>`` that is itself a link would otherwise have its target
+    replaced somewhere else entirely, which no caller asked for.
+    """
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    canonical = tmp_path / "models" / "VG01-test"
+    canonical.parent.mkdir(parents=True)
+    canonical.symlink_to(elsewhere, target_is_directory=True)
+    staged = tmp_path / ".staging" / "run" / "models" / "VG01-test"
+    staged.mkdir(parents=True)
+    (staged / "marker.txt").write_text("new", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="symlink"):
+        promote_staged_fit(str(staged), str(canonical))
+
+    assert staged.is_dir()
+    assert list(elsewhere.iterdir()) == []

--- a/tests/test_fit_manifest.py
+++ b/tests/test_fit_manifest.py
@@ -67,44 +67,103 @@ def test_write_fit_manifest_records_data_code_and_sampling(tmp_path):
     assert isinstance(manifest["runtime"]["direct_package_origins"], dict)
 
 
-def test_git_metadata_records_detached_head_as_null(monkeypatch):
-    outputs = {
-        ("rev-parse", "HEAD"): "abc123\n",
-        ("branch", "--show-current"): "\n",
-        ("status", "--porcelain", "--untracked-files=normal"): "",
+def _git(repository: Path, *arguments: str) -> str:
+    """Run one Git command in ``repository`` with no ambient identity."""
+    result = subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "-c",
+            "commit.gpgsign=false",
+            *arguments,
+        ],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _repository(tmp_path: Path) -> Path:
+    """A one-commit repository, so a commit and a branch both exist."""
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    _git(repository, "init", "--initial-branch=main", "--quiet")
+    (repository / "tracked.txt").write_text("one", encoding="utf-8")
+    _git(repository, "add", "tracked.txt")
+    _git(repository, "commit", "--quiet", "-m", "initial")
+    return repository
+
+
+def test_git_metadata_records_a_clean_checkout(tmp_path):
+    """The four recorded keys, against a real repository rather than a stub.
+
+    ``validate_fit_output`` turns ``dirty is not False`` into a refusal to
+    resume or publish, so "clean" has to be recorded as exactly ``False`` --
+    not ``None``, which is what an unavailable query records.
+    """
+    repository = _repository(tmp_path)
+
+    assert git_metadata(str(repository)) == {
+        "commit": _git(repository, "rev-parse", "HEAD"),
+        "branch": "main",
+        "detached": False,
+        "dirty": False,
     }
 
-    def fake_run(command, **kwargs):
-        del kwargs
-        return subprocess.CompletedProcess(
-            command,
-            0,
-            stdout=outputs[tuple(command[1:])],
-            stderr="",
-        )
 
-    monkeypatch.setattr("vocab_growth.fit_artifacts.subprocess.run", fake_run)
+def test_git_metadata_records_detached_head_as_null(tmp_path):
+    repository = _repository(tmp_path)
+    commit = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "checkout", "--quiet", "--detach", commit)
 
-    metadata = git_metadata("/repo")
-
-    assert metadata == {
-        "commit": "abc123",
+    assert git_metadata(str(repository)) == {
+        "commit": commit,
         "branch": None,
         "detached": True,
         "dirty": False,
     }
 
 
-def test_git_metadata_distinguishes_unavailable_git(monkeypatch):
-    def fail_run(command, **kwargs):
-        del command, kwargs
-        raise OSError("git unavailable")
+def test_git_metadata_counts_an_untracked_file_as_dirty(tmp_path):
+    """Untracked entries are dirt, and ignored ones are not.
 
-    monkeypatch.setattr("vocab_growth.fit_artifacts.subprocess.run", fail_run)
+    Both halves matter to ``require_clean_fit``: a fit whose output directory
+    happens to sit inside the checkout must not be recorded as dirty for that
+    reason, while a genuinely uncommitted source file must be.
+    """
+    repository = _repository(tmp_path)
+    (repository / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+    _git(repository, "add", ".gitignore")
+    _git(repository, "commit", "--quiet", "-m", "ignore")
+    (repository / "ignored").mkdir()
+    (repository / "ignored" / "trace.nc").write_bytes(b"artefact")
+    assert git_metadata(str(repository))["dirty"] is False
 
-    metadata = git_metadata("/repo")
+    (repository / "untracked.py").write_text("x = 1\n", encoding="utf-8")
+    assert git_metadata(str(repository))["dirty"] is True
 
-    assert metadata == {
+
+def test_git_metadata_distinguishes_unavailable_git(tmp_path):
+    """A directory that is not a working tree records nothing, not a clean one.
+
+    ``dirty`` must stay ``None`` here. ``False`` would let an unverifiable
+    checkout satisfy the publication provenance check.
+    """
+    outside = tmp_path / "not-a-repo"
+    outside.mkdir()
+
+    assert git_metadata(str(outside)) == {
+        "commit": None,
+        "branch": None,
+        "detached": None,
+        "dirty": None,
+    }
+    assert git_metadata(str(tmp_path / "absent")) == {
         "commit": None,
         "branch": None,
         "detached": None,

--- a/tests/test_gp_utils.py
+++ b/tests/test_gp_utils.py
@@ -22,7 +22,7 @@ import pytensor.tensor as pt
 import pytest
 
 from vocab_growth.models.build_utils import CLAMP_SOFTNESS
-from vocab_growth.models.common import get_hsgp_hyperparams
+from vocab_growth.models.common import get_hsgp_hyperparams, hsgp_design_for
 from vocab_growth.models.definitions import SubjectFactorPriorParams
 from vocab_growth.models.gp_utils import (
     CHILD_FACTOR_ANCHOR_ORDER,
@@ -639,3 +639,56 @@ def test_pinned_centre_decouples_the_basis_from_appended_query_rows():
     )
     assert not np.allclose(lazy_base, lazy_extended[:9])
 
+
+
+# --- saved HSGP geometry (dse-research-utils 0.14.0) ---------------------------
+#
+# `get_hsgp_hyperparams` now returns the two lists `pm.gp.HSGP` takes, taken
+# from a realised `HSGPDesign`; `_gp_from_mean` builds the object from that
+# record through the shared factory rather than by assigning PyMC's private
+# `_X_center`. The geometry is the fit's, so these check that it is the same
+# geometry and that it replays unchanged on grids other than the one it came
+# from.
+
+
+def test_the_saved_design_is_the_geometry_the_engines_build_from():
+    """One record, three scalars, agreeing with the pair the engines pass on."""
+    domain = np.array([[-1.5], [3.5]])
+    ell_range_z = (0.3, 1.2)
+
+    design = hsgp_design_for(domain, ell_range_z)
+    L, M = get_hsgp_hyperparams(domain, ell_range_z)
+
+    assert [design.L] == L and [design.m] == M
+    # The centre is the declared domain's midpoint, which is what
+    # `GPGrid.from_age_grids` pins, and not the midpoint of any query grid.
+    assert design.center == 1.0
+    assert design.calibration_version == "pymc-expquad-v1"
+
+
+def test_saved_geometry_replays_on_subset_and_extended_grids():
+    """The #234 property, now a property of the record rather than of a pin.
+
+    A basis built from saved geometry evaluates each row the same way whatever
+    else is in the array with it: a subset gives the same rows as the full
+    grid, and appending reporting ages beyond the observed range leaves the
+    shared rows untouched. Without a fixed centre, PyMC takes it from the
+    min/max of whatever it is handed, so both of these would move.
+    """
+    from dse_research_utils.statistics.models.hsgp_design import (
+        HSGPDesign,
+        create_hsgp,
+    )
+
+    low, high = -2.5, 1.9
+    design = HSGPDesign(m=24, L=(high - low) / 2 * 1.7, center=(low + high) / 2)
+    rows = np.linspace(low, high, 40).reshape(-1, 1)
+
+    with pm.Model():
+        gp = create_hsgp(design, cov_func=pm.gp.cov.ExpQuad(1, ls=0.4))
+        full = gp.prior_linearized(rows)[0].eval()
+        subset = gp.prior_linearized(rows[7:19])[0].eval()
+        extended = gp.prior_linearized(np.vstack([rows, [[high]], [[low]]]))[0].eval()
+
+    np.testing.assert_array_equal(full[7:19], subset)
+    np.testing.assert_array_equal(full, extended[: len(rows)])

--- a/tests/test_loo_compare.py
+++ b/tests/test_loo_compare.py
@@ -37,11 +37,19 @@ def _make_trace(u_mask, s_mask, u_ll, s_ll, *, constant_data=True):
     ``u_ll`` / ``s_ll`` are (chain, draw, factor) arrays whose factor lengths
     must match the mask counts (unless a test deliberately breaks that).
     """
+    u_values = np.asarray(u_ll, dtype=float)
     log_likelihood = xr.Dataset(
         {
-            "y_u_obs": (("chain", "draw", "obs_u_id"), np.asarray(u_ll, dtype=float)),
+            "y_u_obs": (("chain", "draw", "obs_u_id"), u_values),
             "y_s_obs": (("chain", "draw", "obs_s_id"), np.asarray(s_ll, dtype=float)),
-        }
+        },
+        # The chain and draw labels a trace read back from `trace.nc` carries.
+        # The combination is by explicit unit now, and it checks that the
+        # factors it sums were drawn from the same samples.
+        coords={
+            "chain": np.arange(u_values.shape[0]),
+            "draw": np.arange(u_values.shape[1]),
+        },
     )
     groups = {"log_likelihood": log_likelihood}
     if constant_data:

--- a/tests/test_predictive_calibration.py
+++ b/tests/test_predictive_calibration.py
@@ -307,8 +307,16 @@ def test_render_calibration_section_explains_a_legacy_table(tmp_path, capsys):
 # --------------------------------------------------------------------------
 
 
-def _stratifiable_trace(n_rows: int, n_conditional: int):
-    """A minimal trace carrying one outcome and a branch indicator."""
+def _stratifiable_trace(n_rows: int, n_conditional: int, *, observed_ids=None):
+    """A minimal trace carrying one outcome and a branch indicator.
+
+    The chain, draw and observation coordinates are the ones a real trace
+    carries: every engine builds its model with ``pm.Model(coords=...)``, and
+    the calibration writer now checks the observed array's labels against the
+    replications' rather than assuming equal lengths mean equal rows.
+    ``observed_ids`` overrides the observed group's labels so that check can be
+    exercised.
+    """
     import xarray as xr
 
     rng = np.random.default_rng(20260824)
@@ -316,17 +324,29 @@ def _stratifiable_trace(n_rows: int, n_conditional: int):
     observed = rng.integers(0, 20, size=n_rows)
     is_conditional = np.zeros(n_rows, dtype=int)
     is_conditional[:n_conditional] = 1
+    row_ids = np.arange(n_rows)
     return xr.DataTree.from_dict(
         {
             "posterior_predictive": xr.Dataset(
-                {"y_s_obs": (("chain", "draw", "obs_s_id"), predictive)}
+                {"y_s_obs": (("chain", "draw", "obs_s_id"), predictive)},
+                coords={
+                    "chain": np.arange(2),
+                    "draw": np.arange(50),
+                    "obs_s_id": row_ids,
+                },
             ),
-            "observed_data": xr.Dataset({"y_s_obs": (("obs_s_id",), observed)}),
+            "observed_data": xr.Dataset(
+                {"y_s_obs": (("obs_s_id",), observed)},
+                coords={
+                    "obs_s_id": row_ids if observed_ids is None else observed_ids
+                },
+            ),
             "constant_data": xr.Dataset(
                 {
                     "obs_s_mask": (("obs_id",), np.ones(n_rows, dtype=int)),
                     "s_is_conditional": (("obs_s_id",), is_conditional),
-                }
+                },
+                coords={"obs_s_id": row_ids},
             ),
         }
     )
@@ -421,3 +441,42 @@ def test_calibration_rejects_a_stratum_that_is_not_row_aligned(tmp_path):
             (("spoken", "y_s_obs", "obs_s_mask"),),
             strata={"spoken": ("short", "a", "b")},
         )
+
+
+def test_calibration_rejects_observations_labelled_differently_from_the_draws(tmp_path):
+    """Equal lengths never established that the rows are the same rows.
+
+    The observed group and the posterior-predictive group are separate arrays
+    on the trace. Before the labelled extraction they were flattened and paired
+    by position, so a reordered or re-labelled observed group would have been
+    scored against the wrong replications and produced a plausible table.
+    """
+    from vocab_growth.models.calibration import write_trace_calibration
+
+    n_rows = 12
+    trace = _stratifiable_trace(
+        n_rows, n_conditional=6, observed_ids=np.arange(n_rows)[::-1]
+    )
+    analysis_df = pd.DataFrame({"age": np.linspace(10, 60, n_rows)})
+
+    with pytest.raises(ValueError, match="Cannot align 'y_s_obs'"):
+        write_trace_calibration(
+            trace,
+            analysis_df,
+            str(tmp_path),
+            (("spoken", "y_s_obs", "obs_s_mask"),),
+        )
+
+
+def test_calibration_rejects_a_non_finite_observation(tmp_path):
+    """A NaN outcome means the engine masked the wrong rows.
+
+    Reported here rather than left to the shared checks, so the message names
+    the table being written and how many rows are unusable.
+    """
+    observed = np.array([1.0, np.nan, 3.0])
+    predictive = np.array([[0, 1, 2, 3], [0, 1, 2, 3], [1, 2, 3, 4]])
+    ages = np.array([12.0, 13.0, 14.0])
+
+    with pytest.raises(ValueError, match="finite observations; 1 of 3"):
+        predictive_calibration_table(observed, predictive, ages)

--- a/tests/test_publication_checks.py
+++ b/tests/test_publication_checks.py
@@ -8,6 +8,14 @@ of its 24 figures, and reported as published because the page returned 200.
 The model-report upload had the same gap. These tests pin the three checks
 that close it: the asset list is derived from the page, an upload that left a
 referenced asset out is named, and every published file is requested back.
+
+Since the shared library's 0.14.0 release the parsing is
+``dse_research_utils.report.assets``, and two of these tests changed with it. A
+reference to a file that is not there is now a failure rather than something
+quietly left off the list; and an ``href`` is URL-decoded once, so linking a
+file literally named ``50%20.csv`` as ``href="50%20.csv"`` asks the browser for
+``50 .csv`` and is a broken link, not a compatibility target. Both forms are
+kept below.
 """
 
 from __future__ import annotations
@@ -15,15 +23,17 @@ from __future__ import annotations
 import functools
 import http.server
 import threading
-from contextlib import nullcontext
 from types import SimpleNamespace
 from urllib.parse import quote
 
 import pytest
 
 from vocab_growth.publication_checks import (
+    describe_failures,
+    inspect_report,
+    local_failures,
     referenced_assets,
-    unpublished_assets,
+    upload_failures,
     verify_published,
 )
 
@@ -32,44 +42,151 @@ _PAGE = """<html><head>
 <link rel="stylesheet" href="https://cdn.example.org/site.css">
 </head><body>
 <img src="figures/trajectory.png">
-<img src="figures/missing.png">
 <img src="data:image/png;base64,AAAA">
+<a href="tables/summary.csv">download</a>
 <a href="#section">anchor</a>
 <a href="index.html?tab=2">query</a>
 <a href="mailto:someone@example.org">mail</a>
-<a href="../outside.txt">outside</a>
 </body></html>
 """
+
+#: The same page plus the two references no upload could satisfy: a figure that
+#: was never written, and a link out of the published directory.
+_BROKEN_PAGE = _PAGE.replace(
+    "</body>", '<img src="figures/missing.png"><a href="../outside.txt">out</a></body>'
+)
+
+
+def _write_page(directory, html):
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "index_files").mkdir(exist_ok=True)
+    (directory / "index_files" / "style.css").write_text("body{}", encoding="utf-8")
+    (directory / "figures").mkdir(exist_ok=True)
+    (directory / "figures" / "trajectory.png").write_bytes(b"png")
+    (directory / "tables").mkdir(exist_ok=True)
+    (directory / "tables" / "summary.csv").write_text("a,b\n", encoding="utf-8")
+    (directory.parent / "outside.txt").write_text("x", encoding="utf-8")
+    target = directory / "index.html"
+    target.write_text(html, encoding="utf-8")
+    return target
 
 
 @pytest.fixture
 def page(tmp_path):
-    (tmp_path / "index_files").mkdir()
-    (tmp_path / "index_files" / "style.css").write_text("body{}", encoding="utf-8")
-    (tmp_path / "figures").mkdir()
-    (tmp_path / "figures" / "trajectory.png").write_bytes(b"png")
-    (tmp_path.parent / "outside.txt").write_text("x", encoding="utf-8")
-    html = tmp_path / "index.html"
-    html.write_text(_PAGE, encoding="utf-8")
-    return html
+    return _write_page(tmp_path, _PAGE)
+
+
+@pytest.fixture
+def broken_page(tmp_path):
+    return _write_page(tmp_path, _BROKEN_PAGE)
 
 
 def test_referenced_assets_are_derived_from_the_page(page):
     assets = referenced_assets(str(page))
     # Local files that exist, relative to the page, POSIX separators. External
-    # URLs, data URIs, anchors, query links, mailto and a file outside the
-    # page's directory tree are not assets the upload could have carried.
-    assert assets == ["figures/trajectory.png", "index_files/style.css"]
-
-
-def test_unpublished_assets_names_what_the_upload_left_out(page):
-    assert unpublished_assets(str(page), ["index.html", "index_files/style.css"]) == [
-        "figures/trajectory.png"
+    # URLs, data URIs, anchors and mailto are not assets the upload could carry;
+    # the query link resolves to the page itself, which the caller publishes
+    # separately. The CSV download link *is* required: these reports offer their
+    # summary tables that way, and a 404 there is as broken as a missing image.
+    assert assets == [
+        "figures/trajectory.png",
+        "index_files/style.css",
+        "tables/summary.csv",
     ]
+    assert local_failures(inspect_report(str(page))) == ()
+
+
+def test_a_reference_no_upload_could_satisfy_is_named_not_dropped(broken_page):
+    """The previous scanner left both of these off the list entirely.
+
+    A page referencing a figure that was never written then published silently,
+    which is the 2026-09-03 failure with the missing file one step earlier.
+    """
+    failures = {failure.path: failure.reason for failure in local_failures(inspect_report(str(broken_page)))}
+    assert failures == {"figures/missing.png": "missing", "../outside.txt": "outside_root"}
+    # The list a publisher copies from still contains only files that exist.
+    assert "figures/missing.png" not in referenced_assets(str(broken_page))
+
+
+def test_upload_failures_name_what_the_upload_left_out(page):
+    assert describe_failures(
+        upload_failures(str(page), ["index.html", "index_files/style.css"])
+    ) == ["figures/trajectory.png (not_uploaded)", "tables/summary.csv (not_uploaded)"]
     # Backslash paths from a Windows walker compare equal.
-    assert unpublished_assets(
-        str(page), ["index.html", "index_files\\style.css", "figures\\trajectory.png"]
-    ) == []
+    assert (
+        upload_failures(
+            str(page),
+            [
+                "index.html",
+                "index_files\\style.css",
+                "figures\\trajectory.png",
+                "tables\\summary.csv",
+            ],
+        )
+        == ()
+    )
+
+
+def test_an_inventory_entry_cannot_hide_a_missing_local_file(broken_page):
+    """Claiming to have uploaded a file that is not there is not a pass."""
+    reasons = {
+        failure.reason
+        for failure in upload_failures(
+            str(broken_page),
+            [
+                "index.html",
+                "index_files/style.css",
+                "figures/trajectory.png",
+                "figures/missing.png",
+                "tables/summary.csv",
+            ],
+        )
+    }
+    assert reasons == {"missing", "outside_root"}
+
+
+@pytest.mark.parametrize(
+    ("markup", "reason"),
+    [
+        ('<base href="assets/">', "unsupported_base"),
+        ('<img src="figures/trajectory.png" srcset="figures/trajectory.png 2x">', "unsupported_srcset"),
+        ('<img src="/figures/trajectory.png">', "root_relative_url"),
+    ],
+)
+def test_constructs_that_change_what_a_browser_loads_are_not_certified(
+    tmp_path, markup, reason
+):
+    """Each of these decides which file is actually requested.
+
+    Ignoring them would let the check certify a bundle the browser does not
+    load: ``base href`` re-roots every relative URL, ``srcset`` can select a
+    file nothing else references, and a root-relative URL resolves at the site
+    origin rather than under the upload prefix.
+    """
+    page = _write_page(tmp_path, _PAGE.replace("<body>", "<body>" + markup))
+    assert reason in {failure.reason for failure in local_failures(inspect_report(str(page)))}
+
+
+def test_a_literal_percent_in_a_filename_has_to_be_encoded_twice(tmp_path):
+    """``href="50%20.csv"`` asks the browser for ``50 .csv``.
+
+    The previous scanner matched the raw attribute against the filesystem, so
+    it reported this page as complete while a reader clicking the link got a
+    404. The correctly encoded form is ``50%2520.csv``; both are pinned.
+    """
+    (tmp_path / "50%20.csv").write_text("a,b\n", encoding="utf-8")
+    mismatched = _write_page(
+        tmp_path / "raw", _PAGE.replace("<body>", '<body><a href="50%20.csv">table</a>')
+    )
+    (tmp_path / "raw" / "50%20.csv").write_text("a,b\n", encoding="utf-8")
+    assert [failure.path for failure in local_failures(inspect_report(str(mismatched)))] == ["50 .csv"]
+
+    encoded = _write_page(
+        tmp_path / "enc", _PAGE.replace("<body>", '<body><a href="50%2520.csv">table</a>')
+    )
+    (tmp_path / "enc" / "50%20.csv").write_text("a,b\n", encoding="utf-8")
+    assert local_failures(inspect_report(str(encoded))) == ()
+    assert "50%20.csv" in referenced_assets(str(encoded))
 
 
 @pytest.fixture
@@ -89,17 +206,43 @@ def served(page):
 
 def test_verify_published_requests_every_file_back(served, page):
     assets = referenced_assets(str(page))
-    assert verify_published(served, ["index.html", *assets]) == []
+    assert verify_published(served, ["index.html", *assets]) == ()
     # A file the page references but the upload did not carry is reported by
-    # path, which is the 2026-09-03 failure made visible.
+    # path and status, which is the 2026-09-03 failure made visible.
     failures = verify_published(served, ["index.html", "figures/absent.png"])
-    assert failures == ["HTTPError figures/absent.png"]
+    assert describe_failures(failures) == ["figures/absent.png (http_status 404)"]
 
 
 def test_verify_published_reports_an_unreachable_host():
     failures = verify_published("http://127.0.0.1:9/", ["index.html"], timeout=1.0)
     assert len(failures) == 1
-    assert failures[0].endswith(" index.html")
+    assert failures[0].path == "index.html" and failures[0].status_code is None
+
+
+def test_verify_published_can_be_driven_through_an_injected_transport():
+    """Each distinct path is requested once, in the order given, encoded once.
+
+    The transport is injectable so the encoding and the request order can be
+    checked without a server, and so a caller can supply one that follows the
+    same no-redirect rule.
+    """
+    requests = []
+
+    def fetch_status(url: str, timeout: float) -> int:
+        requests.append(url)
+        return 404 if url.endswith("missing.png") else 200
+
+    failures = verify_published(
+        "https://example.org/report%20one/",
+        ["index.html", "tables/a+b.csv", "index.html", "missing.png"],
+        fetch_status=fetch_status,
+    )
+    assert requests == [
+        "https://example.org/report%20one/index.html",
+        "https://example.org/report%20one/tables/a%2Bb.csv",
+        "https://example.org/report%20one/missing.png",
+    ]
+    assert describe_failures(failures) == ["missing.png (http_status 404)"]
 
 
 @pytest.fixture
@@ -111,8 +254,14 @@ def upload_report(tmp_path, monkeypatch):
         path = tmp_path / name
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("asset", encoding="utf-8")
+    # A literal percent sign in a filename is `%25` in an href, so the file
+    # named `50%20.csv` is linked as `50%2520.csv`. The uploader still sends,
+    # and the HTTP check still encodes, the raw name.
     (tmp_path / "index.html").write_text(
-        "".join(f'<a href="{name}">asset</a>' for name in names), encoding="utf-8"
+        "".join(
+            f'<a href="{name.replace("%", "%25")}">asset</a>' for name in names
+        ),
+        encoding="utf-8",
     )
     (tmp_path / "trace.nc").write_bytes(b"excluded")
     sent, requested = [], []
@@ -126,21 +275,22 @@ def upload_report(tmp_path, monkeypatch):
     monkeypatch.setattr("azure.identity.DefaultAzureCredential", lambda: object())
     monkeypatch.setenv("DSERESEARCH_BLOB_CONTAINER_URL", "https://acct.blob.core.windows.net/reports")
 
-    def request(url, **kwargs):
+    def fetch_status(url, timeout):
         requested.append(url)
-        return nullcontext(SimpleNamespace(status=200))
+        return 200
 
-    monkeypatch.setattr("urllib.request.urlopen", request)
-    return ValidatedFitOutput(str(tmp_path)), names, sent, requested
+    return ValidatedFitOutput(str(tmp_path)), names, sent, requested, fetch_status
 
 
 def test_upload_matches_raw_names_and_requests_encoded_urls(upload_report):
     from vocab_growth.storage import upload_to_blob_storage
 
-    output, names, sent, requested = upload_report
-    report = upload_to_blob_storage(output, "model (dev)")
+    output, names, sent, requested, fetch_status = upload_report
+    report = upload_to_blob_storage(output, "model (dev)", fetch_status=fetch_status)
     prefix = report.removesuffix("index.html")
     assert "model%20%28dev%29/" in prefix
+    # The entry page is requested first, deliberately: a publication whose own
+    # page is unreachable is not worth checking asset by asset.
     assert requested == [report, *(prefix + quote(name, safe="/") for name in sorted(names))]
     assert len(sent) == len(names) + 1
     assert not any(name.endswith("trace.nc") for name in sent)
@@ -151,9 +301,11 @@ def test_upload_matches_raw_names_and_requests_encoded_urls(upload_report):
 def test_upload_still_rejects_skipped_referenced_files(upload_report, skipped):
     from vocab_growth.storage import upload_to_blob_storage
 
-    output, _, _, requested = upload_report
-    with pytest.raises(RuntimeError, match="were not uploaded") as error:
-        upload_to_blob_storage(output, "model", skip=lambda name: name == skipped)
+    output, _, _, requested, fetch_status = upload_report
+    with pytest.raises(RuntimeError, match="this upload cannot serve") as error:
+        upload_to_blob_storage(
+            output, "model", skip=lambda name: name == skipped, fetch_status=fetch_status
+        )
     assert skipped in str(error.value)
     assert requested == []
 
@@ -161,7 +313,36 @@ def test_upload_still_rejects_skipped_referenced_files(upload_report, skipped):
 def test_nested_index_does_not_replace_skipped_root(upload_report):
     from vocab_growth.storage import upload_to_blob_storage
 
-    output, _, _, requested = upload_report
+    output, _, _, requested, fetch_status = upload_report
     with pytest.raises(RuntimeError, match="No index.html report"):
-        upload_to_blob_storage(output, "model", skip=lambda name: name == "index.html")
+        upload_to_blob_storage(
+            output,
+            "model",
+            skip=lambda name: name == "index.html",
+            fetch_status=fetch_status,
+        )
     assert requested == []
+
+
+def test_upload_fails_when_a_published_file_does_not_resolve(upload_report):
+    """A 200 on the page says nothing about the files it needs.
+
+    This is the 2026-09-03 failure exactly: `index.html` answered, every figure
+    did not, and the publication was reported complete. Driven through the
+    injected transport, so the check runs without a network.
+    """
+    from vocab_growth.storage import upload_to_blob_storage
+
+    output, _, _, requested, _ = upload_report
+
+    def fetch_status(url, timeout):
+        requested.append(url)
+        # The entry page answers; nothing beside it does.
+        return 200 if len(requested) == 1 else 404
+
+    with pytest.raises(RuntimeError, match="did not return 200") as error:
+        upload_to_blob_storage(output, "model", fetch_status=fetch_status)
+    message = str(error.value)
+    assert requested[0].endswith("/index.html")
+    assert "5 of 6 published files" in message
+    assert "http_status 404" in message

--- a/tests/test_report_cells.py
+++ b/tests/test_report_cells.py
@@ -1728,3 +1728,71 @@ def test_reference_child_calibration_sets_the_curve_beside_the_sample(tmp_path, 
 def test_reference_child_calibration_says_so_without_a_monthly_summary(tmp_path, capsys):
     report_cells.render_reference_child_calibration(str(_fit(tmp_path)))
     assert "no monthly summary" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Read states (dse-research-utils 0.14.0)
+# ---------------------------------------------------------------------------
+# The report's artefact reads distinguish three states rather than two. A file
+# this engine never writes and a file that cannot be parsed used to be the same
+# thing here -- both rendered the pending-fit placeholder, which tells a reader
+# "this fit has yet to produce it" about a fit that produced something damaged.
+
+
+def test_a_damaged_summary_is_not_a_fit_that_has_yet_to_produce_one(tmp_path):
+    """A parse failure raises; the placeholder is reserved for absence."""
+    (tmp_path / "posterior_summary.csv").write_text(
+        'age_months,Ey_median\n1,2\n"unterminated\n', encoding="utf-8"
+    )
+
+    assert report_cells._read(str(tmp_path), "absent_table") is None
+    with pytest.raises(report_cells.ReportArtefactError, match="parse_error"):
+        report_cells._read(str(tmp_path), "posterior_summary")
+
+
+def test_a_table_written_with_no_rows_still_reads_as_absent(tmp_path):
+    """`pd.DataFrame([]).to_csv()` writes a bare newline, not a damaged file.
+
+    Several writers here build their table from a list of row dicts and write
+    it whatever that list contains. With no rows the frame has no columns at
+    all, and the file records "there was nothing to tabulate" — which the
+    report has always rendered as pending, and must keep rendering that way.
+    """
+    pd.DataFrame([]).to_csv(tmp_path / "posterior_summary.csv", index=False)
+    (tmp_path / "diagnostics.csv").write_text("\n", encoding="utf-8")
+
+    assert report_cells._read(str(tmp_path), "posterior_summary") is None
+    assert report_cells.fitted_parameters(str(tmp_path)) == set()
+
+
+def test_a_damaged_diagnostics_table_does_not_silently_empty_the_prior_check(tmp_path):
+    """`fitted_parameters` decides which priors a report claims were sampled.
+
+    Returning an empty set for an unreadable file would silently withdraw every
+    parameter from the priors table instead of saying the file is damaged.
+    """
+    (tmp_path / "diagnostics.csv").write_text(
+        'name,r_hat\neta_u,1.0\n"unterminated\n', encoding="utf-8"
+    )
+
+    with pytest.raises(report_cells.ReportArtefactError, match="diagnostics.csv"):
+        report_cells.fitted_parameters(str(tmp_path))
+
+
+def test_an_unreadable_gate_payload_says_so_rather_than_reporting_no_gate(tmp_path, capsys):
+    """Absent and unreadable are different sentences on the rendered page."""
+    report_cells.render_diagnostic_verdict(str(tmp_path))
+    assert "No `diagnostics_summary.json`" in capsys.readouterr().out
+
+    (tmp_path / "diagnostics_summary.json").write_text("{not json", encoding="utf-8")
+    report_cells.render_diagnostic_verdict(str(tmp_path))
+    out = capsys.readouterr().out
+    assert "could not be read" in out and "parse_error" in out
+
+
+def test_an_unreadable_loo_summary_says_so_rather_than_reporting_none(tmp_path, capsys):
+    (tmp_path / "loo_summary.csv").write_text('a,b\n1,2\n"unterminated\n', encoding="utf-8")
+
+    report_cells.render_loo_section(str(tmp_path))
+    out = capsys.readouterr().out
+    assert "could not be read" in out and "parse_error" in out

--- a/uv.lock
+++ b/uv.lock
@@ -550,8 +550,8 @@ wheels = [
 
 [[package]]
 name = "dse-research-utils"
-version = "0.13.0"
-source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.13.0#458cc41b1dc33f4c0204919253ac92251c61b2bb" }
+version = "0.14.0"
+source = { git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.14.0#50390f4f9cd19033e3d0dc9bd050b383bd413c36" }
 dependencies = [
     { name = "arviz" },
     { name = "arviz-base" },
@@ -629,7 +629,7 @@ typecheck = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.13.0" }]
+requires-dist = [{ name = "dse-research-utils", extras = ["columnar", "graphs", "io", "jax", "notebook", "viz"], git = "https://github.com/dseinternational/research.git?subdirectory=src%2Fpython&tag=v0.14.0" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

Pin `dse-research-utils` to the `v0.14.0` tag (lock commit `50390f4`, no other locked package moved, extras unchanged) and route this repository's remaining local copies through the helpers that release adds. Followed the tagged [0.14.0 upgrade notes](https://github.com/dseinternational/research/blob/v0.14.0/docs/migrating-to-0.14.md) and [combined migration guide](https://github.com/dseinternational/research/blob/v0.14.0/docs/consolidation-migration.md). The full record, including every decision to *not* delegate, is in [the migration note](notes/202609071034-research-utils-014-migration.md).

## What now delegates

- **Files and directories.** `write_json_atomic` keeps its serialisation — the stored bytes are what a `comparison_manifest.json` hashes — and replaces its temporary-file dance with `storage.files.atomic_write`. The shared temporary file is owner-only, so a new `write_atomic` restores the historical `0o666 & ~umask` explicitly and is now the single place that decision is made; `sync_report_figures` writes its generated tables through it too. `promote_staged_fit` and the figure-cache sync delegate their renames to `storage.directories.promote_directory`, keeping the lock scope (threads of one process, stated and justified) and the backup-deleted-on-success policy. `promotion_path` resolves parent chains deliberately, because `<repo>/output` is a symlink to a scratch volume on the fitting VM and the helper refuses symlinked ancestors.
- **Provenance.** `git_metadata` keeps its four manifest keys and their meanings and obtains them from `git_snapshot` — one bounded `status --porcelain=v2` call, `GIT_*` overrides stripped, the 10-second timeout this repository has always allowed passed explicitly. `comparisons_provenance._file_sha256` is `sha256_file` plus this project's `sha256:` prefix.
- **Administration likelihood.** `administration_log_likelihood` hands its factors to `aggregate_log_likelihood` with the units stated explicitly, so `obs_joint` *is* the analysis-frame position rather than a rank that happened to coincide with it. `scripts/loo_compare.py` carried the original of that arithmetic and now delegates too, keeping its `y_joint` name and its own refusals.
- **Predictive summaries.** `predictive_calibration_table` takes its per-observation quantities from `predictive_observation_checks`; the age banding, zero rates, group means and table schema stay. `write_trace_calibration` extracts draws through `sample_matrix` and takes observed values through `SampleMatrix.observed_values`, so the two trace groups are checked by label instead of paired by position.
- **Report reads.** `report_cells` reads through `read_csv` / `read_json` and distinguishes absent from damaged. `read_manifest` deliberately stays on the permissive parser (manifests can carry bare `NaN` tokens and must stay readable). `nearest_row` replaces the single-row lookups in `report_cells` and `_report_data.qmd`.
- **HSGP.** `get_hsgp_hyperparams` returns the two lists `pm.gp.HSGP` takes from a realised `HSGPDesign` (`c_floor=None`, the calibration unchanged); `_gp_from_mean` builds the object with `create_hsgp`, replacing the assignment to PyMC's private `_X_center`. Priors, variable names and order, dimensions, observed-row projection and anchoring are untouched.

## Behaviour that deliberately changes

- A required page reference to a file that is not on disk is now a publication failure. The previous scanner dropped it, so a page referencing a figure that was never written published silently — the 2026-09-03 comparison-book failure one step earlier.
- `base href`, `srcset` and root-relative URLs are reported as unsupported rather than certified. Each decides which file a browser actually requests.
- An `href` is URL-decoded once. The existing test linked a file literally named `50%20.csv` as `href="50%20.csv"`, which asks a browser for `50 .csv`; the guide names that test as not a valid compatibility target. Both the mismatch and the correctly encoded `50%2520.csv` are pinned.
- A damaged artefact no longer renders as a pending-fit placeholder. This also fixes a live defect: `render_calibration_section` read the calibration CSV with a bare `pd.read_csv`, and a fit whose trace carried no recognised outcome writes a column-less file that aborted the report cell with `EmptyDataError`.
- `upload_to_blob_storage` gained an optional `fetch_status` transport. Before it, one upload test reached a real Azure endpoint, because the shared default transport is `build_opener(...).open` rather than the `urlopen` the test patched.

## Validation

Equivalence was established by comparing each migrated function against its previous implementation, inlined, rather than by reasoning about the code:

- **Administration likelihood** — 200 randomised cases (one to three factors including a matrix-valued composition factor, 3–40 administrations, 1–4 chains) identical bit-for-bit, coordinates included; on a 60-administration, 4×500-draw case the pointwise PSIS-LOO `elpd_i` and Pareto-k arrays are identical too.
- **Predictive calibration** — 364 complete tables compared with `assert_frame_equal(check_exact=True, check_dtype=True)` across 120 randomised shapes, three chunk sizes and float64/float32/int32/int64 draws. All identical.
- **HSGP** — 500 randomised calibrations reproduce the previous `m`, `L` and centre exactly; 200 randomised constructions give a bit-for-bit equal basis, spectral density and pinned centre; `trend_and_gp` draws identically under both constructions for three centres and three seeds, with the same free RVs in the same order. Saved geometry replays identically on full, subset and extended query grids.

`uv sync --locked`, Ruff, mypy, Prettier and CSpell pass. The complete suite (`-m "slow or not slow" -n auto --dist loadfile`) passes with 2,283 tests and 11 skipped, including the slow sampling and numerical-optimisation tests.

This checkout has no complete fitted model output, so the report check renders the actual report functions against labelled synthetic fixtures: a healthy fit, a fit whose diagnostics payload and LOO summary are corrupt, a fit whose calibration table is the column-less file above, and an absent fit. All three states read as intended. The `_report_data.qmd` helpers were executed against a synthetic figure cache.

## Refits

The executable-code signature hashes every module in the package plus the installed `dse-research-utils` version; both moved. Every existing fit therefore fails that check under `resume`, `sync` and `publish` and needs a reporting-quality refit before its results are syndicated or built on — the intended behaviour of that check, not bypassed here. `render` and `provisional-sync` do not ask for it, so existing fits remain renderable for review. No manifest is rewritten; historical manifests stay records of the code that produced them. Model definitions are untouched. **No reporting-quality refits and no publication uploads were performed in this PR.**

Closes #313
