### PR TITLE
Correct the per-fit cost in the slow-test note

### DIFF
--- a/notes/202609111158-slow-test-cost-was-not-data-preparation.md
+++ b/notes/202609111158-slow-test-cost-was-not-data-preparation.md
@@ -36,7 +36,11 @@ summary_var_names = [var.name for var in model.unobserved_RVs if var.size.eval()
 
 The fix is to stop compiling once per variable. Most of these variables have a fully static type shape — every scalar prior does — so their element count is the product of it, needing no PyTensor at all; the rest are evaluated **together** in one compiled function. Over all twenty-one models and all eighty-five registered variants the two implementations return **byte-identical lists in byte-identical order, 106 of 106**, at 416.9 s against 97.7 s.
 
-This is production code, not test code, so every fit pays it too — trivially, at six seconds each, which is why it was never noticed there.
+This is production code, not test code, so every fit pays it too — and never noticeably, which is why it sat there.
+
+**Corrected 2026-09-11, on review.** This paragraph first said "six seconds each", which was the _synthetic-frame maximum_ (VG24) read as if it were the per-fit cost. Re-measured on the **real** full-size frames a fit actually uses, the old implementation costs **1.2 s (VG11, 18,500 rows) to 3.5 s (VG24)** and the new one 0.9 s to 2.5 s — a saving under two seconds on a fit that runs for an hour. The two figures differ because a real frame leaves more of these variables with a symbolic observation dimension, so more of them go through the batched evaluation instead of the static-shape shortcut; the 4–20x speed-ups in this note are synthetic-frame figures and belong to the test file, which is where the 106 repetitions are. The conclusion is unchanged and the reason for it is now the right one: negligible in a fit, and the whole cost of a file that pays it 106 times.
+
+The same caution applies to the table above and the one in §1: both are synthetic-frame measurements, and the build total moved between runs (3.6 s in §1's stage profile, 6.4 s in §2's) with compilation warm-up. Nothing in the comparison depends on which, because both were measured against the 75.8 s in the same run — but they are not the same number measured twice, and should not be read as one. Identical output was re-verified on the real frames too: VG10, VG11, VG15, VG16, VG22 and VG24 all return byte-identical summary and gate lists under both implementations.
 
 ## 3. The synthetic frame, kept for a different reason than the one proposed
 


### PR DESCRIPTION
> [!NOTE]
> Drafted by an LLM-based AI tool (Claude Code/Opus 5).

Documentation only; follows [#334](https://github.com/dseinternational/vocabulary-growth/pull/334) on review.

`notes/202609111158` said every fit pays **six seconds** for `diagnostics_var_names`. Six seconds was VG24's cost on the **synthetic** frame, read across as if it were the per-fit cost. Re-measured on the real full-size frames a fit actually uses:

| model | rows | old | new |
| ----- | ---: | --: | --: |
| VG11 | 18,500 | 1.16 s | 0.93 s |
| VG16 | 1,708 | 2.53 s | 1.73 s |
| VG10 | 1,708 | 2.56 s | 2.09 s |
| VG22 | 1,708 | 2.95 s | 2.46 s |
| VG15 | 1,708 | 3.24 s | 1.62 s |
| VG24 | 1,708 | 3.51 s | 1.74 s |

So **1.2–3.5 s**, not six, and a saving under two seconds on a fit that runs for an hour. A real frame leaves more of these variables with a symbolic observation dimension, so fewer take the static-shape shortcut and the speed-up is smaller than on the synthetic frame — which is why the 4–20x figures in that note belong to the test file, where the 106 repetitions are.

**Nothing about #334's conclusion or its measured savings changes.** The test-file and CI timings were measured end to end, before and after, and stand: 6m02 → 1m30 serially, and CI's `tests-slow` pytest step 9m33 → 4m16/5m16. What was wrong was the sentence explaining why nobody had noticed the cost in a fit — and it is more convincing with the right number, not less.

Two smaller things the same review turned up, now recorded in the note:

- The two build totals in it (3.6 s in §1's stage profile, 6.4 s beside the 75.8 s in §2) are **separate runs of the same quantity** with different compilation warm-up, not one number quoted twice. The comparison does not depend on which, because each was measured against the 75.8 s in its own run, but they should not be read as one figure.
- **Identical output re-verified on real frames.** #334 verified the old and new `diagnostics_var_names` agree across 21 models and 85 variants on the *synthetic* frame only. Re-run on real full-size frames — VG10, VG11, VG15, VG16, VG22, VG24, including VG11's 14,553 child effects and VG22's factor block — both implementations return byte-identical summary and gate lists, in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
